### PR TITLE
add compatible packages

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -14,7 +14,7 @@
 #  issues            optional   integer-list    List of integers referencing primary issues at latex3/tagging-project
 #  related-issues    optional   integer-list    List of integers referencing secondary, related issues at latex3/tagging-project
 #  tasks             optional   markdown-string Free text markdown action items for tean
-#  supported-through optional   string-list     list of either "package"  or a tagging project module such as "phase-III" or "math", etc. from `latex-lab`.
+#  supported-through optional   string-list     list of either "package" or a tagging project module such as "phase-III" or "math", etc. from `latex-lab`.
 #  updated           optional   date            yyyy-mm-dd date when the entry was updated.
 
 # ------------------------
@@ -122,7 +122,7 @@
    ctan-pkg: latex-base
    type: package
    status: compatible
-   comments: "Empty compability package, can be removed from the preamble"
+   comments: "Empty compatibility package, can be removed from the preamble"
    issues:
    updated: 2024-07-07
 
@@ -218,10 +218,9 @@
 
  - name: dcolumn
    type: package
-   status: unknown
+   status: compatible
    issues:
-   tasks: needs tests
-   updated: 2024-07-06
+   updated: 2024-07-08
 
  - name: delarray
    type: package
@@ -385,10 +384,9 @@
 
  - name: graphpap
    type: package
-   status: unknown
+   status: compatible
    issues:
-   tasks: needs tests
-   updated: 2024-07-06
+   updated: 2024-07-08
 
 #------------------------ HHH ----------------------------
 
@@ -446,10 +444,9 @@
 
  - name: l3sys-query
    type: package
-   status: unknown
+   status: compatible
    issues:
-   tasks: needs tests
-   updated: 2024-07-06
+   updated: 2024-07-08
 
  - name: latexrelease
    type: package
@@ -599,10 +596,9 @@
 
  - name: shortvrb
    type: package
-   status: unknown
+   status: compatible
    issues:
-   tasks: needs tests
-   updated: 2024-07-06
+   updated: 2024-07-08
 
  - name: showidx
    ctan-pkg: latex-base
@@ -784,10 +780,9 @@
 
  - name: xspace
    type: package
-   status: unknown
+   status: compatible
    issues:
-   tasks: needs tests
-   updated: 2024-07-06
+   updated: 2024-07-08
 
 
 #-------------------------------- class files -----------------------


### PR DESCRIPTION
Changes status to "compatible" for packages `dcolumn`, `graphpap`, `l3sys-query`, `shortvrb`, and `xspace`. If you'd prefer separate PR's for each package, please let me know.

Below are some test files for each package that demonstrate the main feature (mostly taken from the package docs) and have passed the PAC checker. I'm aware passing the checker doesn't necessarily mean the tagging is useful for e.g. a screen reader, so someone who knows more than me may want to check the actual structure.

## dcolumn
```tex
\DocumentMetadata{
  lang=en-US,
  pdfversion=2.0,
  pdfstandard=ua-2,
  testphase={phase-III,math,title,table,firstaid}
  }
\documentclass{article}
\usepackage{dcolumn}

\newcolumntype{d}[1]{D{.}{\cdot}{#1}}
\newcolumntype{.}{D{.}{.}{-1}}
\newcolumntype{,}{D{,}{,}{2}}

\title{dcolumn tagging test}

\begin{document}

% can't contain vertical rules
% but this is also true without dcolumn
\begin{center}
\begin{tabular}{d{-1}d{2}.,}
1.2   & 1.2   &1.2    &1,2    \\
1.23  & 1.23  &12.5   &300,2  \\
1121.2& 1121.2&861.20 &674,29 \\
184   & 184   &10     &69     \\
.4    & .4    &       &,4     \\
   &       &.4     &
\end{tabular}
\end{center}

\end{document}
```

## graphpap
```tex
\DocumentMetadata{
  lang=en-US,
  pdfversion=2.0,
  pdfstandard=ua-2,
  testphase={phase-III,math,title,table,firstaid}
  }
\documentclass{article}
\usepackage{graphpap}

\title{graphpap tagging test}

\begin{document}

\graphpaper(0,0)(200,200)

\vspace{2cm}

\graphpaper[20](0,0)(200,200)

\end{document}
```

## l3sys-query
```tex
\DocumentMetadata{
  lang=en-US,
  pdfversion=2.0,
  pdfstandard=ua-2,
  testphase={phase-III,math,title,table,firstaid}
  }
\documentclass{article}
\usepackage{l3sys-query}

\title{l3sys-query tagging test}

\begin{document}

\QueryWorkingDirectory{\RESULT}

\RESULT

\QueryFiles{*.png}{#1\par}

\end{document}
```

## shortvrb
```tex
\DocumentMetadata{
  lang=en-US,
  pdfversion=2.0,
  pdfstandard=ua-2,
  testphase={phase-III,math,title,table,firstaid}
  }
\documentclass{article}
\usepackage{shortvrb}

\title{shortvrb tagging test}

\MakeShortVerb{\|}

\begin{document}

|abc| abc

\end{document}
```

## xspace
```tex
\DocumentMetadata{
  lang=en-US,
  pdfversion=2.0,
  pdfstandard=ua-2,
  testphase={phase-III,math,title,table,firstaid}
  }
\documentclass{article}
\usepackage{xspace}

\newcommand{\gb}{Great Britain\xspace}

\title{xspace tagging test}

\begin{document}

\gb is a very nice place to live.

\gb, a small island off the coast of France.

\end{document}
```