### PR TITLE
add amsbsy info

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -65,10 +65,11 @@
 
  - name: amsbsy
    type: package
-   status: unknown
+   status: partially-compatible
+   comments: "pmb produces extra tags from typesetting argument three times"
    issues:
-   tasks: needs tests
-   updated: 2024-07-06
+   tests: true
+   updated: 2024-07-09
 
  - name: amscd
    type: package

--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -66,6 +66,7 @@
  - name: amsbsy
    type: package
    status: partially-compatible
+   supported-through: [phase-III,math]
    comments: "pmb produces extra tags from typesetting argument three times"
    issues:
    tests: true

--- a/tagging-status/testfiles/amsbsy/amsbsy-01.tex
+++ b/tagging-status/testfiles/amsbsy/amsbsy-01.tex
@@ -1,0 +1,20 @@
+\DocumentMetadata{
+  lang=en-US,
+  pdfversion=2.0,
+  pdfstandard=ua-2,
+  testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{amsbsy}
+
+\title{amsbsy tagging test}
+
+\begin{document}
+$\phi$
+
+$\boldsymbol{\phi}$
+
+$\sum_i a_i$
+
+$\pmb{\sum_i a_i}$
+\end{document}


### PR DESCRIPTION
This lists amsbsy as "partially-compatible" because `\boldsymbol` seems fine but `\pmb` produces unnecessary tags, I assume because it's typesetting its argument multiple times. A test file is also added.