### PR TITLE
add amsopn compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -91,7 +91,6 @@
  - name: amsopn
    type: package
    status: compatible
-   supported-through: [phase-III]
    issues:
    tests: true
    updated: 2024-07-09

--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -91,6 +91,7 @@
  - name: amsopn
    type: package
    status: compatible
+   supported-through: [phase-III]
    issues:
    tests: true
    updated: 2024-07-09

--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -90,10 +90,10 @@
 
  - name: amsopn
    type: package
-   status: unknown
+   status: compatible
    issues:
-   tasks: needs tests
-   updated: 2024-07-06
+   tests: true
+   updated: 2024-07-09
 
  - name: amstext
    type: package

--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -91,6 +91,9 @@
  - name: amsopn
    type: package
    status: compatible
+   supported-through: [phase-III,math]
+   comments: "Requires the math module.
+     Use of math tagging requires support in external tools."
    issues:
    tests: true
    updated: 2024-07-09

--- a/tagging-status/testfiles/amsopn/amsopn-01.tex
+++ b/tagging-status/testfiles/amsopn/amsopn-01.tex
@@ -1,0 +1,23 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{amsopn}
+
+\title{amsopn tagging test}
+
+\DeclareMathOperator{\Proj}{Proj}
+
+\begin{document}
+
+$\operatorname{MyOp}_i^j$
+
+$\Proj(S)$
+
+$\cosh(\theta)$
+
+\end{document}


### PR DESCRIPTION
This lists amsopn as compatible with an included test file. I'm not sure if I should put "phase=III" or not for "supported-through" because tagging doesn't really make sense without setting `testphase`. I've assumed the default is to not list a "supported-through" entry unless one of the other modules (math, table, etc.) are required.