### PR TITLE
sort order for status

### DIFF
--- a/tagging-status/status-table.md
+++ b/tagging-status/status-table.md
@@ -23,7 +23,7 @@ Click on the column headings to sort the table by the chosen column.
 <td class="{{p.status}}"><a href="https://ctan.org/pkg/
 {%- if p.ctan-pkg -%}{{p.ctan-pkg}}{%- else -%}{{p.name}}{%- endif -%}
 ">{{p.name}}</a></td>
-<td class="{{p.status}}">{{p.status}}</td>
+<td class="{{p.status}}"{% if p.status=="partially-incompatible" %} sorttable_customkey="compatible-partial"{% endif %}>{{p.status}}</td>
 <td>
 {{p.comments | markdownify}}
 {%- if p.references %}

--- a/tagging-status/status-table.md
+++ b/tagging-status/status-table.md
@@ -23,7 +23,7 @@ Click on the column headings to sort the table by the chosen column.
 <td class="{{p.status}}"><a href="https://ctan.org/pkg/
 {%- if p.ctan-pkg -%}{{p.ctan-pkg}}{%- else -%}{{p.name}}{%- endif -%}
 ">{{p.name}}</a></td>
-<td class="{{p.status}}"{% if p.status=="partially-incompatible" %} sorttable_customkey="compatible-partial"{% endif %}>{{p.status}}</td>
+<td class="{{p.status}}"{% if p.status == "partially-compatible" %} sorttable_customkey="compatible-partial"{% endif %}>{{p.status}}</td>
 <td>
 {{p.comments | markdownify}}
 {%- if p.references %}


### PR DESCRIPTION
This PR adds a `sorttable_customkey` (just) on `partially-compatible` entries so the `status` column`sorts as compatible,  partially-compatible,  no-support, unknown

testable at

https://davidcarlisle.github.io/tagging-project/tagging-status/