### PR TITLE
add external issues list

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -13,6 +13,7 @@
 #  references        optional   integer-list    List of integers referencing the bibliography in references.yml
 #  issues            optional   integer-list    List of integers referencing primary issues at latex3/tagging-project
 #  related-issues    optional   integer-list    List of integers referencing secondary, related issues at latex3/tagging-project
+#  external-issues   optional   string-list     List of url referencing related issues at other trackers
 #  tests             optional   boolean         Are there tests in testfiles/<name> ?
 #  tasks             optional   markdown-string Free text markdown action items for team or volunteers
 #  supported-through optional   string-list     List of either "package" or a tagging project module such as "phase-III" or "math", etc. from `latex-lab`.
@@ -146,6 +147,7 @@
    comments: "Requires hyperref." 
    references: [2]
    issues: [18]
+   external-issues: ["https://github.com/plk/biblatex/issues/1366"]
    updated: 2024-07-07
 
  - name: biblatex-chicago

--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -13,7 +13,7 @@
 #  references        optional   integer-list    List of integers referencing the bibliography in references.yml
 #  issues            optional   integer-list    List of integers referencing primary issues at latex3/tagging-project
 #  related-issues    optional   integer-list    List of integers referencing secondary, related issues at latex3/tagging-project
-#  external-issues   optional   string-list     List of url referencing related issues at other trackers
+#  external-issues   optional   string-list     List of urls referencing related issues at other trackers
 #  tests             optional   boolean         Are there tests in testfiles/<name> ?
 #  tasks             optional   markdown-string Free text markdown action items for team or volunteers
 #  supported-through optional   string-list     List of either "package" or a tagging project module such as "phase-III" or "math", etc. from `latex-lab`.

--- a/tagging-status/status-table.md
+++ b/tagging-status/status-table.md
@@ -54,10 +54,10 @@ Related:
 {% endif %}
 {% if p.external-issues %}
 {%- if p.issues or p.related-issues -%}<br/>{%- endif -%}
-Related:
+Other:
 {% for u in p.external-issues %}
 {%- assign ltext = u | replace: "issues/", "" | split: "/" -%}
-<a href="{{u}}">{{ltext | slice: -2, 0}}</a>
+<a href="{{u}}">xx{{ltext | slice: -2}yy</a>
 {% endfor %}
 {% endif %}
 {% if p.tests %}

--- a/tagging-status/status-table.md
+++ b/tagging-status/status-table.md
@@ -57,7 +57,7 @@ Related:
 Other:
 {% for u in p.external-issues %}
 {%- assign ltext = u | replace: "issues/", "" | split: "/" -%}
-<a href="{{u}}">xx{{ltext | slice: -2}yy</a>
+<a href="{{u}}">xx{{ltext | slice: -2}}yy</a>
 {% endfor %}
 {% endif %}
 {% if p.tests %}

--- a/tagging-status/status-table.md
+++ b/tagging-status/status-table.md
@@ -52,6 +52,14 @@ Related:
 <a href="https://github.com/latex3/tagging-project/issues/{{i}}">#{{i}}</a>
 {% endfor %}
 {% endif %}
+{% if p.external-issues %}
+{%- if p.issues or p.related-issues -%}<br/>{%- endif -%}
+Related:
+{% for u in p.external-issues %}
+{%- assign ltext = u | replace: "issues/", "" | split: "/" -%}
+<a href="{{u}}">{{ltext | slice: -2, 0}}</a>
+{% endfor %}
+{% endif %}
 {% if p.tests %}
 <a href="{{ site.github.repository_url }}/tree/main/tagging-status/testfiles/{{p.name}}/">test(s)</a>
 {% endif %}

--- a/tagging-status/status-table.md
+++ b/tagging-status/status-table.md
@@ -57,7 +57,7 @@ Related:
 Other:
 {% for u in p.external-issues %}
 {%- assign ltext = u | replace: "issues/", "" | split: "/" -%}
-<a href="{{u}}">xx{{ltext | slice: -2}}yy</a>
+<a href="{{u}}">{{ltext | slice: -2}}/{{ltext | slice: -1}}</a>
 {% endfor %}
 {% endif %}
 {% if p.tests %}


### PR DESCRIPTION
Adds an `external-issues` key that takes a list of URL to  issues not in the tagging-project repositrory, use full URL rather than a github shorthand such as biblatex/1366 so that you could link to gitlab or a mailing list archive or whatever
The shortened form used as link text possibly works best for github issues but is probably usable in all cases.

see biblatex entry at

https://davidcarlisle.github.io/tagging-project/tagging-status