### PR TITLE
add delarray compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -245,9 +245,11 @@
 
  - name: delarray
    type: package
-   status: unknown
+   status: compatible
+   supported-through: [phase-III,math,table]
    issues:
-   updated: 2024-07-06
+   tests: true
+   updated: 2024-07-10
 
  - name: doc
    type: package

--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -247,6 +247,8 @@
    type: package
    status: compatible
    supported-through: [phase-III,math,table]
+   comments: "Requires the math module.
+     Use of math tagging requires support in external tools."
    issues:
    tests: true
    updated: 2024-07-10

--- a/tagging-status/testfiles/delarray/delarray-01.tex
+++ b/tagging-status/testfiles/delarray/delarray-01.tex
@@ -1,0 +1,22 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table}
+  }
+\documentclass{article}
+\usepackage{delarray}
+
+\title{delarray tagging test}
+
+\begin{document}
+
+% get same PAC warnings with normal arrays
+\[
+\begin{array}[t]({c}) 1\\2\\3 \end{array} 
+\begin{array}[c]({cr}) 1 & a\\2 & b\\3 & c \end{array} 
+\begin{array}[b]({c}) 1\\2\\3 \end{array}
+\]
+
+\end{document}


### PR DESCRIPTION
This lists `delarray` as "compatible". The tagging of
```tex
\begin{array}[t]({c}) 1\\2\\3 \end{array} 
\begin{array}[c]({cr}) 1 & a\\2 & b\\3 & c \end{array} 
\begin{array}[b]({c}) 1\\2\\3 \end{array}
```
with delarray appears to be the same as
```tex
\left(\begin{array}{c} 1\\2\\3 \end{array}\right)
\left(\begin{array}{cr} 1 & a\\2 & b\\3 & c \end{array}\right)
\left(\begin{array}{c} 1\\2\\3 \end{array}\right)
```
without. The PAC checker produces the warning "Possibly inappropriate use of a "Formula" structure element" but this occurs with the non-delarray example above too. Since `array` is already listed as compatible, I assume this is okay.