### PR TITLE
add theorem compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -683,10 +683,10 @@
 
  - name: theorem
    type: package
-   status: unknown
+   status: currently-incompatible
    issues:
-   tasks: needs tests
-   updated: 2024-07-06
+   tests: true
+   updated: 2024-07-10
 
  - name: tikz
    type: package

--- a/tagging-status/testfiles/theorem/theorem-01.tex
+++ b/tagging-status/testfiles/theorem/theorem-01.tex
@@ -1,0 +1,21 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{theorem}
+
+\title{theorem tagging test}
+
+\newtheorem{theorem}{Theorem}
+
+\begin{document}
+
+\begin{theorem}
+bla
+\end{theorem}
+
+\end{document}


### PR DESCRIPTION
This labels the theorem package as "currently-incompatible" and adds a test. Perhaps a comment could be added that the package author @FrankMittelbach does not recommend it.

With that in mind, it would also make sense if "no-support" is more appropriate (feedback welcome).