### PR TITLE
add makeidx compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -544,6 +544,13 @@
 
 #------------------------ MMM ----------------------------
 
+ - name: makeidx
+   type: package
+   status: compatible
+   issues:
+   tests: true
+   updated: 2024-07-11
+
  - name: manyfoot
    type: package
    status: unknown

--- a/tagging-status/testfiles/makeidx/makeidx-01.tex
+++ b/tagging-status/testfiles/makeidx/makeidx-01.tex
@@ -1,0 +1,20 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{makeidx}
+
+\title{makeidx tagging test}
+
+\makeindex
+
+\begin{document}
+Test1\index{bla1}
+
+Test2\index{bla2}
+\printindex
+\end{document}


### PR DESCRIPTION
Lists the makeidx package as "compatible" and adds a test file. I'm not sure if indices are supposed to be tagged specially but the structure looks okay to me.

<img width="222" alt="makeidx_struc" src="https://github.com/latex3/tagging-project/assets/61854785/018f8284-7adb-445d-8f9e-c1204657f274">
