### PR TITLE
add proc compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -888,10 +888,12 @@
 
  - name: proc
    type: class
-   status: unknown
+   status: compatible
+   supported-through: [phase-III,title]
    issues:
-   tasks: needs tests
-   updated: 2024-07-06
+   comments: "Based on article class"
+   tests: true
+   updated: 2024-07-11
 
 #------------------------ RRR ----------------------------
 

--- a/tagging-status/testfiles/proc/proc-01.tex
+++ b/tagging-status/testfiles/proc/proc-01.tex
@@ -1,0 +1,26 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{proc}
+
+\title{proc tagging test}
+\author{Some name}
+
+\begin{document}
+
+\maketitle
+
+\begin{abstract}
+A summary
+\end{abstract}
+
+\section{Some heading}
+text
+
+\copyrightspace
+
+\end{document}


### PR DESCRIPTION
Lists the proc class as compatible and adds a test file. The `\copyrightspace` command produces some empty tags coming from the footnote rule, I think, but this happens with normal footnotes in the article class too.