### PR TITLE
add pstricks compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -605,11 +605,12 @@
 
  - name: pstricks
    type: package
-   status: partially-compatible
-   comments: tagging passes validation but is sub-optimal
+   status: currently-incompatible
+   comments: "Tagging passes validation but is suboptimal. Future compatibility
+              will only be with lualatex; dvips cannot properly support PDF/UA."
    issues:
    tests: true
-   updated: 2024-07-11
+   updated: 2024-07-12
 
 #------------------------ RRR ----------------------------
 

--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -603,7 +603,14 @@
    issues:
    updated: 2024-07-07
 
-   
+ - name: pstricks
+   type: package
+   status: partially-compatible
+   comments: tagging passes validation but is sub-optimal
+   issues:
+   tests: true
+   updated: 2024-07-11
+
 #------------------------ RRR ----------------------------
 
  - name: rotating

--- a/tagging-status/testfiles/pstricks/pstricks-01.tex
+++ b/tagging-status/testfiles/pstricks/pstricks-01.tex
@@ -1,0 +1,30 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{pstricks}
+
+\title{pstricks tagging test}
+
+\begin{document}
+
+\psset{unit=1.2cm}
+\begin{pspicture}(-2.2,-2.2)(2.2,2.2)
+\pswedge[fillstyle=solid,fillcolor=gray]{2}{0}{70}
+\pswedge[fillstyle=solid,fillcolor=lightgray]{2}{70}{200}
+\pswedge[fillstyle=solid,fillcolor=darkgray]{2}{200}{360}
+\SpecialCoor
+\psset{framesep=1.5pt}
+\rput(1.2;35){\psframebox*{\small\$9.0M}}
+\uput{2.2}[45](0,0){Oreos}
+\rput(1.2;135){\psframebox*{\small\$16.7M}}
+\uput{2.2}[135](0,0){Heath}
+\rput(1.2;280){\psframebox*{\small\$23.1M}}
+\uput{2.2}[280](0,0){M\&M}
+\end{pspicture}
+
+\end{document}


### PR DESCRIPTION
Lists pstricks as "partially-compatible" because it doesn't error but there is no information in the tagging structure. Test file included.