### PR TITLE
add incompatibility info for ftnright, layout, rotating, and showidx

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -361,10 +361,10 @@
 
  - name: ftnright
    type: package
-   status: unknown
-   issues:
-   tasks: needs tests
-   updated: 2024-07-06
+   status: currently-incompatible
+   issues: [110]
+   tests: true
+   updated: 2024-07-11
 
 #------------------------ GGG ----------------------------
 

--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -493,10 +493,10 @@
 
  - name: layout
    type: package
-   status: unknown
-   issues:
-   tasks: needs tests
-   updated: 2024-07-06
+   status: currently-incompatible
+   issues: [111]
+   tests: true
+   updated: 2024-07-11
 
  - name: lipsum
    type: package
@@ -616,10 +616,10 @@
 
  - name: rotating
    type: package
-   status: unknown
-   issues:
-   tasks: needs tests
-   updated: 2024-07-06
+   status: currently-incompatible
+   issues: [112]
+   tests: true
+   updated: 2024-07-11
 
 #------------------------ SSS ----------------------------
 
@@ -639,10 +639,10 @@
  - name: showidx
    ctan-pkg: latex-base
    type: package
-   status: unknown
-   issues:
-   tasks: needs tests
-   updated: 2024-07-06
+   status: currently-incompatible
+   issues: [115]
+   tests: true
+   updated: 2024-07-11
 
  - name: showkeys
    type: package

--- a/tagging-status/testfiles/ftnright/ftnright-01.tex
+++ b/tagging-status/testfiles/ftnright/ftnright-01.tex
@@ -1,0 +1,15 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table}
+  }
+\documentclass[twocolumn]{article}
+\usepackage{ftnright}
+
+\title{ftnright tagging test}
+
+\begin{document}
+Some body text\footnote{Some footnote text}
+\end{document}

--- a/tagging-status/testfiles/layout/layout-01.tex
+++ b/tagging-status/testfiles/layout/layout-01.tex
@@ -1,0 +1,15 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{layout}
+
+\title{layout tagging test}
+
+\begin{document}
+\layout
+\end{document}

--- a/tagging-status/testfiles/rotating/rotating-01.tex
+++ b/tagging-status/testfiles/rotating/rotating-01.tex
@@ -1,0 +1,32 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{rotating}
+
+\title{rotating tagging test}
+
+\begin{document}
+Normal text
+
+\begin{sideways}
+sideways text
+\end{sideways}
+
+\begin{sidewaysfigure}
+\centering
+\includegraphics[alt={example image a}]{example-image-a}
+\caption{Some caption text}
+\end{sidewaysfigure}
+
+\begin{figure}
+\centering
+\includegraphics[alt={example image b}]{example-image-b}
+\caption{More caption text}
+\end{figure}
+
+\end{document}

--- a/tagging-status/testfiles/showidx/showidx-01.tex
+++ b/tagging-status/testfiles/showidx/showidx-01.tex
@@ -1,0 +1,19 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{showidx}
+\usepackage{makeidx}
+
+\title{showidx tagging test}
+
+\makeindex
+
+\begin{document}
+Test\index{bla}
+\printindex
+\end{document}


### PR DESCRIPTION
Lists ftnright, layout, rotating, and showidx packages as "currently-incompatible" and adds tests for each. References issues #110, #111, #112, and #115, respectively.