### PR TITLE
add showkeys compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -646,10 +646,11 @@
 
  - name: showkeys
    type: package
-   status: unknown
+   status: partially-compatible
+   comments: "Rules drawn around labels display as Path in tags"
    issues:
-   tasks: needs tests
-   updated: 2024-07-06
+   tests: true
+   updated: 2024-07-11
 
  - name: structuredlog
    type: package

--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -647,7 +647,8 @@
  - name: showkeys
    type: package
    status: partially-compatible
-   comments: "Rules drawn around labels display as Path in tags"
+   comments: "Rules drawn around labels display as Path in tags and the label in the margin is either not tagged
+              at all (pdflatex) or as artifact (lualatex). Unproblematic for a draft, but not UA compatible."
    issues:
    tests: true
    updated: 2024-07-11

--- a/tagging-status/testfiles/showkeys/showkeys-01.tex
+++ b/tagging-status/testfiles/showkeys/showkeys-01.tex
@@ -1,0 +1,24 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{showkeys}
+
+\title{showkeys tagging test}
+
+\begin{document}
+\section{Examples}\label{sec}
+
+Equation \ref{eq}
+
+\begin{equation}
+a=b \label{eq}
+\end{equation}
+
+Section \ref{sec}
+
+\end{document}


### PR DESCRIPTION
Lists showkeys as "partially-compatible" because the rules drawn around the labels display as "Path" in the tagging structure. The included test file gives

<img width="223" alt="showkeys_struc" src="https://github.com/user-attachments/assets/e2d87c1a-9f25-4e2d-b266-1873f2a7db47">
