### PR TITLE
status count

### DIFF
--- a/tagging-status/index.md
+++ b/tagging-status/index.md
@@ -17,7 +17,7 @@ with respect to PDF tagging. `phase-III` is generally needed and not explicitly 
 
 The values in the *Status* column have the following meaning:
 
-- `compatible` This package or class works without any issues when tagging is enabled. If there are problems, please open an issue in [the tagging-project repo](https://github.com/latex3/tagging-project/issues).
+- `compatible` This package or class works without any issues when tagging is enabled. If there are problems, please open an issue in [the tagging-project repo](https://github.com/latex3/tagging-project/issues). ({{site.data.tagging-status | where: "status", "compatible" | size }} entries)
 - `partially-compatible` The package or class is currently partially compatible, e.g., some parts may not work yet, but with some restrictions it can already be used. See comments for details.
 - `currently-incompatible` The package or class is currently incompatible with the tagging code, but we expect it to be updated eventually. 
 - `no-support` This package or class or class is incompatible with the tagging code and we do *not* believe that it will ever be supported.

--- a/tagging-status/index.md
+++ b/tagging-status/index.md
@@ -17,11 +17,11 @@ with respect to PDF tagging. `phase-III` is generally needed and not explicitly 
 
 The values in the *Status* column have the following meaning:
 
-- `compatible` This package or class works without any issues when tagging is enabled. If there are problems, please open an issue in [the tagging-project repo](https://github.com/latex3/tagging-project/issues). ({{site.data.tagging-status | where: "status", "compatible" | size }} entries)
-- `partially-compatible` The package or class is currently partially compatible, e.g., some parts may not work yet, but with some restrictions it can already be used. See comments for details.
-- `currently-incompatible` The package or class is currently incompatible with the tagging code, but we expect it to be updated eventually. 
-- `no-support` This package or class or class is incompatible with the tagging code and we do *not* believe that it will ever be supported.
-- `unknown` The status of this package or class is not known, because there aren't reliable tests yet. Help with testing to determine the real status is very much appreciated.
+- `compatible` This package or class works without any issues when tagging is enabled. If there are problems, please open an issue in [the tagging-project repo](https://github.com/latex3/tagging-project/issues). (**{{site.data.tagging-status | where: "status", "compatible" | size }}** entries.)
+- `partially-compatible` The package or class is currently partially compatible, e.g., some parts may not work yet, but with some restrictions it can already be used. See comments for details. (**{{site.data.tagging-status | where: "status", "partially-compatible" | size }}** entries.)
+- `currently-incompatible` The package or class is currently incompatible with the tagging code, but we expect it to be updated eventually. (**{{site.data.tagging-status | where: "status", "currently-incompatible" | size }}** entries.)
+- `no-support` This package or class or class is incompatible with the tagging code and we do *not* believe that it will ever be supported. (**{{site.data.tagging-status | where: "status", "no-support" | size }}** entries.)
+- `unknown` The status of this package or class is not known, because there aren't reliable tests yet. Help with testing to determine the real status is very much appreciated. (**{{site.data.tagging-status | where: "status", "unknown" | size }}** entries.)
 
 To use packages or classes together with the tagging code it is (nearly) always necessary to load at least `phase-III`of the tagging code, i.e., `testphase=phase-III` in `\DocumentMetadata`. To save space in the tables, this is not explicitly mentioned below. However, if a package or class requires other settings there is an explicit remark in the comments column, e.g., `Tagging support: phase-III, table` which means you have to specify `testphase={phase-III,table}`. If `package` is mentioned at this point it means that the package itself provides the necessary tagging support and not one of the modules in `latex-lab`.
 


### PR DESCRIPTION
Adds a count of each status (across packages and classes) to the status description at the top of the page. 

See https://davidcarlisle.github.io/tagging-project/tagging-status/