### PR TITLE
add fancyhdr compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -302,6 +302,13 @@
 
 #------------------------ FFF ----------------------------
 
+ - name: fancyhdr
+   type: package
+   status: compatible
+   issues:
+   tests: true
+   updated: 2024-07-12
+
  - name: fancyvrb
    type: package
    status: currently-incompatible

--- a/tagging-status/testfiles/fancyhdr/fancyhdr-01.tex
+++ b/tagging-status/testfiles/fancyhdr/fancyhdr-01.tex
@@ -1,0 +1,21 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{fancyhdr}
+
+\pagestyle{fancy}
+
+\title{fancyhdr tagging test}
+
+\begin{document}
+
+\section{Some heading}
+
+bla
+
+\end{document}


### PR DESCRIPTION
Lists fancyhdr as "compatible" and adds a test. My assumption is headers and footers should not be tagged and that's what happens here.