### PR TITLE
add titleps compat

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -727,6 +727,13 @@
    issues: [30]
    updated: 2024-07-06
 
+ - name: titleps
+   type: package
+   status: compatible
+   issues:
+   tests: true
+   updated: 2024-07-12
+
  - name: titlesec
    type: package
    status: currently-incompatible

--- a/tagging-status/testfiles/titleps/titleps-01.tex
+++ b/tagging-status/testfiles/titleps/titleps-01.tex
@@ -1,0 +1,29 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{titleps}
+
+\widenhead{2.1pc}{0pc}
+\newpagestyle{myps}[\small\sffamily\slshape]{
+  \headrule
+  \sethead{titlesec -- titleps}{\sectiontitle}{\thepage}}
+\pagestyle{myps}
+
+\title{titleps tagging test}
+
+\begin{document}
+
+\section{Some heading}
+bla
+
+\newpage
+
+\section{Another heading}
+bla bla
+
+\end{document}


### PR DESCRIPTION
(To complete the titlesec-titletoc-titleps family.) Lists titleps as "compatible" and adds a test file. Like with fancyhdr, the tagging is identical with/without the package.