### PR TITLE
add afterpage compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -52,9 +52,10 @@
 
  - name: afterpage
    type: package
-   status: compatible
+   status: partially-compatible
    issues:
    tests: true
+   tasks: more tests needed
    updated: 2024-07-12
 
  - name: alltt

--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -52,10 +52,10 @@
 
  - name: afterpage
    type: package
-   status: unknown
+   status: compatible
    issues:
-   tasks: needs tests
-   updated: 2024-07-06
+   tests: true
+   updated: 2024-07-12
 
  - name: alltt
    type: package

--- a/tagging-status/testfiles/afterpage/afterpage-01.tex
+++ b/tagging-status/testfiles/afterpage/afterpage-01.tex
@@ -1,0 +1,24 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{afterpage}
+
+\title{afterpage tagging test}
+
+\begin{document}
+  
+bla
+\afterpage{% use tabular as example to check tagging struc
+  \begin{tabular}{cc}
+  A & B \\
+  C & D
+  \end{tabular}
+}%
+foo foo
+
+\end{document}


### PR DESCRIPTION
Lists afterpage as compatible and includes a test file. The tagging seems to appear in the correct place