### PR TITLE
add amscd compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -75,10 +75,12 @@
 
  - name: amscd
    type: package
-   status: unknown
+   status: compatible
+   supported-through: [phase-III,math]
+   comments: "Use of math tagging currently requires support from external tools."
    issues:
-   tasks: needs tests
-   updated: 2024-07-06
+   tests: true
+   updated: 2024-07-12
 
  - name: amsmath
    type: package

--- a/tagging-status/testfiles/amscd/amscd-01.tex
+++ b/tagging-status/testfiles/amscd/amscd-01.tex
@@ -1,0 +1,39 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{amscd,amsmath}
+
+\DeclareMathOperator{\End}{End}
+\DeclareMathOperator{\cov}{cov}
+\DeclareMathOperator{\cf}{cf}
+\DeclareMathOperator{\add}{add}
+\DeclareMathOperator{\non}{non}
+
+\title{amscd tagging test}
+
+\begin{document}
+
+% examples from amscd documentation
+\begin{equation}
+\begin{CD} 
+S^{{\mathcal{W}}_\Lambda}\otimes T @>j>> T\\
+@VVV @VV{\End P}V\\
+(S\otimes T)/I @= (Z\otimes T)/J
+\end{CD}
+\end{equation}
+\begin{equation}
+\begin{CD}
+\cov(\mathcal{L}) @>>> \non(\mathcal{K}) @>>> \cf(\mathcal{K}) @>>> 
+\cf(\mathcal{L})\\
+@VVV @AAA @AAA @VVV\\
+\add(\mathcal{L}) @>>> \add(\mathcal{K}) @>>> \cov(\mathcal{K}) @>>> 
+\non(\mathcal{L})
+\end{CD}
+\end{equation}
+
+\end{document}


### PR DESCRIPTION
Lists amscd as compatible with the usual math disclaimer and adds a test file. The content in the tag structure in acrobat is mostly nonsense but that's also true for other math objects.