### PR TITLE
add bm compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -171,10 +171,12 @@
 
  - name: bm
    type: package
-   status: unknown
+   status: compatible
+   supported-through: [phase-III,math]
+   comments: "Use of math tagging currently requires support from external tools."
    issues:
-   tasks: needs tests
-   updated: 2024-07-06
+   tests: true
+   updated: 2024-07-12
 
  - name: booktabs
    type: package

--- a/tagging-status/testfiles/bm/bm-01.tex
+++ b/tagging-status/testfiles/bm/bm-01.tex
@@ -1,0 +1,23 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{bm}
+
+\bmdefine\balpha{\alpha}
+
+\title{bm tagging test}
+
+\begin{document}
+
+$\alpha \not= \bm{\alpha}$
+
+$\balpha$
+
+$\bm{\sqrt{xyz}}$
+
+\end{document}


### PR DESCRIPTION
Lists bm as compatible and adds a test file. Compatibility code is contained in latex-lab-mathpkg