### PR TITLE
add amstext compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -102,7 +102,7 @@
 
  - name: amstext
    type: package
-   status: compatibl
+   status: compatible
    supported-through: [phase-III,math]
    comments: "Use of math tagging currently requires support from external tools."
    issues:

--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -102,10 +102,12 @@
 
  - name: amstext
    type: package
-   status: unknown
+   status: compatibl
+   supported-through: [phase-III,math]
+   comments: "Use of math tagging currently requires support from external tools."
    issues:
-   tasks: needs tests
-   updated: 2024-07-06
+   tests: true
+   updated: 2024-07-12
 
  - name: amsthm
    type: package

--- a/tagging-status/testfiles/amstext/amstext-01.tex
+++ b/tagging-status/testfiles/amstext/amstext-01.tex
@@ -1,0 +1,23 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{amstext}
+
+\title{amstext tagging test}
+
+\begin{document}
+
+\[
+   x^{2\,\times\,\text{size of $y$}}
+   \leq
+   z_{i_{\text{upper bound of the array}}}
+\]
+
+\text{text outside math mode}
+
+\end{document}


### PR DESCRIPTION
Lists amstext as "compatible" and adds a test file. Correct tagging support for `\text` is found in latex-lab-amsmath