### PR TITLE
add boxedminipage compat

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -658,11 +658,11 @@
 
  - name: boxedminipage
    type: package
-   status: unknown
+   status: partially-compatible
+   comments: "drawn box is tagged as Path instead of artifact"
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-14
+   tests: true
+   updated: 2024-07-15
 
  - name: braket
    type: package

--- a/tagging-status/testfiles/boxedminipage/boxedminipage-01.tex
+++ b/tagging-status/testfiles/boxedminipage/boxedminipage-01.tex
@@ -1,0 +1,39 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{boxedminipage}
+
+\title{boxedminipage tagging test}
+
+\begin{document}
+
+Suspendisse pulvinar vel elit at dapibus. Interdum et malesuada
+fames ac ante ipsum primis in faucibus. Cras nibh orci, posuere
+quis viverra a, gravida nec velit. Pr\ae{}sent porta semper
+tellus, eu pulvinar ante mollis faucibus.
+
+\noindent
+\begin{boxedminipage}[t]{\linewidth}
+This box was created with the boxedminipage environment.
+Notice how the frame is aligned properly with both margins of
+the surrounding text.
+\end{boxedminipage}
+
+Suspendisse pulvinar vel elit at dapibus. Interdum et malesuada
+fames ac ante ipsum primis in faucibus. Cras nibh orci, posuere
+quis viverra a, gravida nec velit. Pr\ae{}sent porta semper
+tellus, eu pulvinar ante mollis faucibus.
+
+\noindent
+\begin{minipage}[t]{\linewidth}
+This box was created with the boxedminipage environment.
+Notice how the frame is aligned properly with both margins of
+the surrounding text.
+\end{minipage}
+
+\end{document}


### PR DESCRIPTION
Lists boxedminipage as "partially-compatible" since the tagging is identical to a regular minipage but the box drawn around it appears as "Path" in the structure tree instead of as an artifact (I think that's what is preferred).