### PR TITLE
add cellspace compat

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -788,11 +788,11 @@
 
  - name: cellspace
    type: package
-   status: unknown
+   status: compatible
+   supported-through: [phase-III,table]
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-14
+   tests: true
+   updated: 2024-07-15
 
  - name: chancery
    type: package

--- a/tagging-status/testfiles/cellspace/cellspace-01.tex
+++ b/tagging-status/testfiles/cellspace/cellspace-01.tex
@@ -1,0 +1,59 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{cellspace,tabularx}
+
+\setlength{\cellspacetoplimit}{2pt}
+\setlength{\cellspacebottomlimit}{2pt}
+\addparagraphcolumntypes{X}
+
+\title{cellspace tagging test}
+
+\begin{document}
+
+\begin{tabular}{cc}
+A & B \\
+C & D
+\end{tabular}
+
+\bigskip
+
+\begin{tabular}{Sc Sc}
+A & B \\
+C & D
+\end{tabular}
+
+\bigskip
+
+\begin{tabularx}{\linewidth}{l X}
+  \hline
+  A       & B B B B B B B B \\
+  A A     & B B B B B B B B
+            B B B B B B B B \\
+  A A A A & $\frac{1}{2}$B B B B B B B B
+            B B B B B B B B
+            B B B B B B B B
+            B B B B B B B B$\frac{1}{2}$ \\
+  \hline
+\end{tabularx}
+
+\bigskip
+
+\begin{tabularx}{\linewidth}{l SX}
+  \hline
+  A       & B B B B B B B B \\
+  A A     & B B B B B B B B
+            B B B B B B B B \\
+  A A A A & $\frac{1}{2}$B B B B B B B B
+            B B B B B B B B
+            B B B B B B B B
+            B B B B B B B B$\frac{1}{2}$ \\
+  \hline
+\end{tabularx}
+
+\end{document}


### PR DESCRIPTION
Lists cellspace as compatible and adds a test file. The table tagging seems identical with or without the cellspace modifications.