### PR TITLE
add shadethm compat

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -3201,10 +3201,10 @@
 
  - name: shadethm
    type: package
-   status: unknown
+   status: currently-incompatible
+   comments: Obsolete package; tcolorbox recommended.
    issues:
-   tests: false
-   tasks: needs tests
+   tests: true
    updated: 2024-07-15
 
  - name: shadow

--- a/tagging-status/testfiles/shadethm/shadethm-01.tex
+++ b/tagging-status/testfiles/shadethm/shadethm-01.tex
@@ -1,0 +1,19 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{shadethm}
+
+\newshadetheorem{theorem}{Theorem}
+
+\begin{document}
+
+\begin{theorem}
+bla
+\end{theorem}
+
+\end{document}


### PR DESCRIPTION
Lists shadethm as "currently-incompatible" since the included test file gives warnings
```
Package tagpdf Warning: Parent-Child 'StructTreeRoot/pdf' --> 'Div/pdf2'.
(tagpdf)                Relation is not allowed (struct 1, /StructTreeRoot -->
(tagpdf)                struct 5) on line 15


Package tagpdf Warning: Parent-Child 'StructTreeRoot/pdf' -->
(tagpdf)                'theorem-like/latex'.
(tagpdf)                Relation is not allowed (struct 5, /Div --> struct 6)
(tagpdf)                on line 16


Package tagpdf Warning: Parent-Child 'StructTreeRoot/pdf' --> 'text/latex'.
(tagpdf)                Relation is not allowed (struct 1, /StructTreeRoot -->
(tagpdf)                struct 11) on line 17


Package tagpdf Warning: Parent-Child 'P/pdf2' --> 'text-unit/latex'.
(tagpdf)                Relation is not allowed (struct 11, /text --> struct
(tagpdf)                12) on line 17
```
Also lists the package as obsolete and recommends tcolorbox instead.