### PR TITLE
add pgfplots and pgfplotstable compat

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -3047,6 +3047,21 @@
    issues:
    updated: 2024-07-07
 
+ - name: pgfplots
+   type: package
+   status: currently-incompatible
+   comments: "Relies on tikz so compatibility will come with that of tikz."
+   tests: false
+   updated: 2024-07-16
+
+ - name: pgfplotstable
+   type: package
+   status: compatible
+   comments: "Table tagging is correct but any interaction with pgfplots
+              is not yet supported."
+   tests: true
+   updated: 2024-07-16
+
  - name: pstricks
    type: package
    status: currently-incompatible

--- a/tagging-status/testfiles/pgfplotstable/pgfplotstable-01.tex
+++ b/tagging-status/testfiles/pgfplotstable/pgfplotstable-01.tex
@@ -1,0 +1,76 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,table,title,firstaid}
+  }
+\begin{filecontents*}{pgfplotstable.example1.dat}
+# Convergence results
+# fictional source, generated 2008
+level dof error1 error2 info grad(log(dof),log(error2)) quot(error1)
+1 4 2.50000000e-01 7.57858283e-01 48 0 0
+2 16 6.25000000e-02 5.00000000e-01 25 -3.00000000e-01 4
+3 64 1.56250000e-02 2.87174589e-01 41 -3.99999999e-01 4
+4 256 3.90625000e-03 1.43587294e-01 8 -5.00000003e-01 4
+5 1024 9.76562500e-04 4.41941738e-02 22 -8.49999999e-01 4
+6 4096 2.44140625e-04 1.69802322e-02 46 -6.90000001e-01 4
+7 16384 6.10351562e-05 8.20091159e-03 40 -5.24999999e-01 4
+8 65536 1.52587891e-05 3.90625000e-03 48 -5.35000000e-01 3.99999999e+00
+9 262144 3.81469727e-06 1.95312500e-03 33 -5.00000000e-01 4.00000001e+00
+10 1048576 9.53674316e-07 9.76562500e-04 2 -5.00000000e-01 4.00000001e+00
+\end{filecontents*}
+
+\documentclass{article}
+\usepackage{pgfplotstable,booktabs}
+\pgfplotsset{compat=newest}
+
+\title{pgfplotstable tagging test}
+
+\begin{document}
+
+\pgfplotstabletypeset[sci zerofill]{
+a b
+5000 1.234e5
+6000 1.631e5
+7000 2.1013e5
+9000 1000000
+}
+
+\bigskip
+
+\pgfplotstableset{% global config, for example in the preamble
+% these columns/<colname>/.style={<options>} things define a style
+% which applies to <colname> only.
+columns/dof/.style={int detect,column type=r,column name=\textsc{Dof}},
+columns/error1/.style={
+sci,sci zerofill,sci sep align,precision=1,sci superscript,
+column name=$e_1$,
+},
+columns/error2/.style={
+sci,sci zerofill,sci sep align,precision=2,sci 10e,
+column name=$e_2$,
+},
+columns/{grad(log(dof),log(error2))}/.style={
+string replace={0}{}, % erase '0'
+column name={$\nabla e_2$},
+dec sep align,
+},
+columns/{quot(error1)}/.style={
+string replace={0}{}, % erase '0'
+column name={$\frac{e_1^{(n)}}{e_1^{(n-1)}}$}
+},
+empty cells with={--}, % replace empty cells with '--'
+every head row/.style={before row=\toprule,after row=\midrule},
+every last row/.style={after row=\bottomrule}
+}
+\pgfplotstabletypeset[ % local config, applies only for this table
+1000 sep={\,},
+columns/info/.style={
+fixed,fixed zerofill,precision=1,showpos,
+column type=r,
+}
+]
+{pgfplotstable.example1.dat}
+         
+\end{document}


### PR DESCRIPTION
Lists [pgfplots](https://www.ctan.org/pkg/pgfplots) as "currently-incompatible" since it relies on tikz and [pgfplotstable](https://www.ctan.org/pkg/pgfplotstable) as "compatible" since its output is just a normal `tabular`. A comment is added about any interaction with pgfplots. The tagging for the test file looks correct to me.