### PR TITLE
add accsupp to tagging-status.yml

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -107,6 +107,14 @@
    tasks: needs tests
    updated: 2024-07-13
 
+ - name: accsupp
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-16
+
  - name: acro
    type: package
    status: unknown


### PR DESCRIPTION
Adds [accsupp](https://www.ctan.org/pkg/accsupp) to the list of packages but leaves status as "unknown". I'll let someone more qualified than me add info about whether or not it's okay to use with the new tagging code.