### PR TITLE
add common packages to tagging-status.yml

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -382,6 +382,14 @@
    tasks: needs tests
    updated: 2024-07-13
 
+ - name: attachfile2
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-17
+
  - name: atveryend
    type: package
    status: compatible
@@ -449,6 +457,14 @@
    tests: false
    tasks: needs tests
    updated: 2024-07-14
+
+ - name: backref
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-17
 
  - name: baskervillef
    type: package
@@ -1225,6 +1241,14 @@
    tasks: needs tests
    updated: 2024-07-14
 
+ - name: embedfile
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-17
+
  - name: embrac
    type: package
    status: unknown
@@ -1316,6 +1340,14 @@
    tests: false
    tasks: needs tests
    updated: 2024-07-14
+
+ - name: eso-pic
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-17
 
  - name: etaremune
    type: package
@@ -1900,6 +1932,14 @@
    issues: [66]
    tests: true
    updated: 2024-07-10
+
+ - name: hologo
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-17
 
  - name: hvfloat
    type: package
@@ -2563,6 +2603,14 @@
    issues: [67]
    updated: 2024-07-06
 
+ - name: minted
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-17
+
  - name: mintspirit
    type: package
    status: compatible
@@ -3069,6 +3117,14 @@
    tests: true
    updated: 2024-07-16
 
+ - name: polyglossia
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-17
+
  - name: pstricks
    type: package
    status: currently-incompatible
@@ -3117,6 +3173,14 @@
    tests: false
    tasks: needs tests
    updated: 2024-07-15
+
+ - name: refcount
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-17
 
  - name: reledmac
    type: package
@@ -3197,6 +3261,22 @@
    tests: false
    tasks: needs tests
    updated: 2024-07-15
+
+ - name: scrextend
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-17
+
+ - name: scrlayer
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-17
 
  - name: scrletter
    type: package
@@ -3579,6 +3659,14 @@
    issues:
    updated: 2024-07-07
 
+ - name: textpos
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-17
+
  - name: tgadventor
    ctan-pkg: tex-gyre-adventor
    type: package
@@ -3761,6 +3849,14 @@
    tasks: needs tests
    updated: 2024-07-15
 
+ - name: tocbasic
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-17
+
  - name: tocbibind
    type: package
    status: unknown
@@ -3821,6 +3917,14 @@
    status: compatible
    issues:
    updated: 2024-07-06
+
+ - name: transparent
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-17
 
  - name: trig
    type: package
@@ -4065,6 +4169,14 @@
    issues:
    updated: 2024-07-07
 
+ - name: xcoffins
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-17
+
  - name: xcomment
    type: package
    status: unknown
@@ -4158,6 +4270,14 @@
    tests: false
    updated: 2024-07-15
 
+ - name: zref
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-17
+
 
 
 
@@ -4208,6 +4328,24 @@
    supported-through: [phase-III,title]
    updated: 2024-07-05
 
+#------------------------ EEE ----------------------------
+
+ - name: exam
+   type: class
+   status: unknown
+   issues:
+   tasks: needs tests
+   updated: 2024-07-17
+
+#------------------------ III ----------------------------
+
+ - name: IEEEtran
+   type: class
+   status: unknown
+   issues:
+   tasks: needs tests
+   updated: 2024-07-17
+
 #------------------------ KKK ----------------------------
 
 #------------------------ LLL ----------------------------
@@ -4218,6 +4356,13 @@
    issues:
    tasks: needs tests
    updated: 2024-07-06
+
+ - name: ltxdoc
+   type: class
+   status: unknown
+   issues:
+   tasks: needs tests
+   updated: 2024-07-17
 
 #------------------------ MMM ----------------------------
 
@@ -4247,6 +4392,14 @@
    supported-through: [phase-III,title]   
    updated: 2024-07-05
 
+ - name: revtex4-2
+   ctan-pkg: revtex
+   type: class
+   status: unknown
+   issues:
+   tasks: needs tests
+   updated: 2024-07-17
+
 #------------------------ SSS ----------------------------
 
  - name: scrartcl
@@ -4272,4 +4425,11 @@
    status: currently-incompatible
    related-issues: [88]
    updated: 2024-07-10
+
+ - name: standalone
+   type: class
+   status: unknown
+   issues:
+   tasks: needs tests
+   updated: 2024-07-17
 


### PR DESCRIPTION
Adds several commonly-used packages and classes to tagging-status.yml without commenting on their status. If any are too obscure to be included please let me know.