### PR TITLE
add csvsimple compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -1001,11 +1001,13 @@
 
  - name: csvsimple
    type: package
-   status: unknown
+   status: compatible
+   comments: "`\\csvautotabularray` etc. are not supported since tabularray is
+             currently incompatible."
+   supported-through: [phase-III,table]
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-14
+   tests: true
+   updated: 2024-07-18
 
  - name: cuprum
    type: package
@@ -3115,6 +3117,7 @@
  - name: pgfplotstable
    type: package
    status: compatible
+   supported-through: [phase-III,table]
    comments: "Table tagging is correct but any interaction with pgfplots
               is not yet supported."
    tests: true

--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -1001,13 +1001,13 @@
 
  - name: csvsimple
    type: package
-   status: compatible
+   status: partially-compatible
    comments: "`\\csvautotabularray` etc. are not supported since tabularray is
              currently incompatible."
    supported-through: [phase-III,table]
    issues:
    tests: true
-   updated: 2024-07-18
+   updated: 2024-07-20
 
  - name: cuprum
    type: package

--- a/tagging-status/testfiles/csvsimple/csvsimple-01.tex
+++ b/tagging-status/testfiles/csvsimple/csvsimple-01.tex
@@ -1,0 +1,45 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\begin{filecontents*}{grade.csv}
+name,givenname,matriculation,gender,grade
+Maier,Hans,12345,m,1.0
+Huber,Anna,23456,f,2.3
+Weißbäck,Werner,34567,m,5.0
+Bauer,Maria,19202,f,3.3
+\end{filecontents*}
+
+\documentclass{article}
+\usepackage[l3]{csvsimple}
+
+\begin{document}
+
+\csvautotabular{grade.csv}
+
+\begin{tabular}{|l|c|}\hline%
+\bfseries Person & \bfseries Matr.~No.
+\csvreader[
+head to column names
+]{grade.csv}{}{%
+\\\givenname\ \name & \matriculation
+}%
+\\\hline
+\end{tabular}
+
+\csvstyle{myTableStyle}{
+tabular = |r|l|c|,
+table head = \hline & Person & Matr.~No.\\\hline\hline,
+late after line = \\\hline,
+head to column names,
+head to column names prefix = MY,
+}
+\csvreader[myTableStyle]
+{grade.csv}{}{%
+\thecsvrow & \MYgivenname~\MYname & \MYmatriculation
+}
+
+\end{document}


### PR DESCRIPTION
Lists csvsimple as compatible and adds a test file. Comments that `\csvautotabularray` is not yet supported because tabularray is not compatible