### PR TITLE
add sillypage compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -3375,11 +3375,11 @@
 
  - name: sillypage
    type: package
-   status: unknown
+   status: partially-compatible
+   comments: "Images are missing alt text."
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-15
+   tests: true
+   updated: 2024-07-18
 
  - name: siunitx
    type: package

--- a/tagging-status/testfiles/sillypage/sillypage-01.tex
+++ b/tagging-status/testfiles/sillypage/sillypage-01.tex
@@ -1,0 +1,20 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,table,title,firstaid}
+  }
+
+\documentclass{article}
+\usepackage{sillypage}
+
+\pagenumbering{silly}
+
+\begin{document}
+
+text
+
+\sillystep{5}
+
+\end{document}


### PR DESCRIPTION
Lists sillypage as "partially-compatible" since the images are missing alt text. Test file included