### PR TITLE
Add extra status for maintainers activly want to be involved/are working on it

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -25,6 +25,7 @@
 # -----                  -------
 # compatible             This package or class works without any issues when tagging is enabled
 # partially-compatible   The package or class is currently partially compatible, see comments column
+# in-progress		 Status can be choosen by maintainers to mark they are aware and already working on it. This means testfiles should not be included in th tagging-project but in the package/class repository.
 # currently-incompatible The package or class is currently incompatible with the tagging code, but we expect it to be updated eventually. 
 # no-support             This package or class or class is incompatible with the tagging code and we do *not* believe that it will ever be supported.
 # unknown                The status of this package or class is not known

--- a/tagging-status/index.md
+++ b/tagging-status/index.md
@@ -42,6 +42,7 @@ If you encounter a problem with a package or class for which there is no issue i
 {% assign xpackages = site.data.tagging-status | where: "type", "package" %}
 {% assign xpc = xpackages | where: "status", "compatible" %}
 {% assign xpp = xpackages | where: "status", "partially-compatible" %}
+{% assign xpm = xpackages | where: "status", "in-progress" %}
 {% assign xpi = xpackages | where: "status", "currently-incompatible" %}
 {% assign xpn = xpackages | where: "status", "no-support" %}
 {% assign xpu = xpackages | where: "status", "unknown" %}
@@ -49,11 +50,12 @@ If you encounter a problem with a package or class for which there is no issue i
 Statistics: The table currently holds **{{xpackages | size }}** packages out of which
 **{{xpc| size }}**  are fully `compatible`,
 **{{xpp | size }}** `partially-compatible`,
+**{{xpm | size}}**`in-progress`,
 **{{xpi | size }}** `currently-incompatible`, and
 **{{xpn | size }}** have  `no-support`.
 The status for the remaining **{{xpu | size }}** packages is `unknown`.
 
-{% assign packages = xpc | concat: xpp | concat: xpi | concat: xpn | concat: xpu %}
+{% assign packages = xpc | concat: xpp | concat: xpm | concat: xpi | concat: xpn | concat: xpu %}
 
 {% include_relative status-table.md %}
 
@@ -64,6 +66,7 @@ The status for the remaining **{{xpu | size }}** packages is `unknown`.
 {% assign xpackages = site.data.tagging-status | where: "type", "class" %}
 {% assign xpc = xpackages | where: "status", "compatible" %}
 {% assign xpp = xpackages | where: "status", "partially-compatible" %}
+{% assign xpm = xpackages | where: "status", "in-progress" %}
 {% assign xpi = xpackages | where: "status", "currently-incompatible" %}
 {% assign xpn = xpackages | where: "status", "no-support" %}
 {% assign xpu = xpackages | where: "status", "unknown" %}
@@ -71,11 +74,12 @@ The status for the remaining **{{xpu | size }}** packages is `unknown`.
 Statistics: The table currently holds **{{xpackages | size }}** classes out of which
 **{{xpc| size }}**  are fully `compatible`,
 **{{xpp | size }}** `partially-compatible`,
+**{{xpm | size}}**`in-progress`,
 **{{xpi | size }}** `currently-incompatible`, and
 **{{xpn | size }}** have  `no-support`.
 The status for the remaining **{{xpu | size }}** classes is `unknown`.
 
-{% assign packages = xpc | concat: xpp | concat: xpi | concat: xpn | concat: xpu %}
+{% assign packages = xpc | concat: xpp | concat: xpm | concat: xpi | concat: xpn | concat: xpu %}
 
 {% include_relative status-table.md %}
 


### PR DESCRIPTION
As discussed during the developers workshop before TUG I'd love to have some kind of status indicating that testfiles are provided elsewhere and the package maintainers are actually working on it, including the link to the repo. 

To show an example I would – in case you approve this PR - edit the entry for ragged2e in the following way:

```yaml
- name: ragged2e
  type: package
  status: in-progress
  tests: true
  source-repository: https://gitlab.com/TeXhackse/ragged2e
  supported-through: phase-III
  updated: 2024-07-19
```
edit: move the repo to a separate key as suggested in the comments.

I tried to find out how the website is built, which I did not manage on first try, so I just tried to find out how it works. Idea was to help, in case it's not helpful just drop this PR. Not sure if you want to stick to the 3 letter naming for the columns. I tried to… 

Not sure about the naming … but I thought `ìn-progress` is a good idea, but that makes the 3 letter thing a bit more complicated. Currently I added `xpm` where `m` stands for `maintained` which would also be an option… but that usually would not indicate that someone is actually working on this feature extension. 