### PR TITLE
Add many packages

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -2365,14 +2365,6 @@
    tasks: needs tests
    updated: 2024-07-18
 
- - name: floatpag
-   type: package
-   status: unknown
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
-
  - name: floatrow
    type: package
    status: unknown

--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -92,6 +92,14 @@
    tasks: needs tests
    updated: 2024-07-13
 
+ - name: academicons
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: accanthis
    type: package
    status: compatible
@@ -139,6 +147,14 @@
    tasks: needs tests
    updated: 2024-07-13
 
+ - name: adjmulticols
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: adjustbox
    type: package
    status: unknown
@@ -162,12 +178,13 @@
    tests: false
    updated: 2024-07-13
 
- - name: almendra
+ - name: algorithm2e
    type: package
-   status: compatible
+   status: unknown
    issues:
    tests: false
-   updated: 2024-07-13
+   tasks: needs tests
+   updated: 2024-07-18
 
  - name: algorithmicx
    type: package
@@ -194,11 +211,42 @@
    tasks: needs tests
    updated: 2024-07-14
 
+ - name: aliascnt
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: aligned-overset
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: alltt
    type: package
    status: currently-incompatible
    issues: [131]
    updated: 2024-07-14
+
+ - name: almendra
+   type: package
+   status: compatible
+   issues:
+   tests: false
+   updated: 2024-07-13
+
+ - name: alphalph
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
  - name: amsbsy
    type: package
@@ -217,6 +265,14 @@
    issues:
    tests: true
    updated: 2024-07-12
+
+ - name: amscdx
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
  - name: amsfonts
    type: package
@@ -288,7 +344,23 @@
    tasks: needs tests
    updated: 2024-07-06
 
+ - name: andika
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: animate
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: anonchap
    type: package
    status: unknown
    issues:
@@ -392,6 +464,22 @@
    tasks: needs tests
    updated: 2024-07-13
 
+ - name: asymptote
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: atkinson
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: attachfile2
    type: package
    status: unknown
@@ -425,6 +513,30 @@
    tasks: needs tests
    updated: 2024-07-13
 
+ - name: auto-pst-pdf
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: auto-pst-pdf-lua
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: autoaligne
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: avant
    ctan-pkg: psnfss
    type: package
@@ -441,6 +553,14 @@
              clash with the math module. `phase-III,math` should be used instead which
              provides broader tagging support without the need to load an additional package.
    updated: 2024-07-14
+
+ - name: axodraw2
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
 #------------------------ BBB ----------------------------
 
@@ -476,6 +596,14 @@
    tasks: needs tests
    updated: 2024-07-17
 
+ - name: balance
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: baskervillef
    type: package
    status: compatible
@@ -483,12 +611,28 @@
    tests: false
    updated: 2024-07-14
 
+ - name: bbding
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: bboldx
    type: package
    status: compatible
    issues:
    tests: true
    updated: 2024-07-16
+
+ - name: bclogo
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
  - name: beton
    type: package
@@ -594,6 +738,14 @@
    tasks: needs tests
    updated: 2024-07-14
 
+ - name: bicaption
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: bidi
    type: package
    status: unknown
@@ -617,6 +769,14 @@
    tasks: needs tests
    updated: 2024-07-04
 
+ - name: bigintcalc
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: bigstrut
    type: package
    status: unknown
@@ -632,6 +792,14 @@
    issues:
    tests: false
    updated: 2024-07-14
+
+ - name: bitset
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
  - name: bitter
    type: package
@@ -655,6 +823,14 @@
    tests: true
    updated: 2024-07-12
 
+ - name: bmpsize
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: boldline
    type: package
    status: unknown
@@ -662,6 +838,14 @@
    tests: false
    tasks: needs tests
    updated: 2024-07-14
+
+ - name: booklet
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
  - name: bookman
    ctan-pkg: psnfss
@@ -706,6 +890,14 @@
    tests: true
    updated: 2024-07-17
 
+ - name: breakurl
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: breqn
    type: package
    status: currently-incompatible
@@ -714,6 +906,14 @@
    tasks: needs more tests
    updated: 2024-07-14
 
+ - name: bussproofs
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: bxeepic
    type: package
    status: unknown
@@ -721,6 +921,14 @@
    tests: false
    tasks: needs tests
    updated: 2024-07-14
+
+ - name: bytefield
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
 #------------------------ CCC ----------------------------
 
@@ -788,6 +996,14 @@
    issues:
    updated: 2024-07-06
 
+ - name: cancel
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: capt-of
    type: package
    status: unknown
@@ -821,6 +1037,14 @@
    tests: true
    updated: 2024-07-08
 
+ - name: carlito
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: cases
    type: package
    status: unknown
@@ -837,12 +1061,28 @@
    tasks: needs tests
    updated: 2024-07-18
 
+ - name: ccaption
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: ccfonts
    type: package
    status: compatible
    issues:
    tests: false
    updated: 2024-07-14
+
+ - name: ccicons
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
  - name: cellspace
    type: package
@@ -851,6 +1091,22 @@
    issues:
    tests: true
    updated: 2024-07-15
+
+ - name: centernot
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: cfr-lm
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
  - name: chancery
    type: package
@@ -868,6 +1124,14 @@
    tests: false
    tasks: needs tests
    updated: 2024-07-14
+
+ - name: changepage
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
  - name: changes
    type: package
@@ -902,7 +1166,47 @@
    tests: false
    updated: 2024-07-14
 
+ - name: chemarr
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: chemfig
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: chemformula
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: chemgreek
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: chemmacros
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: chemnum
    type: package
    status: unknown
    issues:
@@ -925,6 +1229,22 @@
    tests: false
    updated: 2024-07-14
 
+ - name: circledsteps
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: circledtext
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: cite
    type: package
    status: unknown
@@ -933,12 +1253,28 @@
    tasks: needs tests
    updated: 2024-07-14
 
+ - name: cjk-ko
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: classico
    type: package
    status: compatible
    issues:
    tests: false
    updated: 2024-07-14
+
+ - name: classlist
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
  - name: cleveref
    type: package
@@ -948,6 +1284,14 @@
    issues: [2]
    tests: true
    updated: 2024-07-08
+
+ - name: clrstrip
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
  - name: cmbright
    type: package
@@ -963,12 +1307,36 @@
    tests: false
    updated: 2024-07-14
 
+ - name: codehigh
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: coelacanth
    type: package
    status: compatible
    issues:
    tests: false
    updated: 2024-07-14
+
+ - name: collcell
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: collectbox
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
  - name: colonequals
    type: package
@@ -1008,6 +1376,14 @@
    tasks: needs tests
    updated: 2024-07-14
 
+ - name: concmath-otf
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: continue
    type: package
    status: unknown
@@ -1024,6 +1400,22 @@
    tasks: needs tests
    updated: 2024-07-18
 
+ - name: contriesofeurope
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: cooperhewitt
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: courier
    type: package
    status: compatible
@@ -1031,6 +1423,22 @@
    issues:
    tests: false
    updated: 2024-07-14
+
+ - name: covington
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: cprotect
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
  - name: crop
    type: package
@@ -1055,12 +1463,52 @@
    tasks: needs tests
    updated: 2024-07-14
 
+ - name: ctable
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: cuprum
    type: package
    status: compatible
    issues:
    tests: false
    updated: 2024-07-14
+
+ - name: currfile
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: curve2e
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: cuted
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: cutwin
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
  - name: cyklop
    type: package
@@ -1111,6 +1559,14 @@
    tests: false
    updated: 2024-07-13
 
+ - name: DSSerif
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: dashrule
    type: package
    status: unknown
@@ -1159,6 +1615,14 @@
    tests: true
    updated: 2024-07-08
 
+ - name: decorule
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: dejavu
    type: package
    status: compatible
@@ -1182,6 +1646,14 @@
    tests: true
    updated: 2024-07-10
 
+ - name: derivative
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: diagbox
    type: package
    status: unknown
@@ -1198,11 +1670,27 @@
    tasks: needs tests
    updated: 2024-07-14
 
+ - name: dingbat
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: doc
    type: package
    status: currently-incompatible
    issues: [44]
    updated: 2024-07-06
+
+ - name: doclicense
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
  - name: docstrip
    type: package
@@ -1211,6 +1699,14 @@
    tests: false
    tasks: needs tests
    updated: 2024-07-14
+
+ - name: doi
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
  - name: dotlessi
    type: package
@@ -1269,12 +1765,44 @@
 
 #------------------------ EEE ----------------------------
 
+ - name: ETbb
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: easyfig
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: easylist
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: ebgaramond
    type: package
    status: compatible
    issues:
    tests: false
    updated: 2024-07-14
+
+ - name: ebproof
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
  - name: econlipsum
    type: package
@@ -1292,6 +1820,22 @@
    tasks: needs tests
    updated: 2024-07-14
 
+ - name: eforms
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: ekdosis
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: ellipsis
    type: package
    status: unknown
@@ -1299,6 +1843,14 @@
    tests: false
    tasks: needs tests
    updated: 2024-07-14
+
+ - name: embedall
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
  - name: embedfile
    type: package
@@ -1315,6 +1867,22 @@
    tests: false
    tasks: needs tests
    updated: 2024-07-14
+
+ - name: emo
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: emoji
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
  - name: empheq
    type: package
@@ -1339,6 +1907,22 @@
    tasks: needs tests
    updated: 2024-07-14
 
+ - name: endnotesj
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: engord
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: enotez
    type: package
    status: unknown
@@ -1346,6 +1930,14 @@
    tests: false
    tasks: needs tests
    updated: 2024-07-14
+
+ - name: enparen
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
  - name: enumerate
    type: package
@@ -1362,7 +1954,15 @@
    issues: [61]
    related-issues: [4]
    updated: 2024-07-06
-   
+
+ - name: eolgrab
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: epic
    status: unknown
    issues:
@@ -1384,6 +1984,22 @@
    comments: "Obsolete, small wrapper around graphicx"
    issues:
    updated: 2024-07-07
+
+ - name: epstopdf
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: eqparbox
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
  - name: erewhon
    type: package
@@ -1460,6 +2076,14 @@
    tests: false
    updated: 2024-07-14
 
+ - name: euler-math
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: eulervm
    type: package
    status: compatible
@@ -1511,6 +2135,15 @@
    tasks: needs tests
    updated: 2024-07-14
 
+ - name: extramarks
+   ctan-pkg: fancyhdr
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
 #------------------------ FFF ----------------------------
 
  - name: FiraMono
@@ -1528,6 +2161,14 @@
    issues:
    tests: false
    updated: 2024-07-13
+
+ - name: faktor
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
  - name: fancybox
    type: package
@@ -1566,6 +2207,14 @@
    tests: false
    updated: 2024-07-14
 
+ - name: fbox
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: fcolumn
    type: package
    status: unknown
@@ -1574,6 +2223,14 @@
    tasks: needs tests
    updated: 2024-07-14
 
+ - name: fdsymbol
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: fewerfloatpages
    type: package
    status: unknown
@@ -1581,6 +2238,22 @@
    tests: false
    tasks: needs tests
    updated: 2024-07-14
+
+ - name: fibnum
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: figcaps
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
  - name: filecontentsdef
    type: package
@@ -1597,6 +2270,30 @@
    tests: false
    tasks: needs tests
    updated: 2024-07-14
+
+ - name: firamath-otf
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: fitbox
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: fitch
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
  - name: fix-cm
    type: package
@@ -1642,6 +2339,14 @@
    tasks: needs tests
    updated: 2024-07-14
 
+ - name: flippdf
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: float
    type: package
    status: currently-incompatible
@@ -1650,12 +2355,52 @@
    tasks: needs tests
    updated: 2024-07-06
 
+ - name: floatflt
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: floatpag
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: floatrow
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: flowfram
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: fltrace
    ctan-pkg: latex-base
    type: package
    status: compatible
    issues:
    updated: 2024-07-06
+
+ - name: flushend
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
  - name: fmtcount
    type: package
@@ -1666,6 +2411,14 @@
    updated: 2024-07-14
 
  - name: fnbreak
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: fncychap
    type: package
    status: unknown
    issues:
@@ -1705,6 +2458,14 @@
    tasks: needs tests
    updated: 2024-07-18
 
+ - name: fnumprint
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: fontawesome5
    type: package
    status: compatible
@@ -1724,6 +2485,14 @@
    status: compatible
    issues:
    updated: 2024-07-06
+
+ - name: fontsetup
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
  - name: fontspec
    type: package
@@ -1794,6 +2563,14 @@
    tasks: needs tests
    updated: 2024-07-18
 
+ - name: forum
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: fourier
    ctan-pkg: fourier
    type: package
@@ -1809,6 +2586,23 @@
    issues:
    tests: false
    updated: 2024-07-14
+
+ - name: fourier-otf
+   ctan-pkg: erewhon-math
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: fouriernc
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
  - name: framed
    type: package
@@ -1834,6 +2628,14 @@
    tests: false
    tasks: needs tests
    updated: 2024-07-14
+
+ - name: froufrou
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
  - name: ftnright
    type: package
@@ -1906,12 +2708,44 @@
    tasks: needs tests
    updated: 2024-07-18
 
+ - name: gelasio
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: gelasiomath
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: gensymb
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: gentium
    type: package
    status: compatible
    issues:
    tests: false
    updated: 2024-07-14
+
+ - name: gentombow
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
  - name: geometry
    type: package
@@ -2000,6 +2834,14 @@
    tests: false
    updated: 2024-07-14
 
+ - name: ghsystem
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: gillius
    type: package
    status: compatible
@@ -2015,6 +2857,30 @@
    tests: false
    updated: 2024-07-14
 
+ - name: gincltex
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: gindex
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: gitinfo-lua
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: gitinfo2
    type: package
    status: compatible
@@ -2029,6 +2895,14 @@
    tasks: needs tests
    issues: [48]
    updated: 2024-07-06
+
+ - name: grabbox
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
  - name: graphics
    type: package
@@ -2059,6 +2933,22 @@
    tests: true
    updated: 2024-07-08
 
+ - name: grfext
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: gridset
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: grmath
    ctan-pkg: babel-greek
    type: package
@@ -2069,6 +2959,14 @@
    updated: 2024-07-14
 
 #------------------------ HHH ----------------------------
+
+ - name: hanging
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
  - name: har2nat
    type: package
@@ -2093,6 +2991,14 @@
    issues:
    tests: false
    updated: 2024-07-14
+
+ - name: heros-otf
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
  - name: hetarom
    ctan-pkg: xymtex
@@ -2136,6 +3042,70 @@
    tasks: needs tests
    updated: 2024-07-14
 
+ - name: hvindex
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: hvlogos
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: hypbmsec
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: hypcap
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: hypdestopt
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: hypdoc
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: hypdvips
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: hyperbar
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: hyperref
    type: package
    status: compatible
@@ -2150,6 +3120,30 @@
               handled by the kernel code."
    issues:
    updated: 2024-07-07
+
+ - name: hypgotoe
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: hyphenat
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: hyphsubst
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
 #------------------------ III ----------------------------
 
@@ -2169,12 +3163,28 @@
    tests: false
    updated: 2024-07-13
 
+ - name: ibarra
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: ifetex
    type: package
    status: compatible
    issues:
    tests: false
    updated: 2024-07-15
+
+ - name: ifdraft
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
  - name: iflang
    type: package
@@ -2190,6 +3200,22 @@
    issues:
    tests: false
    updated: 2024-07-15
+
+ - name: ifoddpage
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: ifplatform
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
  - name: ifptex
    type: package
@@ -2231,6 +3257,14 @@
    issues:
    tests: false
    updated: 2024-07-15
+
+ - name: import
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
  - name: incgraph
    type: package
@@ -2275,6 +3309,14 @@
    issues:
    updated: 2024-07-06
 
+ - name: intcalc
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: interval
    type: package
    status: unknown
@@ -2283,12 +3325,28 @@
    tasks: needs tests
    updated: 2024-07-15
 
+ - name: intopdf
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: iwona
    type: package
    status: compatible
    issues:
    tests: false
    updated: 2024-07-15
+
+ - name: iwonamath
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
 #------------------------ JJJ ----------------------------
 
@@ -2300,6 +3358,30 @@
    tasks: needs tests
    updated: 2024-07-15
 
+ - name: josefin
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: junicode
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: junicodevf
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: jurabib
    type: package
    status: unknown
@@ -2310,6 +3392,14 @@
 
 
 #------------------------ KKK ----------------------------
+
+ - name: kanbun
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
  - name: kantlipsum
    type: package
@@ -2325,6 +3415,14 @@
    tests: false
    tasks: needs tests
    updated: 2024-07-15
+
+ - name: keystroke
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
  - name: keyval
    type: package
@@ -2400,6 +3498,15 @@
    tests: false
    updated: 2024-07-13
 
+ - name: LobsterTwo
+   ctan-pkg: lobster2
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: l3sys-query
    type: package
    status: compatible
@@ -2407,12 +3514,28 @@
    tests: true
    updated: 2024-07-08
 
+ - name: labelschanged
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: lastpage
    type: package
    status: compatible
    issues:
    updated: 2024-07-12
-   
+
+ - name: latex2pydata
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: latexrelease
    type: package
    status: partially-compatible
@@ -2450,6 +3573,47 @@
    tasks: needs tests
    updated: 2024-07-15
 
+ - name: leftidx
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: leftindex
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: lete-sans-math
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: letterspace
+   ctan-pkg: microtype
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: letterswitharrows
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: lettrine
    type: package
    status: unknown
@@ -2472,6 +3636,22 @@
    tests: false
    updated: 2024-07-15
 
+ - name: libertinus-otf
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: libertinust1math
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: librebaskerville
    type: package
    status: compatible
@@ -2492,6 +3672,14 @@
    issues:
    tests: false
    updated: 2024-07-15
+
+ - name: linebreaker
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
  - name: lineno
    type: package
@@ -2520,6 +3708,7 @@
    type: package
    status: compatible
    issues:
+   tests: false
    updated: 2024-07-06
 
  - name: listings
@@ -2531,6 +3720,22 @@
    related-issues: [41]
    tests: true
    updated: 2024-07-12
+
+ - name: listliketab
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: listofitems
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
  - name: literat
    ctan-pkg: literaturnaya
@@ -2547,6 +3752,22 @@
    tests: false
    updated: 2024-07-15
 
+ - name: logix
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: longdivision
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: longtable
    type: package
    status: partially-compatible
@@ -2555,6 +3776,14 @@
    comments: longtables with page breaks works only with luatex
    related-issues: [38]
    updated: 2024-07-06
+
+ - name: lpic
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
  - name: lscape
    type: package
@@ -2579,6 +3808,14 @@
    tasks: needs tests
    updated: 2024-07-15
 
+ - name: ltxgrid
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: ltxtable
    type: package
    status: unknown
@@ -2595,6 +3832,14 @@
    tasks: needs tests
    updated: 2024-07-15
 
+ - name: lua-typo
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: lua-ul
    type: package
    status: unknown
@@ -2602,6 +3847,46 @@
    tests: false
    tasks: needs tests
    updated: 2024-07-15
+
+ - name: lua-widow-control
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: luacode
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: lualatex-math
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: luamathalign
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: luamesh
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
  - name: luamplib
    type: package
@@ -2625,6 +3910,38 @@
    issues: [87]
    updated: 2024-07-06
 
+ - name: luatexko
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: luatodonotes
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: luavlna
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: lucida-otf
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: lucidabr
    type: package
    status: compatible
@@ -2647,7 +3964,23 @@
    tasks: needs tests
    updated: 2024-07-15
 
+ - name: lyluatex
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
 #------------------------ MMM ----------------------------
+
+ - name: MnSymbol
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
  - name: magaz
    type: package
@@ -2656,6 +3989,14 @@
    tests: false
    tasks: needs tests
    updated: 2024-07-15
+
+ - name: magicnum
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
  - name: makeidx
    type: package
@@ -2701,6 +4042,14 @@
    tests: false
    updated: 2024-07-15
 
+ - name: mathabx
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: mathalpha
    type: package
    status: unknown
@@ -2710,6 +4059,14 @@
    updated: 2024-07-15
 
  - name: mathastext
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: mathdesign
    type: package
    status: unknown
    issues:
@@ -2778,6 +4135,14 @@
    tasks: needs tests
    updated: 2024-07-15
 
+ - name: mcaption
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: mcite
    type: package
    status: unknown
@@ -2801,6 +4166,14 @@
    issues: [73]
    updated: 2024-07-06
 
+ - name: mdsymbol
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: media9
    type: package
    status: unknown
@@ -2817,12 +4190,60 @@
    tasks: needs tests
    updated: 2024-07-18
 
+ - name: mercatormap
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: menukeys
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: merriweather
    type: package
    status: compatible
    issues:
    tests: false
    updated: 2024-07-15
+
+ - name: metalogo
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: metalogox
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: mfirstuc
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: mhchem
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
  - name: miama
    type: package
@@ -2837,6 +4258,30 @@
    comments: Footnote patching doesn’t work but otherwise supported.
    issues: [67]
    updated: 2024-07-06
+
+ - name: midpage
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: minibox
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: minitoc
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
  - name: minted
    type: package
@@ -2938,6 +4383,31 @@
    tasks: needs tests
    updated: 2024-07-15
 
+ - name: multido
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: multiexpand
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: multimedia
+   ctan-pkg: beamer
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: multirow
    type: package
    status: unknown
@@ -2962,6 +4432,14 @@
    tasks: needs tests
    updated: 2024-07-18
 
+ - name: mwe
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: mweights
    type: package
    status: compatible
@@ -2970,6 +4448,14 @@
    updated: 2024-07-15
 
 #------------------------ NNN ----------------------------
+
+ - name: nameauth
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
  - name: named
    type: package
@@ -3006,6 +4492,14 @@
    tests: false
    tasks: needs tests
    updated: 2024-07-15
+
+ - name: navigator
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
  - name: nccfoots
    type: package
@@ -3055,6 +4549,14 @@
    tests: false
    tasks: needs tests
    updated: 2024-07-15
+
+ - name: newproof
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
  - name: newpxmath
    ctan-pkg: newpx
@@ -3106,6 +4608,22 @@
    tests: false
    updated: 2024-07-15
 
+ - name: newtxsf
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: newtxtt
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: newunicodechar
    type: package
    status: unknown
@@ -3129,12 +4647,28 @@
    tests: false
    updated: 2024-07-15
 
+ - name: nidanfloat
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: nolbreaks
    status: unknown
    issues:
    tests: false
    tasks: needs tests
    updated: 2024-07-15
+
+ - name: nomencl
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
  - name: nonumonpart
    status: unknown
@@ -3212,12 +4746,52 @@
    tasks: needs tests
    updated: 2024-07-15
 
+ - name: nth
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: ntheorem
    status: unknown
    issues:
    tests: false
    tasks: needs tests
    updated: 2024-07-15
+
+ - name: numerica
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: numerica-plus
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: numerica-tables
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: numspell
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
 #------------------------ OOO ----------------------------
 
@@ -3234,6 +4808,14 @@
    tests: false
    tasks: needs tests
    updated: 2024-07-15
+
+ - name: odsfile
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
  - name: old-arrows
    status: unknown
@@ -3255,6 +4837,14 @@
    tests: false
    tasks: needs tests
    updated: 2024-07-15
+
+ - name: orcidlink
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
  - name: oscola
    type: package
@@ -3286,6 +4876,14 @@
    updated: 2024-07-15
 
 #------------------------ PPP ----------------------------
+
+ - name: PoiretOne
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
  - name: PTMono
    ctan-pkg: paratype
@@ -3351,6 +4949,38 @@
    tasks: needs tests
    updated: 2024-07-18
 
+ - name: pagegrid
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: pagenote
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: pagesel
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: pagella-otf
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: pageslts
    type: package
    status: unknown
@@ -3360,6 +4990,14 @@
    updated: 2024-07-18
 
  - name: paracol
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: paralist
    type: package
    status: unknown
    issues:
@@ -3383,7 +5021,23 @@
    tasks: needs tests
    updated: 2024-07-18
 
+ - name: parnotes
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: parskip
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: pbalance
    type: package
    status: unknown
    issues:
@@ -3423,6 +5077,54 @@
    tasks: needs tests
    updated: 2024-07-18
 
+ - name: pdfcomment
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: pdfescape
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: pdfmarginpar
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: pdfmsym
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: pdfoverlay
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: pdfrender
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: pdfpages
    type: package
    status: currently-incompatible
@@ -3440,6 +5142,14 @@
    issues:
    updated: 2024-07-07
 
+ - name: perltex
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: perpage
    type: package
    status: unknown
@@ -3449,6 +5159,23 @@
    updated: 2024-07-18
 
  - name: pfnote
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: pgfmorepages
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: pgfpages
+   ctan-pkg: pgf
    type: package
    status: unknown
    issues:
@@ -3471,7 +5198,90 @@
    tests: true
    updated: 2024-07-16
 
+ - name: phonenumbers
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: piano
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: picins
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: picture
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: pifont
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: piton
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: placeins
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: plex-mono
+   ctan-pkg: plex
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: plex-sans
+   ctan-pkg: plex
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: plex-serif
+   ctan-pkg: plex
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: pmboxdraw
    type: package
    status: unknown
    issues:
@@ -3487,7 +5297,63 @@
    tasks: needs tests
    updated: 2024-07-17
 
+ - name: postnotes
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: prelim2e
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: preview
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: prftree
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: prooftrees
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: psfrag
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: pst-pdf
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: pst2pdf
    type: package
    status: unknown
    issues:
@@ -3504,9 +5370,49 @@
    tests: true
    updated: 2024-07-12
 
+ - name: pxpic
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: pyluatex
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: pythontex
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
 #------------------------ QQQ ----------------------------
 
  - name: qrcode
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: quattrocento
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: quotchap
    type: package
    status: unknown
    issues:
@@ -3537,6 +5443,14 @@
    issues:
    tests: false
    updated: 2024-07-15
+
+ - name: realboxes
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
  - name: realscripts
    type: package
@@ -3610,6 +5524,22 @@
    tasks: needs tests
    updated: 2024-07-15
 
+ - name: repltext
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: rerunfilecheck
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: resizegather
    type: package
    status: unknown
@@ -3617,6 +5547,14 @@
    tests: false
    tasks: needs tests
    updated: 2024-07-15
+
+ - name: returntogrid
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
  - name: roboto
    type: package
@@ -3640,6 +5578,14 @@
    tests: true
    updated: 2024-07-11
 
+ - name: rotchiffre
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: rotfloat
    type: package
    status: unknown
@@ -3648,7 +5594,23 @@
    tasks: needs tests
    updated: 2024-07-15
 
+ - name: rotpages
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
 #------------------------ SSS ----------------------------
+
+ - name: sansmath
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
  - name: savetrees
    type: package
@@ -3667,6 +5629,22 @@
    updated: 2024-07-15
 
  - name: scalerel
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: schola-otf
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: scholax
    type: package
    status: unknown
    issues:
@@ -3698,6 +5676,22 @@
    tasks: needs tests
    updated: 2024-07-17
 
+ - name: scrlayer-fancyhdr
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-17
+
+ - name: scrlayer-notecolumn
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-17
+
  - name: scrletter
    type: package
    status: unknown
@@ -3712,7 +5706,63 @@
    tasks: needs tests
    updated: 2024-07-15
 
+ - name: secdot
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: sectionbreak
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: sectsty
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: selectp
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: selinput
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: selnolig
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: sepfootnotes
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: setouterhbox
    type: package
    status: unknown
    issues:
@@ -3727,6 +5777,14 @@
    tests: false
    tasks: needs tests
    updated: 2024-07-15
+
+ - name: settobox
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
  - name: shadethm
    type: package
@@ -3744,6 +5802,14 @@
    tasks: needs tests
    updated: 2024-07-15
 
+ - name: shapepar
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: shellesc
    type: package
    status: compatible
@@ -3756,6 +5822,22 @@
    issues:
    tests: true
    updated: 2024-07-08
+
+ - name: showexpl
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: showframe
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
  - name: showhyphenation
    type: package
@@ -3806,6 +5888,14 @@
    tasks: needs tests
    updated: 2024-07-15
 
+ - name: simpleicons
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: siunitx
    type: package
    status: unknown
@@ -3813,6 +5903,14 @@
    tests: false
    tasks: needs tests
    updated: 2024-07-15
+
+ - name: slashed
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
  - name: snapshot
    type: package
@@ -3837,6 +5935,14 @@
    tests: false
    tasks: needs tests
    updated: 2024-07-15
+
+ - name: soulpos
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
  - name: soulutf8
    type: package
@@ -3867,6 +5973,31 @@
    tests: false
    updated: 2024-07-15
 
+ - name: spark-otf
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: spectral
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: splitidx
+   ctan-pkg: splitindex
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: spreadtab
    type: package
    status: compatible
@@ -3884,6 +6015,38 @@
    updated: 2024-07-15
 
  - name: stackengine
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: stackrel
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: stampinclude
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: standardsectioning
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: steinmetz
    type: package
    status: unknown
    issues:
@@ -3922,6 +6085,22 @@
    tests: false
    updated: 2024-07-15
 
+ - name: storebox
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: stringenc
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: structuredlog
    type: package
    status: compatible
@@ -3943,6 +6122,14 @@
    tasks: needs tests
    updated: 2024-07-15
 
+ - name: subeqn
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: subfig
    type: package
    status: unknown
@@ -3959,6 +6146,14 @@
    tasks: needs tests
    updated: 2024-07-18
 
+ - name: superiors
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: supertabular
    type: package
    status: unknown
@@ -3966,6 +6161,14 @@
    tests: false
    tasks: needs tests
    updated: 2024-07-15
+
+ - name: svg
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
  - name: svn-multi
    type: package
@@ -3975,6 +6178,14 @@
    tasks: needs tests
    updated: 2024-07-15
 
+ - name: systeme
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
 #------------------------ TTT ----------------------------
 
  - name: TheanoDidot
@@ -3983,6 +6194,22 @@
    issues:
    tests: false
    updated: 2024-07-13
+
+ - name: TheanoModern
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: TheanoOldStyle
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
  - name: tableof
    type: package
@@ -4081,12 +6308,60 @@
    tasks: needs further tests
    updated: 2024-07-06
 
+ - name: telprint
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: tempora
    type: package
    status: compatible
    issues:
    tests: false
    updated: 2024-07-15
+
+ - name: tensind
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: tensor
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: termes-otf
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: tex-locale
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: tex4ebook
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
  - name: tex4ht
    type: package
@@ -4095,6 +6370,14 @@
    tests: false
    tasks: needs tests
    updated: 2024-07-15
+
+ - name: texosquery
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
  - name: textcase
    type: package
@@ -4110,6 +6393,14 @@
    comments: "Package no longer needed as definitions have been moved into the kernel"
    issues:
    updated: 2024-07-07
+
+ - name: textgreek
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
  - name: textpos
    type: package
@@ -4190,6 +6481,14 @@
    tests: true
    updated: 2024-07-10
 
+ - name: thepdfnumber
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: thmbox
    type: package
    status: unknown
@@ -4221,6 +6520,22 @@
    tests: false
    tasks: needs tests
    updated: 2024-07-15
+
+ - name: thumbpdf
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: thumbs
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
  - name: tikz
    type: package
@@ -4373,6 +6688,14 @@
    tasks: needs tests
    updated: 2024-07-18
 
+ - name: totalcount
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: trace
    type: package
    status: compatible
@@ -4385,6 +6708,14 @@
    status: compatible
    issues:
    updated: 2024-07-06
+
+ - name: tracklang
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
  - name: transparent
    type: package
@@ -4415,6 +6746,14 @@
    tests: false
    tasks: needs tests
    updated: 2024-07-15
+
+ - name: twemojis
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
  - name: txfonts
    type: package
@@ -4480,12 +6819,28 @@
    tasks: needs tests
    updated: 2024-07-15
 
+ - name: uniquecounter
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: universalis
    type: package
    status: compatible
    issues:
    tests: false
    updated: 2024-07-15
+
+ - name: unravel
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
  - name: upquote
    type: package
@@ -4582,6 +6937,14 @@
    tasks: needs tests
    updated: 2024-07-15
 
+ - name: versonotes
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: vertbars
    type: package
    status: unknown
@@ -4589,6 +6952,14 @@
    tests: false
    tasks: needs tests
    updated: 2024-07-15
+
+ - name: vwcol
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
 #------------------------ WWW ----------------------------
 
@@ -4614,6 +6985,22 @@
    tests: false
    updated: 2024-07-15
 
+ - name: witharrows
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: wordcloud
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: wrapfig
    type: package
    status: currently-incompatible
@@ -4621,6 +7008,22 @@
    issues: [40]
    tests: true
    updated: 2024-07-10
+
+ - name: wrapfig2
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: wrapstuff
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
 #------------------------ XXX ----------------------------
 
@@ -4661,6 +7064,38 @@
    tasks: needs tests
    updated: 2024-07-15
 
+ - name: xecjk
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: xetexko
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: xevlna
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: xfakebold
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: xfrac
    type: package
    status: unknown
@@ -4677,7 +7112,39 @@
    tasks: needs tests
    updated: 2024-07-15
 
+ - name: xhfill
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: xint
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: xistercian
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: xkeyval
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: xlop
    type: package
    status: unknown
    issues:
@@ -4708,6 +7175,22 @@
    tasks: needs tests
    updated: 2024-07-18
 
+ - name: xpiano
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: xpinyin
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: xr
    type: package
    status: compatible
@@ -4720,6 +7203,14 @@
    comments: Package now identical to xr, thus not necessary any longer when hyperref is used.
    issues:
    updated: 2024-07-10
+
+ - name: xsavebox
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
  - name: xsim
    type: package
@@ -4736,12 +7227,28 @@
    tests: true
    updated: 2024-07-08
 
+ - name: xstring
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
  - name: xtemplate
    type: package
    status: compatible
    issues:
    tests: false
    updated: 2024-07-15
+
+ - name: xurl
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
  - name: xy
    ctan-pkg: xypic
@@ -4761,7 +7268,31 @@
    tests: false
    updated: 2024-07-15
 
+ - name: yfonts-otf
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
+ - name: yhmath
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
 #------------------------ ZZZ ----------------------------
+
+ - name: zhnumber
+   type: package
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
  - name: zlmtt
    type: package
@@ -4859,6 +7390,16 @@
    supported-through: [phase-III,title]
    updated: 2024-07-05
 
+#------------------------ CCC ----------------------------
+
+ - name: combine
+   type: class
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
 #------------------------ EEE ----------------------------
 
  - name: exam
@@ -4879,9 +7420,27 @@
    tasks: needs tests
    updated: 2024-07-17
 
+#------------------------ JJJ ----------------------------
+
+ - name: jlreq
+   type: class
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
+
 #------------------------ KKK ----------------------------
 
 #------------------------ LLL ----------------------------
+
+ - name: leaflet
+   type: class
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-06
 
  - name: letter
    type: class
@@ -4916,6 +7475,27 @@
    comments: "Some code showing the needed adjustments can be found in the 
               [bible example](https://github.com/latex3/tagging-project/blob/main/project-examples/ASV/bible.tex)"
    updated: 2024-07-05
+
+#------------------------ NNN ----------------------------
+
+ - name: novel
+   type: class
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-06
+
+#------------------------ OOO ----------------------------
+
+ - name: oblivoir
+   ctan-pkg: kotex-oblivoir
+   type: class
+   status: unknown
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-07-18
 
 #------------------------ PPP ----------------------------
 


### PR DESCRIPTION
Taking @car222222's [comment](https://github.com/latex3/tagging-project/pull/190#issuecomment-2235251497) to heart...

Adds many packages to tagging-status.yml without commenting on status. Many like the font packages could probably be marked as compatible without test files but I'll save that for another PR. I tried to include only packages that I think have a nonzero number of users and are not
1. very specific to a journal, conference, or university
2. obviously reliant on tikz or pstricks since these are not yet compatible anyways

This is in no way complete, just the result of a cursory browse through CTAN.

floatpag was removed from the addition since I see it will be added in #211.