### PR TITLE
priority

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -9,6 +9,7 @@
 #  type              required   string          "class" or "package" (may need eg tikz or beamer themes in the end?)
 #  status            required   string          Status of package, see list below.
 #  ctan-pkg          optional   string          Name for ctan.org/pkg/?? link if different to name
+#  priority          optional   integer         Priority of work for unknown entries (omitted from table if > 3)
 #  comments          optional   markdown-string Free text markdown comments
 #  references        optional   integer-list    List of integers referencing the bibliography in references.yml
 #  issues            optional   integer-list    List of integers referencing primary issues at latex3/tagging-project
@@ -39,6 +40,7 @@
  # - name: 
  #   type: package
  #   status: unknown
+ #   priority: 9
  #   issues:
  #   tests: false
  #   tasks: needs tests
@@ -79,6 +81,7 @@
  - name: abraces
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -87,6 +90,7 @@
  - name: abstract
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -95,6 +99,7 @@
  - name: academicons
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -110,6 +115,7 @@
  - name: accents
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -118,6 +124,7 @@
  - name: accsupp
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -126,6 +133,7 @@
  - name: acro
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -134,6 +142,7 @@
  - name: addlines
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -142,6 +151,7 @@
  - name: adforn
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -150,6 +160,7 @@
  - name: adjmulticol
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -158,6 +169,7 @@
  - name: adjustbox
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -181,6 +193,7 @@
  - name: algorithm2e
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -189,6 +202,7 @@
  - name: algorithmicx
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -197,6 +211,7 @@
  - name: algorithms
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -206,6 +221,7 @@
    ctan-pkg: algorithmicx
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -214,6 +230,7 @@
  - name: aliascnt
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -222,6 +239,7 @@
  - name: aligned-overset
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -243,6 +261,7 @@
  - name: alphalph
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -269,6 +288,7 @@
  - name: amscdx
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -305,6 +325,7 @@
  - name: amsrefs
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -340,6 +361,7 @@
    ctan-pkg: latex-amsmath
    type: package
    status: unknown
+   priority: 2
    issues:
    tasks: needs tests
    updated: 2024-07-06
@@ -347,6 +369,7 @@
  - name: andika
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -355,6 +378,7 @@
  - name: animate
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -363,6 +387,7 @@
  - name: anonchap
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -372,6 +397,7 @@
    ctan-pkg: poltawski
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -389,6 +415,7 @@
    ctan-pkg: bibtex
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -397,6 +424,7 @@
  - name: arabi
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -405,6 +433,7 @@
  - name: arabicfront
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -413,6 +442,7 @@
  - name: arabluatex
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -443,6 +473,7 @@
  - name: asciilist
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -451,6 +482,7 @@
  - name: askinclude
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -459,6 +491,7 @@
  - name: astron
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -467,6 +500,7 @@
  - name: asymptote
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -475,6 +509,7 @@
  - name: atkinson
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -483,6 +518,7 @@
  - name: attachfile2
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -499,6 +535,7 @@
  - name: authblk
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -508,6 +545,7 @@
    ctan-pkg: authordate
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -516,6 +554,7 @@
  - name: auto-pst-pdf
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -524,6 +563,7 @@
  - name: auto-pst-pdf-lua
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -532,6 +572,7 @@
  - name: autoaligne
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -557,6 +598,7 @@
  - name: axodraw2
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -574,6 +616,7 @@
  - name: babel
    type: package
    status: unknown
+   priority: 2
    comments: Most likely compatible for many languages, but this needs tests for each language, so listed as unknown for now.
    issues:
    tests: false
@@ -583,6 +626,7 @@
  - name: babelbib
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -591,6 +635,7 @@
  - name: backref
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -599,6 +644,7 @@
  - name: balance
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -614,6 +660,7 @@
  - name: bbding
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -629,6 +676,7 @@
  - name: bclogo
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -652,6 +700,7 @@
  - name: bibentry
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -709,6 +758,7 @@
  - name: biblatex2bibitem
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -717,6 +767,7 @@
  - name: biblist
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -725,6 +776,7 @@
  - name: bibtopic
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -733,6 +785,7 @@
  - name: bibunits
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -741,6 +794,7 @@
  - name: bicaption
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -749,6 +803,7 @@
  - name: bidi
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -757,6 +812,7 @@
  - name: bigdelim
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -765,6 +821,7 @@
  - name: bigfoot
    type: package
    status: unknown
+   priority: 2
    comments: To be supported or not? 
    tasks: needs tests
    updated: 2024-07-04
@@ -772,6 +829,7 @@
  - name: bigintcalc
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -780,6 +838,7 @@
  - name: bigstrut
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -796,6 +855,7 @@
  - name: bitset
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -826,6 +886,7 @@
  - name: bmpsize
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -834,6 +895,7 @@
  - name: boldline
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -842,6 +904,7 @@
  - name: booklet
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -859,6 +922,7 @@
  - name: bookmark
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -893,6 +957,7 @@
  - name: breakurl
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -909,6 +974,7 @@
  - name: bussproofs
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -917,6 +983,7 @@
  - name: bxeepic
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -925,6 +992,7 @@
  - name: bytefield
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -935,6 +1003,7 @@
  - name: CJK
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -943,6 +1012,7 @@
  - name: CTeX
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -999,6 +1069,7 @@
  - name: cancel
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -1007,6 +1078,7 @@
  - name: capt-of
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -1015,6 +1087,7 @@
  - name: captdef
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -1023,6 +1096,7 @@
  - name: captcont
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -1040,6 +1114,7 @@
  - name: carlito
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -1048,6 +1123,7 @@
  - name: cases
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -1056,6 +1132,7 @@
  - name: catchfile
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -1064,6 +1141,7 @@
  - name: ccaption
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -1079,6 +1157,7 @@
  - name: ccicons
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -1095,6 +1174,7 @@
  - name: centernot
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -1103,6 +1183,7 @@
  - name: cfr-lm
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -1120,6 +1201,7 @@
  - name: changebar
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -1128,6 +1210,7 @@
  - name: changepage
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -1136,6 +1219,7 @@
  - name: changes
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -1144,6 +1228,7 @@
  - name: chappg
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -1152,6 +1237,7 @@
  - name: chapterbib
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -1169,6 +1255,7 @@
  - name: chemarr
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -1177,6 +1264,7 @@
  - name: chemfig
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -1185,6 +1273,7 @@
  - name: chemformula
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -1193,6 +1282,7 @@
  - name: chemgreek
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -1201,6 +1291,7 @@
  - name: chemmacros
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -1209,6 +1300,7 @@
  - name: chemnum
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -1217,6 +1309,7 @@
  - name: chicago
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -1232,6 +1325,7 @@
  - name: circledsteps
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -1240,6 +1334,7 @@
  - name: circledtext
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -1248,6 +1343,7 @@
  - name: cite
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -1256,6 +1352,7 @@
  - name: cjk-ko
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -1271,6 +1368,7 @@
  - name: classlist
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -1288,6 +1386,7 @@
  - name: clrstrip
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -1310,6 +1409,7 @@
  - name: codehigh
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -1325,6 +1425,7 @@
  - name: collcell
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -1333,6 +1434,7 @@
  - name: collectbox
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -1341,6 +1443,7 @@
  - name: colonequals
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -1355,6 +1458,7 @@
  - name: colorspace
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -1371,6 +1475,7 @@
  - name: comment
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -1379,6 +1484,7 @@
  - name: concmath-otf
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -1387,6 +1493,7 @@
  - name: continue
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -1395,6 +1502,7 @@
  - name: contour
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -1403,6 +1511,7 @@
  - name: countriesofeurope
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -1411,6 +1520,7 @@
  - name: cooperhewitt
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -1427,6 +1537,7 @@
  - name: covington
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -1435,6 +1546,7 @@
  - name: cprotect
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -1443,6 +1555,7 @@
  - name: crop
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -1468,6 +1581,7 @@
  - name: ctable
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -1483,6 +1597,7 @@
  - name: currfile
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -1491,6 +1606,7 @@
  - name: curve2e
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -1499,6 +1615,7 @@
  - name: cuted
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -1507,6 +1624,7 @@
  - name: cutwin
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -1564,6 +1682,7 @@
  - name: DSSerif
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -1572,6 +1691,7 @@
  - name: dashrule
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -1580,6 +1700,7 @@
  - name: dashundergaps
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -1588,6 +1709,7 @@
  - name: datatool
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -1604,6 +1726,7 @@
  - name: dblfnote
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -1620,6 +1743,7 @@
  - name: decorule
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -1651,6 +1775,7 @@
  - name: derivative
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -1659,6 +1784,7 @@
  - name: diagbox
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -1667,6 +1793,7 @@
  - name: diffcoeff
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -1675,6 +1802,7 @@
  - name: dingbat
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -1689,6 +1817,7 @@
  - name: doclicense
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -1697,6 +1826,7 @@
  - name: docstrip
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -1705,6 +1835,7 @@
  - name: doi
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -1713,6 +1844,7 @@
  - name: dotlessi
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -1721,6 +1853,7 @@
  - name: draftwatermark
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -1770,6 +1903,7 @@
  - name: ETbb
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -1778,6 +1912,7 @@
  - name: easyfig
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -1786,6 +1921,7 @@
  - name: easylist
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -1801,6 +1937,7 @@
  - name: ebproof
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -1809,6 +1946,7 @@
  - name: econlipsum
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -1817,6 +1955,7 @@
  - name: eepic
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -1825,6 +1964,7 @@
  - name: eforms
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -1833,6 +1973,7 @@
  - name: ekdosis
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -1841,6 +1982,7 @@
  - name: ellipsis
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -1849,6 +1991,7 @@
  - name: embedall
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -1857,6 +2000,7 @@
  - name: embedfile
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -1865,6 +2009,7 @@
  - name: embrac
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -1873,6 +2018,7 @@
  - name: emo
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -1881,6 +2027,7 @@
  - name: emoji
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -1896,6 +2043,7 @@
  - name: endfloat
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -1904,6 +2052,7 @@
  - name: endnotes
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -1912,6 +2061,7 @@
  - name: endnotesj
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -1920,6 +2070,7 @@
  - name: engord
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -1928,6 +2079,7 @@
  - name: enotez
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -1936,6 +2088,7 @@
  - name: enparen
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -1960,6 +2113,7 @@
  - name: eolgrab
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -1967,6 +2121,7 @@
 
  - name: epic
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -1975,6 +2130,7 @@
  - name: epigraph
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -1990,6 +2146,7 @@
  - name: epstopdf
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -1998,6 +2155,7 @@
  - name: eqparbox
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -2013,6 +2171,7 @@
  - name: esint
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -2021,6 +2180,7 @@
  - name: eso-pic
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -2036,6 +2196,7 @@
  - name: ethiop
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -2044,6 +2205,7 @@
  - name: etoc
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -2081,6 +2243,7 @@
  - name: euler-math
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -2103,6 +2266,7 @@
  - name: expex
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -2124,6 +2288,7 @@
  - name: extarrows
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -2132,6 +2297,7 @@
  - name: extdash
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -2141,6 +2307,7 @@
    ctan-pkg: fancyhdr
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -2167,6 +2334,7 @@
  - name: faktor
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -2175,6 +2343,7 @@
  - name: fancybox
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -2190,6 +2359,7 @@
  - name: fancypar
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -2212,6 +2382,7 @@
  - name: fbox
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -2220,6 +2391,7 @@
  - name: fcolumn
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -2228,6 +2400,7 @@
  - name: fdsymbol
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -2236,6 +2409,7 @@
  - name: fewerfloatpages
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -2244,6 +2418,7 @@
  - name: fibnum
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -2252,6 +2427,7 @@
  - name: figcaps
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -2260,6 +2436,7 @@
  - name: filecontentsdef
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -2268,6 +2445,7 @@
  - name: filemod
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -2276,6 +2454,7 @@
  - name: firamath-otf
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -2284,6 +2463,7 @@
  - name: fitbox
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -2292,6 +2472,7 @@
  - name: fitch
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -2306,6 +2487,7 @@
  - name: fixfoot
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -2321,6 +2503,7 @@
  - name: fixme
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -2336,6 +2519,7 @@
  - name: flexisym
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -2344,6 +2528,7 @@
  - name: flippdf
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -2368,6 +2553,7 @@
  - name: floatflt
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -2376,6 +2562,7 @@
  - name: floatrow
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -2384,6 +2571,7 @@
  - name: flowfram
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -2399,6 +2587,7 @@
  - name: flushend
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -2407,6 +2596,7 @@
  - name: fmtcount
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -2415,6 +2605,7 @@
  - name: fnbreak
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -2423,6 +2614,7 @@
  - name: fncychap
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -2431,6 +2623,7 @@
  - name: fncylab
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -2439,6 +2632,7 @@
  - name: fnlineno
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -2447,6 +2641,7 @@
  - name: fnpct
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -2455,6 +2650,7 @@
  - name: fnpos
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -2463,6 +2659,7 @@
  - name: fnumprint
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -2491,6 +2688,7 @@
  - name: fontsetup
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -2505,6 +2703,7 @@
  - name: fonttable
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -2521,6 +2720,7 @@
  - name: footnote
    type: package
    status: unknown
+   priority: 2
    tasks: needs tests
    comments: To be supported or not?
    updated: 2024-07-06
@@ -2528,6 +2728,7 @@
  - name: footnotebackref
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -2536,6 +2737,7 @@
  - name: footnotehyper
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -2544,6 +2746,7 @@
  - name: footnoterange
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -2552,6 +2755,7 @@
  - name: footnpag
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -2560,6 +2764,7 @@
  - name: forest
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -2568,6 +2773,7 @@
  - name: forum
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -2593,6 +2799,7 @@
    ctan-pkg: erewhon-math
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -2601,6 +2808,7 @@
  - name: fouriernc
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -2609,6 +2817,7 @@
  - name: framed
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -2618,6 +2827,7 @@
    ctan-pkg: e-french
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -2626,6 +2836,7 @@
  - name: frenchle
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -2634,6 +2845,7 @@
  - name: froufrou
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -2649,6 +2861,7 @@
  - name: fvextra
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -2657,6 +2870,7 @@
  - name: fwlw
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -2705,6 +2919,7 @@
  - name: gb4e
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -2713,6 +2928,7 @@
  - name: gelasio
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -2721,6 +2937,7 @@
  - name: gelasiomath
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -2729,6 +2946,7 @@
  - name: gensymb
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -2744,6 +2962,7 @@
  - name: gentombow
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -2759,6 +2978,7 @@
  - name: gettitlestring
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -2839,6 +3059,7 @@
  - name: ghsystem
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -2862,6 +3083,7 @@
  - name: gincltex
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -2870,6 +3092,7 @@
  - name: gindex
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -2878,6 +3101,7 @@
  - name: gitinfo-lua
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -2893,6 +3117,7 @@
  - name: glossaries
    type: package
    status: unknown
+   priority: 2
    comments: An old issue appears to be fixed.
    tasks: needs tests
    issues: [48]
@@ -2901,6 +3126,7 @@
  - name: grabbox
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -2938,6 +3164,7 @@
  - name: grfext
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -2946,6 +3173,7 @@
  - name: gridset
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -2955,6 +3183,7 @@
    ctan-pkg: babel-greek
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -2965,6 +3194,7 @@
  - name: hanging
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -2973,6 +3203,7 @@
  - name: har2nat
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -2981,6 +3212,7 @@
  - name: harvard
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -2997,6 +3229,7 @@
  - name: heros-otf
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -3006,6 +3239,7 @@
    ctan-pkg: xymtex
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -3031,6 +3265,7 @@
  - name: hologo
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -3039,6 +3274,7 @@
  - name: hvfloat
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -3047,6 +3283,7 @@
  - name: hvindex
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -3055,6 +3292,7 @@
  - name: hvlogos
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -3063,6 +3301,7 @@
  - name: hypbmsec
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -3071,6 +3310,7 @@
  - name: hypcap
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -3079,6 +3319,7 @@
  - name: hypdestopt
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -3087,6 +3328,7 @@
  - name: hypdoc
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -3095,6 +3337,7 @@
  - name: hypdvips
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -3103,6 +3346,7 @@
  - name: hyperbar
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -3126,6 +3370,7 @@
  - name: hypgotoe
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -3134,6 +3379,7 @@
  - name: hyphenat
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -3142,6 +3388,7 @@
  - name: hyphsubst
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -3168,6 +3415,7 @@
  - name: ibarra
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -3183,6 +3431,7 @@
  - name: ifdraft
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -3191,6 +3440,7 @@
  - name: iflang
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -3206,6 +3456,7 @@
  - name: ifoddpage
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -3214,6 +3465,7 @@
  - name: ifplatform
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -3263,6 +3515,7 @@
  - name: import
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -3271,6 +3524,7 @@
  - name: incgraph
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -3292,6 +3546,7 @@
  - name: index
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -3300,6 +3555,7 @@
  - name: indxcite
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -3314,6 +3570,7 @@
  - name: intcalc
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -3322,6 +3579,7 @@
  - name: interval
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -3330,6 +3588,7 @@
  - name: intopdf
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -3345,6 +3604,7 @@
  - name: iwonamath
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -3355,6 +3615,7 @@
  - name: jmb
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -3363,6 +3624,7 @@
  - name: josefin
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -3371,6 +3633,7 @@
  - name: junicode
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -3379,6 +3642,7 @@
  - name: junicodevf
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -3387,6 +3651,7 @@
  - name: jurabib
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -3398,6 +3663,7 @@
  - name: kanbun
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -3413,6 +3679,7 @@
  - name: keyfloat
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -3421,6 +3688,7 @@
  - name: keystroke
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -3435,6 +3703,7 @@
  - name: keyvaltable
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -3444,6 +3713,7 @@
    ctan-pkg: cjk-ko
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -3504,6 +3774,7 @@
    ctan-pkg: lobster2
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -3519,6 +3790,7 @@
  - name: labelschanged
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -3533,6 +3805,7 @@
  - name: latex2pydata
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -3570,6 +3843,7 @@
  - name: layouts
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -3578,6 +3852,7 @@
  - name: leftidx
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -3586,6 +3861,7 @@
  - name: leftindex
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -3594,6 +3870,7 @@
  - name: lete-sans-math
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -3603,6 +3880,7 @@
    ctan-pkg: microtype
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -3611,6 +3889,7 @@
  - name: letterswitharrows
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -3619,6 +3898,7 @@
  - name: lettrine
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -3641,6 +3921,7 @@
  - name: libertinus-otf
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -3649,6 +3930,7 @@
  - name: libertinust1math
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -3678,6 +3960,7 @@
  - name: linebreaker
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -3695,6 +3978,7 @@
  - name: linguex
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -3727,6 +4011,7 @@
  - name: listliketab
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -3735,6 +4020,7 @@
  - name: listofitems
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -3758,6 +4044,7 @@
  - name: logix
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -3766,6 +4053,7 @@
  - name: longdivision
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -3783,6 +4071,7 @@
  - name: lpic
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -3791,6 +4080,7 @@
  - name: lscape
    type: package
    status: unknown
+   priority: 2
    issues:
    tasks: needs tests
    updated: 2024-07-06
@@ -3798,6 +4088,7 @@
  - name: ltablex
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -3806,6 +4097,7 @@
  - name: ltcaption
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -3814,6 +4106,7 @@
  - name: ltxgrid
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -3822,6 +4115,7 @@
  - name: ltxtable
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -3830,6 +4124,7 @@
  - name: lua-check-hyphen
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -3838,6 +4133,7 @@
  - name: lua-typo
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -3846,6 +4142,7 @@
  - name: lua-ul
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -3854,6 +4151,7 @@
  - name: lua-widow-control
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -3862,6 +4160,7 @@
  - name: luacode
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -3870,6 +4169,7 @@
  - name: lualatex-math
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -3878,6 +4178,7 @@
  - name: luamathalign
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -3886,6 +4187,7 @@
  - name: luamesh
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -3901,6 +4203,7 @@
  - name: luapstricks
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -3916,6 +4219,7 @@
  - name: luatexko
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -3924,6 +4228,7 @@
  - name: luatodonotes
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -3932,6 +4237,7 @@
  - name: luavlna
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -3940,6 +4246,7 @@
  - name: lucida-otf
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -3962,6 +4269,7 @@
  - name: lwarp
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -3970,6 +4278,7 @@
  - name: lyluatex
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -3980,6 +4289,7 @@
  - name: MnSymbol
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -3988,6 +4298,7 @@
  - name: magaz
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -3996,6 +4307,7 @@
  - name: magicnum
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -4011,6 +4323,7 @@
  - name: manyfoot
    type: package
    status: unknown
+   priority: 2
    tasks: needs tests
    comments: To be supported or not?
    updated: 2024-07-06
@@ -4025,6 +4338,7 @@
  - name: marginnote
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -4033,6 +4347,7 @@
  - name: markdown
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -4048,6 +4363,7 @@
  - name: mathabx
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -4056,6 +4372,7 @@
  - name: mathalpha
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -4064,6 +4381,7 @@
  - name: mathastext
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -4072,6 +4390,7 @@
  - name: mathdesign
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -4080,6 +4399,7 @@
  - name: mathdots
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -4119,6 +4439,7 @@
  - name: mathrsfs
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -4127,12 +4448,14 @@
  - name: mathtools
    type: package
    status: unknown
+   priority: 2
    tasks: needs tests
    updated: 2024-07-06
 
  - name: mattens
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -4141,6 +4464,7 @@
  - name: mcaption
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -4149,6 +4473,7 @@
  - name: mcite
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -4157,6 +4482,7 @@
  - name: mciteplus
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -4172,6 +4498,7 @@
  - name: mdsymbol
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -4180,6 +4507,7 @@
  - name: media9
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -4188,6 +4516,7 @@
  - name: memoize
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -4196,6 +4525,7 @@
  - name: mercatormap
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -4204,6 +4534,7 @@
  - name: menukeys
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -4219,6 +4550,7 @@
  - name: metalogo
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -4227,6 +4559,7 @@
  - name: metalogox
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -4235,6 +4568,7 @@
  - name: mfirstuc
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -4243,6 +4577,7 @@
  - name: mhchem
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -4265,6 +4600,7 @@
  - name: midpage
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -4273,6 +4609,7 @@
  - name: minibox
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -4281,6 +4618,7 @@
  - name: minitoc
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -4310,6 +4648,7 @@
  - name: mleftright
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -4318,6 +4657,7 @@
  - name: montex
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -4333,6 +4673,7 @@
  - name: moreverb
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -4348,6 +4689,7 @@
  - name: mparhack
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -4356,6 +4698,7 @@
  - name: multiaudience
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -4364,6 +4707,7 @@
  - name: multibib
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -4379,6 +4723,7 @@
  - name: multicolrule
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -4387,6 +4732,7 @@
  - name: multido
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -4395,6 +4741,7 @@
  - name: multiexpand
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -4404,6 +4751,7 @@
    ctan-pkg: beamer
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -4412,6 +4760,7 @@
  - name: multirow
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -4420,6 +4769,7 @@
  - name: multitoc
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -4428,6 +4778,7 @@
  - name: musixtex
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -4436,6 +4787,7 @@
  - name: mwe
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -4453,6 +4805,7 @@
  - name: nameauth
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -4461,6 +4814,7 @@
  - name: named
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -4476,6 +4830,7 @@
  - name: nar
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -4489,6 +4844,7 @@
  - name: nature
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -4497,6 +4853,7 @@
  - name: navigator
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -4505,6 +4862,7 @@
  - name: nccfoots
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -4513,6 +4871,7 @@
  - name: needspace
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -4521,6 +4880,7 @@
  - name: newapa
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -4538,6 +4898,7 @@
  - name: newcomputermodern
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -4546,6 +4907,7 @@
  - name: newfloat
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -4554,6 +4916,7 @@
  - name: newproof
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -4563,6 +4926,7 @@
    ctan-pkg: newpx
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -4571,6 +4935,7 @@
  - name: newpx
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -4587,6 +4952,7 @@
  - name: newtx
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -4596,6 +4962,7 @@
    ctan-pkg: newtx
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -4612,6 +4979,7 @@
  - name: newtxsf
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -4620,6 +4988,7 @@
  - name: newtxtt
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -4628,6 +4997,7 @@
  - name: newunicodechar
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -4636,6 +5006,7 @@
  - name: newverbs
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -4651,6 +5022,7 @@
  - name: nidanfloat
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -4658,6 +5030,7 @@
 
  - name: nolbreaks
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -4666,6 +5039,7 @@
  - name: nomencl
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -4673,6 +5047,7 @@
 
  - name: nonumonpart
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -4680,6 +5055,7 @@
 
  - name: nopageno
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -4718,6 +5094,7 @@
 
  - name: notoccite
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -4742,6 +5119,7 @@
 
  - name: notomath
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -4750,6 +5128,7 @@
  - name: nth
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -4757,6 +5136,7 @@
 
  - name: ntheorem
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -4765,6 +5145,7 @@
  - name: numerica
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -4773,6 +5154,7 @@
  - name: numerica-plus
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -4781,6 +5163,7 @@
  - name: numerica-tables
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -4789,6 +5172,7 @@
  - name: numspell
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -4805,6 +5189,7 @@
 
  - name: ocgx2
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -4813,6 +5198,7 @@
  - name: odsfile
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -4820,6 +5206,7 @@
 
  - name: old-arrows
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -4827,6 +5214,7 @@
 
  - name: onepagem
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -4834,6 +5222,7 @@
 
  - name: optional
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -4842,6 +5231,7 @@
  - name: orcidlink
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -4857,6 +5247,7 @@
 
  - name: oubraces
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -4871,6 +5262,7 @@
 
  - name: overpic
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -4881,6 +5273,7 @@
  - name: PoiretOne
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -4945,6 +5338,7 @@
  - name: pagecolor
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -4953,6 +5347,7 @@
  - name: pagegrid
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -4961,6 +5356,7 @@
  - name: pagenote
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -4969,6 +5365,7 @@
  - name: pagesel
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -4977,6 +5374,7 @@
  - name: pagella-otf
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -4985,6 +5383,7 @@
  - name: pageslts
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -4993,6 +5392,7 @@
  - name: paracol
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5001,6 +5401,7 @@
  - name: paralist
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5009,6 +5410,7 @@
  - name: parallel
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5017,6 +5419,7 @@
  - name: parcolumns
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5025,6 +5428,7 @@
  - name: parnotes
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5033,6 +5437,7 @@
  - name: parskip
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5041,6 +5446,7 @@
  - name: pbalance
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5049,6 +5455,7 @@
  - name: pdfcol
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5057,6 +5464,7 @@
  - name: pdfcolfoot
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5065,6 +5473,7 @@
  - name: pdfcolparallel
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5073,6 +5482,7 @@
  - name: pdfcolparcolumns
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5081,6 +5491,7 @@
  - name: pdfcomment
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5089,6 +5500,7 @@
  - name: pdfescape
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5097,6 +5509,7 @@
  - name: pdfmarginpar
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5105,6 +5518,7 @@
  - name: pdfmsym
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5113,6 +5527,7 @@
  - name: pdfoverlay
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5121,6 +5536,7 @@
  - name: pdfrender
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5146,6 +5562,7 @@
  - name: perltex
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5154,6 +5571,7 @@
  - name: perpage
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5162,6 +5580,7 @@
  - name: pfnote
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5170,6 +5589,7 @@
  - name: pgfmorepages
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5179,6 +5599,7 @@
    ctan-pkg: pgf
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5203,6 +5624,7 @@
  - name: phonenumbers
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5211,6 +5633,7 @@
  - name: piano
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5219,6 +5642,7 @@
  - name: picins
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5227,6 +5651,7 @@
  - name: picture
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5235,6 +5660,7 @@
  - name: pifont
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5243,6 +5669,7 @@
  - name: piton
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5251,6 +5678,7 @@
  - name: placeins
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5260,6 +5688,7 @@
    ctan-pkg: plex
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5269,6 +5698,7 @@
    ctan-pkg: plex
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5278,6 +5708,7 @@
    ctan-pkg: plex
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5286,6 +5717,7 @@
  - name: pmboxdraw
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5294,6 +5726,7 @@
  - name: polyglossia
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5302,6 +5735,7 @@
  - name: postnotes
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5310,6 +5744,7 @@
  - name: prelim2e
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5318,6 +5753,7 @@
  - name: preview
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5326,6 +5762,7 @@
  - name: prftree
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5334,6 +5771,7 @@
  - name: prooftrees
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5342,6 +5780,7 @@
  - name: psfrag
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5350,6 +5789,7 @@
  - name: pst-pdf
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5358,6 +5798,7 @@
  - name: pst2pdf
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5375,6 +5816,7 @@
  - name: pxpic
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5383,6 +5825,7 @@
  - name: pyluatex
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5391,6 +5834,7 @@
  - name: pythontex
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5401,6 +5845,7 @@
  - name: qrcode
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5409,6 +5854,7 @@
  - name: quattrocento
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5417,6 +5863,7 @@
  - name: quotchap
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5434,6 +5881,7 @@
  - name: ragged2e
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -5449,6 +5897,7 @@
  - name: realboxes
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5457,6 +5906,7 @@
  - name: realscripts
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -5465,6 +5915,7 @@
  - name: refcheck
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -5473,6 +5924,7 @@
  - name: refcount
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5481,6 +5933,7 @@
  - name: refstyle
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5489,6 +5942,7 @@
  - name: regexpatch
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5497,6 +5951,7 @@
  - name: reledmac
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -5505,6 +5960,7 @@
  - name: reledpar
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5513,6 +5969,7 @@
  - name: relsize
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -5521,6 +5978,7 @@
  - name: repeatindex
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -5529,6 +5987,7 @@
  - name: repltext
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5537,6 +5996,7 @@
  - name: rerunfilecheck
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5545,6 +6005,7 @@
  - name: resizegather
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -5553,6 +6014,7 @@
  - name: returntogrid
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5583,6 +6045,7 @@
  - name: rotchiffre
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5591,6 +6054,7 @@
  - name: rotfloat
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -5599,6 +6063,7 @@
  - name: rotpages
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5609,6 +6074,7 @@
  - name: sansmath
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5617,6 +6083,7 @@
  - name: savetrees
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -5625,6 +6092,7 @@
  - name: scalefnt
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -5633,6 +6101,7 @@
  - name: scalerel
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5641,6 +6110,7 @@
  - name: schola-otf
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5649,6 +6119,7 @@
  - name: scholax
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5657,6 +6128,7 @@
  - name: scontents
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5665,6 +6137,7 @@
  - name: scrextend
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5673,6 +6146,7 @@
  - name: scrlayer
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5681,6 +6155,7 @@
  - name: scrlayer-fancyhdr
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5689,6 +6164,7 @@
  - name: scrlayer-notecolumn
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5697,12 +6173,14 @@
  - name: scrletter
    type: package
    status: unknown
+   priority: 9
    related-issues: [88]
    updated: 2024-07-10
 
  - name: scrlayer-scrpage
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -5711,6 +6189,7 @@
  - name: secdot
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5719,6 +6198,7 @@
  - name: sectionbreak
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5727,6 +6207,7 @@
  - name: sectsty
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5735,6 +6216,7 @@
  - name: selectp
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5743,6 +6225,7 @@
  - name: selinput
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5751,6 +6234,7 @@
  - name: selnolig
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5759,6 +6243,7 @@
  - name: sepfootnotes
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5767,6 +6252,7 @@
  - name: setouterhbox
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5775,6 +6261,7 @@
  - name: setspace
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -5783,6 +6270,7 @@
  - name: settobox
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5799,6 +6287,7 @@
  - name: shadow
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -5807,6 +6296,7 @@
  - name: shapepar
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5828,6 +6318,7 @@
  - name: showexpl
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5836,6 +6327,7 @@
  - name: showframe
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5844,6 +6336,7 @@
  - name: showhyphenation
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -5869,6 +6362,7 @@
  - name: showtags
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -5877,6 +6371,7 @@
  - name: sidecap
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -5893,6 +6388,7 @@
  - name: simpleicons
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5901,6 +6397,7 @@
  - name: siunitx
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -5909,6 +6406,7 @@
  - name: slashed
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5917,6 +6415,7 @@
  - name: snapshot
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -5925,6 +6424,7 @@
  - name: snotez
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -5933,6 +6433,7 @@
  - name: soul
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -5941,6 +6442,7 @@
  - name: soulpos
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5949,6 +6451,7 @@
  - name: soulutf8
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -5978,6 +6481,7 @@
  - name: spark-otf
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5986,6 +6490,7 @@
  - name: spectral
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -5995,6 +6500,7 @@
    ctan-pkg: splitindex
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -6011,6 +6517,7 @@
  - name: spverbatim
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -6019,6 +6526,7 @@
  - name: stackengine
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -6027,6 +6535,7 @@
  - name: stackrel
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -6035,6 +6544,7 @@
  - name: stampinclude
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -6043,6 +6553,7 @@
  - name: standardsectioning
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -6051,6 +6562,7 @@
  - name: steinmetz
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -6059,6 +6571,7 @@
  - name: stfloats
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -6090,6 +6603,7 @@
  - name: storebox
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -6098,6 +6612,7 @@
  - name: stringenc
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -6119,6 +6634,7 @@
  - name: subdepth
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -6127,6 +6643,7 @@
  - name: subeqn
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -6135,6 +6652,7 @@
  - name: subfig
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -6143,6 +6661,7 @@
  - name: subfiles
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -6151,6 +6670,7 @@
  - name: superiors
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -6159,6 +6679,7 @@
  - name: supertabular
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -6167,6 +6688,7 @@
  - name: svg
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -6175,6 +6697,7 @@
  - name: svn-multi
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -6183,6 +6706,7 @@
  - name: systeme
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -6200,6 +6724,7 @@
  - name: TheanoModern
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -6208,6 +6733,7 @@
  - name: TheanoOldStyle
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -6224,6 +6750,7 @@
  - name: tableof
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -6232,6 +6759,7 @@
  - name: tabls
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -6240,6 +6768,7 @@
  - name: tabto
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -6296,6 +6825,7 @@
  - name: tagging
    type: package
    status: unknown
+   priority: 2
    comments: This package allows conditional typesetting, i.e., tagging here means that the LaTeX source has labeled regions that you can include or exclude.
    issues:
    tests: false
@@ -6305,6 +6835,7 @@
  - name: tasks
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -6321,6 +6852,7 @@
  - name: telprint
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -6336,6 +6868,7 @@
  - name: tensind
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -6344,6 +6877,7 @@
  - name: tensor
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -6352,6 +6886,7 @@
  - name: termes-otf
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -6360,6 +6895,7 @@
  - name: tex-locale
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -6368,6 +6904,7 @@
  - name: tex4ebook
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -6376,6 +6913,7 @@
  - name: tex4ht
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -6384,6 +6922,7 @@
  - name: texosquery
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -6392,6 +6931,7 @@
  - name: textcase
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -6407,6 +6947,7 @@
  - name: textgreek
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -6415,6 +6956,7 @@
  - name: textpos
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -6494,6 +7036,7 @@
  - name: thepdfnumber
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -6502,6 +7045,7 @@
  - name: thmbox
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -6510,6 +7054,7 @@
  - name: thmtools
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -6518,6 +7063,7 @@
  - name: threeparttable
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -6526,6 +7072,7 @@
  - name: threeparttablex
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -6534,6 +7081,7 @@
  - name: thumbpdf
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -6542,6 +7090,7 @@
  - name: thumbs
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -6562,6 +7111,7 @@
  - name: tikzducks
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -6570,6 +7120,7 @@
  - name: tikzlings
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -6593,6 +7144,7 @@
  - name: tipa
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -6608,6 +7160,7 @@
  - name: titleref
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -6629,6 +7182,7 @@
  - name: titling
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -6637,6 +7191,7 @@
  - name: tocbasic
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -6645,6 +7200,7 @@
  - name: tocbibind
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -6653,6 +7209,7 @@
  - name: tocdata
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -6669,6 +7226,7 @@
  - name: tocstyle
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -6677,6 +7235,7 @@
  - name: tocvsec2
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -6685,6 +7244,7 @@
  - name: todonotes
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -6693,6 +7253,7 @@
  - name: topcapt
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -6701,6 +7262,7 @@
  - name: totalcount
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -6722,6 +7284,7 @@
  - name: tracklang
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -6730,6 +7293,7 @@
  - name: transparent
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -6744,6 +7308,7 @@
  - name: truncate
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -6752,6 +7317,7 @@
  - name: turnthepage
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -6760,6 +7326,7 @@
  - name: twemojis
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -6776,6 +7343,7 @@
  - name: typearea
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -6784,6 +7352,7 @@
  - name: typed-checklist
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -6794,6 +7363,7 @@
  - name: ulem
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -6802,6 +7372,7 @@
  - name: underoverlap
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -6810,6 +7381,7 @@
  - name: underscore
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -6824,6 +7396,7 @@
  - name: unicodefonttable
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -6832,6 +7405,7 @@
  - name: uniquecounter
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -6847,6 +7421,7 @@
  - name: unravel
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -6855,6 +7430,7 @@
  - name: upquote
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -6863,6 +7439,7 @@
  - name: upref
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -6871,6 +7448,7 @@
  - name: uri
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -6886,6 +7464,7 @@
  - name: urlbst
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -6919,6 +7498,7 @@
  - name: verbatim
    type: package
    status: unknown
+   priority: 2
    issues:
    tasks: needs tests
    updated: 2024-07-06
@@ -6926,6 +7506,7 @@
  - name: verbdef
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -6942,6 +7523,7 @@
  - name: version
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -6950,6 +7532,7 @@
  - name: versonotes
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -6958,6 +7541,7 @@
  - name: vertbars
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -6966,6 +7550,7 @@
  - name: vwcol
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -6983,6 +7568,7 @@
  - name: widetable
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -6998,6 +7584,7 @@
  - name: witharrows
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -7006,6 +7593,7 @@
  - name: wordcloud
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -7022,6 +7610,7 @@
  - name: wrapfig2
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -7030,6 +7619,7 @@
  - name: wrapstuff
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -7047,6 +7637,7 @@
  - name: xcite
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -7061,6 +7652,7 @@
  - name: xcoffins
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -7069,6 +7661,7 @@
  - name: xcomment
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -7077,6 +7670,7 @@
  - name: xecjk
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -7085,6 +7679,7 @@
  - name: xetexko
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -7093,6 +7688,7 @@
  - name: xevlna
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -7101,6 +7697,7 @@
  - name: xfakebold
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -7116,6 +7713,7 @@
  - name: xgreek
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -7124,6 +7722,7 @@
  - name: xhfill
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -7132,6 +7731,7 @@
  - name: xint
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -7140,6 +7740,7 @@
  - name: xistercian
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -7148,6 +7749,7 @@
  - name: xkeyval
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -7156,6 +7758,7 @@
  - name: xlop
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -7164,6 +7767,7 @@
  - name: xltabular
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -7179,6 +7783,7 @@
  - name: xpatch
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -7187,6 +7792,7 @@
  - name: xpiano
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -7195,6 +7801,7 @@
  - name: xpinyin
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -7216,6 +7823,7 @@
  - name: xsavebox
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -7224,6 +7832,7 @@
  - name: xsim
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -7239,6 +7848,7 @@
  - name: xstring
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -7254,6 +7864,7 @@
  - name: xurl
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -7263,6 +7874,7 @@
    ctan-pkg: xypic
    type: package
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -7280,6 +7892,7 @@
  - name: yfonts-otf
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -7288,6 +7901,7 @@
  - name: yhmath
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -7298,6 +7912,7 @@
  - name: zhnumber
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -7313,6 +7928,7 @@
  - name: zref
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -7321,6 +7937,7 @@
  - name: zref-check
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -7329,6 +7946,7 @@
  - name: zref-clever
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -7337,6 +7955,7 @@
  - name: zref-vario
    type: package
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -7351,6 +7970,7 @@
  - name: acmart
    type: class
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -7404,6 +8024,7 @@
  - name: combine
    type: class
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -7414,6 +8035,7 @@
  - name: exam
    type: class
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -7424,6 +8046,7 @@
  - name: IEEEtran
    type: class
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -7434,6 +8057,7 @@
  - name: jlreq
    type: class
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -7446,6 +8070,7 @@
  - name: leaflet
    type: class
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -7454,6 +8079,7 @@
  - name: letter
    type: class
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -7463,6 +8089,7 @@
    ctan-pkg: tugboat
    type: class
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -7471,6 +8098,7 @@
  - name: ltxdoc
    type: class
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -7490,6 +8118,7 @@
  - name: novel
    type: class
    status: unknown
+   priority: 2
    issues:
    tests: false
    tasks: needs tests
@@ -7501,6 +8130,7 @@
    ctan-pkg: kotex-oblivoir
    type: class
    status: unknown
+   priority: 9
    issues:
    tests: false
    tasks: needs tests
@@ -7529,6 +8159,7 @@
    ctan-pkg: revtex
    type: class
    status: unknown
+   priority: 9
    issues:
    tasks: needs tests
    updated: 2024-07-17
@@ -7550,6 +8181,7 @@
  - name: scrlttr2
    type: class
    status: unknown
+   priority: 9
    related-issues: [88]
    updated: 2024-07-10
 
@@ -7562,6 +8194,7 @@
  - name: standalone
    type: class
    status: unknown
+   priority: 9
    issues:
    tasks: needs tests
    updated: 2024-07-17

--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -9,7 +9,7 @@
 #  type              required   string          "class" or "package" (may need eg tikz or beamer themes in the end?)
 #  status            required   string          Status of package, see list below.
 #  ctan-pkg          optional   string          Name for ctan.org/pkg/?? link if different to name
-#  priority          optional   integer         Priority of work for unknown entries (omitted from table if > 2)
+#  priority          optional   integer         Priority of work for unknown and incompatible entries (omitted from table if > 4)
 #  comments          optional   markdown-string Free text markdown comments
 #  references        optional   integer-list    List of integers referencing the bibliography in references.yml
 #  issues            optional   integer-list    List of integers referencing primary issues at latex3/tagging-project
@@ -8251,20 +8251,6 @@
    type: class
    status: currently-incompatible
    priority: 2
-   related-issues: [88]
-   updated: 2024-07-10
-
- - name: scrreporta
-   type: class
-   status: currently-incompatible
-   priority: 4
-   related-issues: [88]
-   updated: 2024-07-10
-   
- - name: scrreportb
-   type: class
-   status: currently-incompatible
-   priority: 6
    related-issues: [88]
    updated: 2024-07-10
 

--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -98,7 +98,7 @@
 
  - name: academicons
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -123,7 +123,7 @@
 
  - name: accsupp
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -159,7 +159,7 @@
 
  - name: adjmulticol
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -192,7 +192,7 @@
 
  - name: algorithm2e
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -229,7 +229,7 @@
 
  - name: aliascnt
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -238,7 +238,7 @@
 
  - name: aligned-overset
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -260,7 +260,7 @@
 
  - name: alphalph
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -287,7 +287,7 @@
 
  - name: amscdx
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -368,7 +368,7 @@
 
  - name: andika
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -377,7 +377,7 @@
 
  - name: animate
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -386,7 +386,7 @@
 
  - name: anonchap
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -499,7 +499,7 @@
 
  - name: asymptote
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -508,7 +508,7 @@
 
  - name: atkinson
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -517,7 +517,7 @@
 
  - name: attachfile2
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -553,7 +553,7 @@
 
  - name: auto-pst-pdf
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -562,7 +562,7 @@
 
  - name: auto-pst-pdf-lua
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -571,7 +571,7 @@
 
  - name: autoaligne
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -597,7 +597,7 @@
 
  - name: axodraw2
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -634,7 +634,7 @@
 
  - name: backref
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -643,7 +643,7 @@
 
  - name: balance
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -659,7 +659,7 @@
 
  - name: bbding
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -675,7 +675,7 @@
 
  - name: bclogo
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -793,7 +793,7 @@
 
  - name: bicaption
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -828,7 +828,7 @@
 
  - name: bigintcalc
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -854,7 +854,7 @@
 
  - name: bitset
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -885,7 +885,7 @@
 
  - name: bmpsize
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -903,7 +903,7 @@
 
  - name: booklet
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -956,7 +956,7 @@
 
  - name: breakurl
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -973,7 +973,7 @@
 
  - name: bussproofs
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -991,7 +991,7 @@
 
  - name: bytefield
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -1068,7 +1068,7 @@
 
  - name: cancel
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -1077,7 +1077,7 @@
 
  - name: capt-of
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -1086,7 +1086,7 @@
 
  - name: captdef
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -1113,7 +1113,7 @@
 
  - name: carlito
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -1131,7 +1131,7 @@
 
  - name: catchfile
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -1140,7 +1140,7 @@
 
  - name: ccaption
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -1156,7 +1156,7 @@
 
  - name: ccicons
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -1173,7 +1173,7 @@
 
  - name: centernot
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -1182,7 +1182,7 @@
 
  - name: cfr-lm
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -1209,7 +1209,7 @@
 
  - name: changepage
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -1254,7 +1254,7 @@
 
  - name: chemarr
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -1263,7 +1263,7 @@
 
  - name: chemfig
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -1272,7 +1272,7 @@
 
  - name: chemformula
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -1281,7 +1281,7 @@
 
  - name: chemgreek
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -1290,7 +1290,7 @@
 
  - name: chemmacros
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -1299,7 +1299,7 @@
 
  - name: chemnum
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -1324,7 +1324,7 @@
 
  - name: circledsteps
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -1333,7 +1333,7 @@
 
  - name: circledtext
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -1351,7 +1351,7 @@
 
  - name: cjk-ko
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -1367,7 +1367,7 @@
 
  - name: classlist
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -1385,7 +1385,7 @@
 
  - name: clrstrip
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -1408,7 +1408,7 @@
 
  - name: codehigh
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -1424,7 +1424,7 @@
 
  - name: collcell
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -1433,7 +1433,7 @@
 
  - name: collectbox
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -1483,7 +1483,7 @@
 
  - name: concmath-otf
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -1501,7 +1501,7 @@
 
  - name: contour
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -1510,7 +1510,7 @@
 
  - name: countriesofeurope
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -1519,7 +1519,7 @@
 
  - name: cooperhewitt
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -1536,7 +1536,7 @@
 
  - name: covington
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -1545,7 +1545,7 @@
 
  - name: cprotect
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -1580,7 +1580,7 @@
 
  - name: ctable
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -1596,7 +1596,7 @@
 
  - name: currfile
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -1605,7 +1605,7 @@
 
  - name: curve2e
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -1614,7 +1614,7 @@
 
  - name: cuted
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -1623,7 +1623,7 @@
 
  - name: cutwin
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -1681,7 +1681,7 @@
 
  - name: DSSerif
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -1725,7 +1725,7 @@
 
  - name: dblfnote
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -1742,7 +1742,7 @@
 
  - name: decorule
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -1774,7 +1774,7 @@
 
  - name: derivative
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -1801,7 +1801,7 @@
 
  - name: dingbat
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -1816,7 +1816,7 @@
 
  - name: doclicense
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -1834,7 +1834,7 @@
 
  - name: doi
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -1902,7 +1902,7 @@
 
  - name: ETbb
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -1911,7 +1911,7 @@
 
  - name: easyfig
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -1920,7 +1920,7 @@
 
  - name: easylist
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -1936,7 +1936,7 @@
 
  - name: ebproof
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -1963,7 +1963,7 @@
 
  - name: eforms
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -1972,7 +1972,7 @@
 
  - name: ekdosis
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -1990,7 +1990,7 @@
 
  - name: embedall
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -1999,7 +1999,7 @@
 
  - name: embedfile
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -2017,7 +2017,7 @@
 
  - name: emo
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -2026,7 +2026,7 @@
 
  - name: emoji
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -2060,7 +2060,7 @@
 
  - name: endnotesj
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -2069,7 +2069,7 @@
 
  - name: engord
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -2087,7 +2087,7 @@
 
  - name: enparen
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -2112,7 +2112,7 @@
 
  - name: eolgrab
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -2145,7 +2145,7 @@
 
  - name: epstopdf
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -2154,7 +2154,7 @@
 
  - name: eqparbox
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -2179,7 +2179,7 @@
 
  - name: eso-pic
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -2204,7 +2204,7 @@
 
  - name: etoc
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -2242,7 +2242,7 @@
 
  - name: euler-math
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -2265,7 +2265,7 @@
 
  - name: expex
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -2306,7 +2306,7 @@
  - name: extramarks
    ctan-pkg: fancyhdr
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -2333,7 +2333,7 @@
 
  - name: faktor
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -2381,7 +2381,7 @@
 
  - name: fbox
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -2399,7 +2399,7 @@
 
  - name: fdsymbol
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -2417,7 +2417,7 @@
 
  - name: fibnum
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -2426,7 +2426,7 @@
 
  - name: figcaps
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -2435,7 +2435,7 @@
 
  - name: filecontentsdef
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -2453,7 +2453,7 @@
 
  - name: firamath-otf
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -2462,7 +2462,7 @@
 
  - name: fitbox
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -2471,7 +2471,7 @@
 
  - name: fitch
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -2486,7 +2486,7 @@
 
  - name: fixfoot
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -2527,7 +2527,7 @@
 
  - name: flippdf
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -2552,7 +2552,7 @@
    
  - name: floatflt
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -2561,7 +2561,7 @@
 
  - name: floatrow
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -2570,7 +2570,7 @@
 
  - name: flowfram
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -2586,7 +2586,7 @@
 
  - name: flushend
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -2604,7 +2604,7 @@
 
  - name: fnbreak
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -2613,7 +2613,7 @@
 
  - name: fncychap
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -2622,7 +2622,7 @@
 
  - name: fncylab
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -2631,7 +2631,7 @@
 
  - name: fnlineno
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -2649,7 +2649,7 @@
 
  - name: fnpos
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -2658,7 +2658,7 @@
 
  - name: fnumprint
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -2687,7 +2687,7 @@
 
  - name: fontsetup
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -2702,7 +2702,7 @@
 
  - name: fonttable
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -2727,7 +2727,7 @@
 
  - name: footnotebackref
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -2736,7 +2736,7 @@
 
  - name: footnotehyper
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -2754,7 +2754,7 @@
 
  - name: footnpag
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -2763,7 +2763,7 @@
 
  - name: forest
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -2772,7 +2772,7 @@
 
  - name: forum
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -2798,7 +2798,7 @@
  - name: fourier-otf
    ctan-pkg: erewhon-math
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -2807,7 +2807,7 @@
 
  - name: fouriernc
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -2816,7 +2816,7 @@
 
  - name: framed
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -2844,7 +2844,7 @@
 
  - name: froufrou
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -2918,7 +2918,7 @@
 
  - name: gb4e
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -2927,7 +2927,7 @@
 
  - name: gelasio
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -2936,7 +2936,7 @@
 
  - name: gelasiomath
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -2945,7 +2945,7 @@
 
  - name: gensymb
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -2961,7 +2961,7 @@
 
  - name: gentombow
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -2977,7 +2977,7 @@
 
  - name: gettitlestring
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -3058,7 +3058,7 @@
 
  - name: ghsystem
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -3082,7 +3082,7 @@
 
  - name: gincltex
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -3091,7 +3091,7 @@
 
  - name: gindex
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -3100,7 +3100,7 @@
 
  - name: gitinfo-lua
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -3125,7 +3125,7 @@
 
  - name: grabbox
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -3163,7 +3163,7 @@
 
  - name: grfext
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -3172,7 +3172,7 @@
 
  - name: gridset
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -3193,7 +3193,7 @@
 
  - name: hanging
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -3228,7 +3228,7 @@
 
  - name: heros-otf
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -3264,7 +3264,7 @@
 
  - name: hologo
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -3282,7 +3282,7 @@
 
  - name: hvindex
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -3291,7 +3291,7 @@
 
  - name: hvlogos
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -3300,7 +3300,7 @@
 
  - name: hypbmsec
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -3309,7 +3309,7 @@
 
  - name: hypcap
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -3318,7 +3318,7 @@
 
  - name: hypdestopt
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -3327,7 +3327,7 @@
 
  - name: hypdoc
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -3336,7 +3336,7 @@
 
  - name: hypdvips
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -3345,7 +3345,7 @@
 
  - name: hyperbar
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -3369,7 +3369,7 @@
 
  - name: hypgotoe
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -3378,7 +3378,7 @@
 
  - name: hyphenat
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -3387,7 +3387,7 @@
 
  - name: hyphsubst
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -3414,7 +3414,7 @@
 
  - name: ibarra
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -3430,7 +3430,7 @@
 
  - name: ifdraft
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -3455,7 +3455,7 @@
 
  - name: ifoddpage
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -3464,7 +3464,7 @@
 
  - name: ifplatform
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -3514,7 +3514,7 @@
 
  - name: import
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -3523,7 +3523,7 @@
 
  - name: incgraph
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -3569,7 +3569,7 @@
 
  - name: intcalc
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -3587,7 +3587,7 @@
 
  - name: intopdf
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -3603,7 +3603,7 @@
 
  - name: iwonamath
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -3623,7 +3623,7 @@
 
  - name: josefin
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -3632,7 +3632,7 @@
 
  - name: junicode
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -3641,7 +3641,7 @@
 
  - name: junicodevf
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -3662,7 +3662,7 @@
 
  - name: kanbun
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -3687,7 +3687,7 @@
 
  - name: keystroke
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -3773,7 +3773,7 @@
  - name: LobsterTwo
    ctan-pkg: lobster2
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -3789,7 +3789,7 @@
 
  - name: labelschanged
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -3804,7 +3804,7 @@
 
  - name: latex2pydata
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -3851,7 +3851,7 @@
 
  - name: leftidx
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -3860,7 +3860,7 @@
 
  - name: leftindex
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -3869,7 +3869,7 @@
 
  - name: lete-sans-math
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -3879,7 +3879,7 @@
  - name: letterspace
    ctan-pkg: microtype
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -3888,7 +3888,7 @@
 
  - name: letterswitharrows
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -3920,7 +3920,7 @@
 
  - name: libertinus-otf
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -3929,7 +3929,7 @@
 
  - name: libertinust1math
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -3959,7 +3959,7 @@
 
  - name: linebreaker
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -3977,7 +3977,7 @@
 
  - name: linguex
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -4010,7 +4010,7 @@
 
  - name: listliketab
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -4019,7 +4019,7 @@
 
  - name: listofitems
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -4043,7 +4043,7 @@
 
  - name: logix
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -4052,7 +4052,7 @@
 
  - name: longdivision
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -4070,7 +4070,7 @@
 
  - name: lpic
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -4105,7 +4105,7 @@
 
  - name: ltxgrid
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -4132,7 +4132,7 @@
 
  - name: lua-typo
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -4150,7 +4150,7 @@
 
  - name: lua-widow-control
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -4159,7 +4159,7 @@
 
  - name: luacode
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -4168,7 +4168,7 @@
 
  - name: lualatex-math
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -4177,7 +4177,7 @@
 
  - name: luamathalign
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -4186,7 +4186,7 @@
 
  - name: luamesh
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -4218,7 +4218,7 @@
 
  - name: luatexko
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -4227,7 +4227,7 @@
 
  - name: luatodonotes
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -4236,7 +4236,7 @@
 
  - name: luavlna
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -4245,7 +4245,7 @@
 
  - name: lucida-otf
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -4277,7 +4277,7 @@
 
  - name: lyluatex
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -4288,7 +4288,7 @@
 
  - name: MnSymbol
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -4306,7 +4306,7 @@
 
  - name: magicnum
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -4346,7 +4346,7 @@
 
  - name: markdown
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -4362,7 +4362,7 @@
 
  - name: mathabx
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -4380,7 +4380,7 @@
 
  - name: mathastext
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -4389,7 +4389,7 @@
 
  - name: mathdesign
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -4463,7 +4463,7 @@
 
  - name: mcaption
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -4497,7 +4497,7 @@
 
  - name: mdsymbol
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -4506,7 +4506,7 @@
 
  - name: media9
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -4515,7 +4515,7 @@
 
  - name: memoize
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -4524,7 +4524,7 @@
 
  - name: mercatormap
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -4533,7 +4533,7 @@
 
  - name: menukeys
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -4549,7 +4549,7 @@
 
  - name: metalogo
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -4558,7 +4558,7 @@
 
  - name: metalogox
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -4567,7 +4567,7 @@
 
  - name: mfirstuc
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -4576,7 +4576,7 @@
 
  - name: mhchem
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -4599,7 +4599,7 @@
 
  - name: midpage
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -4608,7 +4608,7 @@
 
  - name: minibox
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -4617,7 +4617,7 @@
 
  - name: minitoc
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -4731,7 +4731,7 @@
 
  - name: multido
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -4740,7 +4740,7 @@
 
  - name: multiexpand
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -4750,7 +4750,7 @@
  - name: multimedia
    ctan-pkg: beamer
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -4777,7 +4777,7 @@
 
  - name: musixtex
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -4786,7 +4786,7 @@
 
  - name: mwe
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -4804,7 +4804,7 @@
 
  - name: nameauth
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -4852,7 +4852,7 @@
 
  - name: navigator
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -4897,7 +4897,7 @@
 
  - name: newcomputermodern
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -4915,7 +4915,7 @@
 
  - name: newproof
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -4978,7 +4978,7 @@
 
  - name: newtxsf
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -4987,7 +4987,7 @@
 
  - name: newtxtt
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -4996,7 +4996,7 @@
 
  - name: newunicodechar
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -5021,7 +5021,7 @@
 
  - name: nidanfloat
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -5038,7 +5038,7 @@
 
  - name: nomencl
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -5127,7 +5127,7 @@
 
  - name: nth
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -5144,7 +5144,7 @@
 
  - name: numerica
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -5153,7 +5153,7 @@
 
  - name: numerica-plus
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -5162,7 +5162,7 @@
 
  - name: numerica-tables
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -5171,7 +5171,7 @@
 
  - name: numspell
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -5197,7 +5197,7 @@
 
  - name: odsfile
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -5230,7 +5230,7 @@
 
  - name: orcidlink
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -5272,7 +5272,7 @@
 
  - name: PoiretOne
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -5337,7 +5337,7 @@
 
  - name: pagecolor
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -5346,7 +5346,7 @@
 
  - name: pagegrid
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -5355,7 +5355,7 @@
 
  - name: pagenote
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -5364,7 +5364,7 @@
 
  - name: pagesel
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -5373,7 +5373,7 @@
 
  - name: pagella-otf
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -5382,7 +5382,7 @@
 
  - name: pageslts
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -5391,7 +5391,7 @@
 
  - name: paracol
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -5400,7 +5400,7 @@
 
  - name: paralist
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -5409,7 +5409,7 @@
 
  - name: parallel
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -5418,7 +5418,7 @@
 
  - name: parcolumns
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -5427,7 +5427,7 @@
 
  - name: parnotes
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -5436,7 +5436,7 @@
 
  - name: parskip
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -5445,7 +5445,7 @@
 
  - name: pbalance
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -5454,7 +5454,7 @@
 
  - name: pdfcol
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -5463,7 +5463,7 @@
 
  - name: pdfcolfoot
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -5472,7 +5472,7 @@
 
  - name: pdfcolparallel
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -5481,7 +5481,7 @@
 
  - name: pdfcolparcolumns
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -5490,7 +5490,7 @@
 
  - name: pdfcomment
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -5499,7 +5499,7 @@
 
  - name: pdfescape
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -5508,7 +5508,7 @@
 
  - name: pdfmarginpar
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -5517,7 +5517,7 @@
 
  - name: pdfmsym
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -5526,7 +5526,7 @@
 
  - name: pdfoverlay
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -5535,7 +5535,7 @@
 
  - name: pdfrender
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -5561,7 +5561,7 @@
 
  - name: perltex
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -5570,7 +5570,7 @@
 
  - name: perpage
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -5579,7 +5579,7 @@
 
  - name: pfnote
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -5588,7 +5588,7 @@
 
  - name: pgfmorepages
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -5598,7 +5598,7 @@
  - name: pgfpages
    ctan-pkg: pgf
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -5623,7 +5623,7 @@
 
  - name: phonenumbers
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -5632,7 +5632,7 @@
 
  - name: piano
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -5641,7 +5641,7 @@
 
  - name: picins
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -5650,7 +5650,7 @@
 
  - name: picture
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -5659,7 +5659,7 @@
 
  - name: pifont
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -5668,7 +5668,7 @@
 
  - name: piton
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -5677,7 +5677,7 @@
 
  - name: placeins
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -5687,7 +5687,7 @@
  - name: plex-mono
    ctan-pkg: plex
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -5697,7 +5697,7 @@
  - name: plex-sans
    ctan-pkg: plex
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -5707,7 +5707,7 @@
  - name: plex-serif
    ctan-pkg: plex
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -5716,7 +5716,7 @@
 
  - name: pmboxdraw
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -5725,7 +5725,7 @@
 
  - name: polyglossia
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -5734,7 +5734,7 @@
 
  - name: postnotes
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -5743,7 +5743,7 @@
 
  - name: prelim2e
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -5752,7 +5752,7 @@
 
  - name: preview
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -5761,7 +5761,7 @@
 
  - name: prftree
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -5770,7 +5770,7 @@
 
  - name: prooftrees
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -5779,7 +5779,7 @@
 
  - name: psfrag
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -5788,7 +5788,7 @@
 
  - name: pst-pdf
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -5797,7 +5797,7 @@
 
  - name: pst2pdf
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -5815,7 +5815,7 @@
 
  - name: pxpic
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -5824,7 +5824,7 @@
 
  - name: pyluatex
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -5833,7 +5833,7 @@
 
  - name: pythontex
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -5844,7 +5844,7 @@
 
  - name: qrcode
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -5853,7 +5853,7 @@
 
  - name: quattrocento
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -5862,7 +5862,7 @@
 
  - name: quotchap
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -5896,7 +5896,7 @@
 
  - name: realboxes
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -5923,7 +5923,7 @@
 
  - name: refcount
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -5932,7 +5932,7 @@
 
  - name: refstyle
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -5941,7 +5941,7 @@
 
  - name: regexpatch
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -5959,7 +5959,7 @@
 
  - name: reledpar
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -5986,7 +5986,7 @@
 
  - name: repltext
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -5995,7 +5995,7 @@
 
  - name: rerunfilecheck
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -6013,7 +6013,7 @@
 
  - name: returntogrid
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -6044,7 +6044,7 @@
 
  - name: rotchiffre
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -6062,7 +6062,7 @@
 
  - name: rotpages
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -6073,7 +6073,7 @@
 
  - name: sansmath
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -6100,7 +6100,7 @@
 
  - name: scalerel
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -6109,7 +6109,7 @@
 
  - name: schola-otf
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -6118,7 +6118,7 @@
 
  - name: scholax
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -6127,7 +6127,7 @@
 
  - name: scontents
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -6136,7 +6136,7 @@
 
  - name: scrextend
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -6145,7 +6145,7 @@
 
  - name: scrlayer
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -6154,7 +6154,7 @@
 
  - name: scrlayer-fancyhdr
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -6163,7 +6163,7 @@
 
  - name: scrlayer-notecolumn
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -6172,7 +6172,7 @@
 
  - name: scrletter
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    related-issues: [88]
    updated: 2024-07-10
@@ -6188,7 +6188,7 @@
 
  - name: secdot
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -6197,7 +6197,7 @@
 
  - name: sectionbreak
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -6206,7 +6206,7 @@
 
  - name: sectsty
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -6215,7 +6215,7 @@
 
  - name: selectp
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -6224,7 +6224,7 @@
 
  - name: selinput
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -6233,7 +6233,7 @@
 
  - name: selnolig
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -6242,7 +6242,7 @@
 
  - name: sepfootnotes
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -6251,7 +6251,7 @@
 
  - name: setouterhbox
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -6269,7 +6269,7 @@
 
  - name: settobox
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -6295,7 +6295,7 @@
 
  - name: shapepar
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -6317,7 +6317,7 @@
 
  - name: showexpl
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -6326,7 +6326,7 @@
 
  - name: showframe
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -6387,7 +6387,7 @@
 
  - name: simpleicons
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -6405,7 +6405,7 @@
 
  - name: slashed
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -6441,7 +6441,7 @@
 
  - name: soulpos
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -6480,7 +6480,7 @@
 
  - name: spark-otf
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -6489,7 +6489,7 @@
 
  - name: spectral
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -6499,7 +6499,7 @@
  - name: splitidx
    ctan-pkg: splitindex
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -6525,7 +6525,7 @@
 
  - name: stackengine
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -6534,7 +6534,7 @@
 
  - name: stackrel
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -6543,7 +6543,7 @@
 
  - name: stampinclude
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -6552,7 +6552,7 @@
 
  - name: standardsectioning
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -6561,7 +6561,7 @@
 
  - name: steinmetz
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -6602,7 +6602,7 @@
 
  - name: storebox
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -6611,7 +6611,7 @@
 
  - name: stringenc
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -6642,7 +6642,7 @@
 
  - name: subeqn
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -6660,7 +6660,7 @@
 
  - name: subfiles
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -6669,7 +6669,7 @@
 
  - name: superiors
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -6687,7 +6687,7 @@
 
  - name: svg
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -6705,7 +6705,7 @@
 
  - name: systeme
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -6723,7 +6723,7 @@
 
  - name: TheanoModern
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -6732,7 +6732,7 @@
 
  - name: TheanoOldStyle
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -6749,7 +6749,7 @@
 
  - name: tableof
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -6851,7 +6851,7 @@
 
  - name: telprint
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -6867,7 +6867,7 @@
 
  - name: tensind
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -6876,7 +6876,7 @@
 
  - name: tensor
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -6885,7 +6885,7 @@
 
  - name: termes-otf
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -6894,7 +6894,7 @@
 
  - name: tex-locale
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -6903,7 +6903,7 @@
 
  - name: tex4ebook
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -6921,7 +6921,7 @@
 
  - name: texosquery
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -6946,7 +6946,7 @@
 
  - name: textgreek
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -6955,7 +6955,7 @@
 
  - name: textpos
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -7035,7 +7035,7 @@
 
  - name: thepdfnumber
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -7080,7 +7080,7 @@
 
  - name: thumbpdf
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -7089,7 +7089,7 @@
 
  - name: thumbs
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -7159,7 +7159,7 @@
 
  - name: titleref
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -7190,7 +7190,7 @@
 
  - name: tocbasic
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -7252,7 +7252,7 @@
 
  - name: topcapt
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -7261,7 +7261,7 @@
 
  - name: totalcount
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -7283,7 +7283,7 @@
 
  - name: tracklang
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -7292,7 +7292,7 @@
 
  - name: transparent
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -7325,7 +7325,7 @@
 
  - name: twemojis
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -7404,7 +7404,7 @@
 
  - name: uniquecounter
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -7420,7 +7420,7 @@
 
  - name: unravel
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -7505,7 +7505,7 @@
 
  - name: verbdef
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -7531,7 +7531,7 @@
 
  - name: versonotes
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -7549,7 +7549,7 @@
 
  - name: vwcol
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -7583,7 +7583,7 @@
 
  - name: witharrows
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -7592,7 +7592,7 @@
 
  - name: wordcloud
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -7609,7 +7609,7 @@
 
  - name: wrapfig2
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -7618,7 +7618,7 @@
 
  - name: wrapstuff
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -7651,7 +7651,7 @@
 
  - name: xcoffins
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -7669,7 +7669,7 @@
 
  - name: xecjk
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -7678,7 +7678,7 @@
 
  - name: xetexko
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -7687,7 +7687,7 @@
 
  - name: xevlna
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -7696,7 +7696,7 @@
 
  - name: xfakebold
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -7721,7 +7721,7 @@
 
  - name: xhfill
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -7730,7 +7730,7 @@
 
  - name: xint
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -7739,7 +7739,7 @@
 
  - name: xistercian
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -7748,7 +7748,7 @@
 
  - name: xkeyval
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -7757,7 +7757,7 @@
 
  - name: xlop
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -7782,7 +7782,7 @@
 
  - name: xpatch
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -7791,7 +7791,7 @@
 
  - name: xpiano
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -7800,7 +7800,7 @@
 
  - name: xpinyin
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -7822,7 +7822,7 @@
 
  - name: xsavebox
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -7831,7 +7831,7 @@
 
  - name: xsim
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -7847,7 +7847,7 @@
 
  - name: xstring
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -7863,7 +7863,7 @@
 
  - name: xurl
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -7891,7 +7891,7 @@
 
  - name: yfonts-otf
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -7900,7 +7900,7 @@
 
  - name: yhmath
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -7911,7 +7911,7 @@
 
  - name: zhnumber
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -7927,7 +7927,7 @@
 
  - name: zref
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -7936,7 +7936,7 @@
 
  - name: zref-check
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -7945,7 +7945,7 @@
 
  - name: zref-clever
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -7954,7 +7954,7 @@
 
  - name: zref-vario
    type: package
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -7969,7 +7969,7 @@
 
  - name: acmart
    type: class
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -8023,7 +8023,7 @@
 
  - name: combine
    type: class
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -8034,7 +8034,7 @@
 
  - name: exam
    type: class
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -8045,7 +8045,7 @@
 
  - name: IEEEtran
    type: class
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -8056,7 +8056,7 @@
 
  - name: jlreq
    type: class
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -8088,7 +8088,7 @@
  - name: ltugboat
    ctan-pkg: tugboat
    type: class
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -8097,7 +8097,7 @@
 
  - name: ltxdoc
    type: class
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -8129,7 +8129,7 @@
  - name: oblivoir
    ctan-pkg: kotex-oblivoir
    type: class
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tests: false
@@ -8158,7 +8158,7 @@
  - name: revtex4-2
    ctan-pkg: revtex
    type: class
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tasks: needs tests
@@ -8180,7 +8180,7 @@
 
  - name: scrlttr2
    type: class
-   status: unknown
+   status: unlisted
    priority: 9
    related-issues: [88]
    updated: 2024-07-10
@@ -8193,7 +8193,7 @@
 
  - name: standalone
    type: class
-   status: unknown
+   status: unlisted
    priority: 9
    issues:
    tasks: needs tests

--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -159,7 +159,7 @@
 
  - name: adjmulticol
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -192,7 +192,7 @@
 
  - name: algorithm2e
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -229,7 +229,7 @@
 
  - name: aliascnt
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -238,7 +238,7 @@
 
  - name: aligned-overset
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -260,7 +260,7 @@
 
  - name: alphalph
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -287,7 +287,7 @@
 
  - name: amscdx
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -368,7 +368,7 @@
 
  - name: andika
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -377,7 +377,7 @@
 
  - name: animate
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -386,7 +386,7 @@
 
  - name: anonchap
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -499,7 +499,7 @@
 
  - name: asymptote
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -508,7 +508,7 @@
 
  - name: atkinson
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -517,7 +517,7 @@
 
  - name: attachfile2
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -553,7 +553,7 @@
 
  - name: auto-pst-pdf
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -562,7 +562,7 @@
 
  - name: auto-pst-pdf-lua
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -571,7 +571,7 @@
 
  - name: autoaligne
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -597,7 +597,7 @@
 
  - name: axodraw2
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -634,7 +634,7 @@
 
  - name: backref
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -643,7 +643,7 @@
 
  - name: balance
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -659,7 +659,7 @@
 
  - name: bbding
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -675,7 +675,7 @@
 
  - name: bclogo
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -793,7 +793,7 @@
 
  - name: bicaption
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -828,7 +828,7 @@
 
  - name: bigintcalc
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -854,7 +854,7 @@
 
  - name: bitset
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -885,7 +885,7 @@
 
  - name: bmpsize
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -903,7 +903,7 @@
 
  - name: booklet
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -956,7 +956,7 @@
 
  - name: breakurl
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -973,7 +973,7 @@
 
  - name: bussproofs
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -991,7 +991,7 @@
 
  - name: bytefield
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -1068,7 +1068,7 @@
 
  - name: cancel
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -1077,7 +1077,7 @@
 
  - name: capt-of
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -1086,7 +1086,7 @@
 
  - name: captdef
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -1113,7 +1113,7 @@
 
  - name: carlito
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -1131,7 +1131,7 @@
 
  - name: catchfile
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -1140,7 +1140,7 @@
 
  - name: ccaption
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -1156,7 +1156,7 @@
 
  - name: ccicons
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -1173,7 +1173,7 @@
 
  - name: centernot
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -1182,7 +1182,7 @@
 
  - name: cfr-lm
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -1209,7 +1209,7 @@
 
  - name: changepage
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -1254,7 +1254,7 @@
 
  - name: chemarr
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -1263,7 +1263,7 @@
 
  - name: chemfig
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -1272,7 +1272,7 @@
 
  - name: chemformula
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -1281,7 +1281,7 @@
 
  - name: chemgreek
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -1290,7 +1290,7 @@
 
  - name: chemmacros
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -1299,7 +1299,7 @@
 
  - name: chemnum
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -1324,7 +1324,7 @@
 
  - name: circledsteps
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -1333,7 +1333,7 @@
 
  - name: circledtext
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -1351,7 +1351,7 @@
 
  - name: cjk-ko
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -1367,7 +1367,7 @@
 
  - name: classlist
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -1385,7 +1385,7 @@
 
  - name: clrstrip
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -1408,7 +1408,7 @@
 
  - name: codehigh
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -1424,7 +1424,7 @@
 
  - name: collcell
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -1433,7 +1433,7 @@
 
  - name: collectbox
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -1483,7 +1483,7 @@
 
  - name: concmath-otf
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -1501,7 +1501,7 @@
 
  - name: contour
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -1510,7 +1510,7 @@
 
  - name: countriesofeurope
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -1519,7 +1519,7 @@
 
  - name: cooperhewitt
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -1536,7 +1536,7 @@
 
  - name: covington
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -1545,7 +1545,7 @@
 
  - name: cprotect
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -1580,7 +1580,7 @@
 
  - name: ctable
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -1596,7 +1596,7 @@
 
  - name: currfile
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -1605,7 +1605,7 @@
 
  - name: curve2e
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -1614,7 +1614,7 @@
 
  - name: cuted
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -1623,7 +1623,7 @@
 
  - name: cutwin
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -1681,7 +1681,7 @@
 
  - name: DSSerif
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -1725,7 +1725,7 @@
 
  - name: dblfnote
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -1742,7 +1742,7 @@
 
  - name: decorule
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -1774,7 +1774,7 @@
 
  - name: derivative
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -1801,7 +1801,7 @@
 
  - name: dingbat
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -1816,7 +1816,7 @@
 
  - name: doclicense
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -1834,7 +1834,7 @@
 
  - name: doi
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -1902,7 +1902,7 @@
 
  - name: ETbb
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -1911,7 +1911,7 @@
 
  - name: easyfig
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -1920,7 +1920,7 @@
 
  - name: easylist
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -1936,7 +1936,7 @@
 
  - name: ebproof
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -1963,7 +1963,7 @@
 
  - name: eforms
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -1972,7 +1972,7 @@
 
  - name: ekdosis
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -1990,7 +1990,7 @@
 
  - name: embedall
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -1999,7 +1999,7 @@
 
  - name: embedfile
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -2017,7 +2017,7 @@
 
  - name: emo
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -2026,7 +2026,7 @@
 
  - name: emoji
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -2060,7 +2060,7 @@
 
  - name: endnotesj
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -2069,7 +2069,7 @@
 
  - name: engord
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -2087,7 +2087,7 @@
 
  - name: enparen
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -2112,7 +2112,7 @@
 
  - name: eolgrab
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -2145,7 +2145,7 @@
 
  - name: epstopdf
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -2154,7 +2154,7 @@
 
  - name: eqparbox
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -2179,7 +2179,7 @@
 
  - name: eso-pic
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -2204,7 +2204,7 @@
 
  - name: etoc
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -2242,7 +2242,7 @@
 
  - name: euler-math
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -2265,7 +2265,7 @@
 
  - name: expex
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -2306,7 +2306,7 @@
  - name: extramarks
    ctan-pkg: fancyhdr
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -2333,7 +2333,7 @@
 
  - name: faktor
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -2381,7 +2381,7 @@
 
  - name: fbox
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -2399,7 +2399,7 @@
 
  - name: fdsymbol
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -2417,7 +2417,7 @@
 
  - name: fibnum
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -2426,7 +2426,7 @@
 
  - name: figcaps
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -2435,7 +2435,7 @@
 
  - name: filecontentsdef
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -2453,7 +2453,7 @@
 
  - name: firamath-otf
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -2462,7 +2462,7 @@
 
  - name: fitbox
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -2471,7 +2471,7 @@
 
  - name: fitch
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -2486,7 +2486,7 @@
 
  - name: fixfoot
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -2527,7 +2527,7 @@
 
  - name: flippdf
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -2552,7 +2552,7 @@
    
  - name: floatflt
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -2561,7 +2561,7 @@
 
  - name: floatrow
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -2570,7 +2570,7 @@
 
  - name: flowfram
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -2586,7 +2586,7 @@
 
  - name: flushend
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -2604,7 +2604,7 @@
 
  - name: fnbreak
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -2613,7 +2613,7 @@
 
  - name: fncychap
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -2622,7 +2622,7 @@
 
  - name: fncylab
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -2631,7 +2631,7 @@
 
  - name: fnlineno
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -2649,7 +2649,7 @@
 
  - name: fnpos
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -2658,7 +2658,7 @@
 
  - name: fnumprint
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -2687,7 +2687,7 @@
 
  - name: fontsetup
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -2702,7 +2702,7 @@
 
  - name: fonttable
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -2727,7 +2727,7 @@
 
  - name: footnotebackref
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -2736,7 +2736,7 @@
 
  - name: footnotehyper
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -2754,7 +2754,7 @@
 
  - name: footnpag
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -2763,7 +2763,7 @@
 
  - name: forest
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -2772,7 +2772,7 @@
 
  - name: forum
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -2798,7 +2798,7 @@
  - name: fourier-otf
    ctan-pkg: erewhon-math
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -2807,7 +2807,7 @@
 
  - name: fouriernc
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -2816,7 +2816,7 @@
 
  - name: framed
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -2844,7 +2844,7 @@
 
  - name: froufrou
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -2918,7 +2918,7 @@
 
  - name: gb4e
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -2927,7 +2927,7 @@
 
  - name: gelasio
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -2936,7 +2936,7 @@
 
  - name: gelasiomath
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -2945,7 +2945,7 @@
 
  - name: gensymb
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -2961,7 +2961,7 @@
 
  - name: gentombow
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -2977,7 +2977,7 @@
 
  - name: gettitlestring
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -3058,7 +3058,7 @@
 
  - name: ghsystem
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -3082,7 +3082,7 @@
 
  - name: gincltex
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -3091,7 +3091,7 @@
 
  - name: gindex
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -3100,7 +3100,7 @@
 
  - name: gitinfo-lua
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -3125,7 +3125,7 @@
 
  - name: grabbox
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -3163,7 +3163,7 @@
 
  - name: grfext
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -3172,7 +3172,7 @@
 
  - name: gridset
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -3193,7 +3193,7 @@
 
  - name: hanging
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -3228,7 +3228,7 @@
 
  - name: heros-otf
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -3264,7 +3264,7 @@
 
  - name: hologo
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -3282,7 +3282,7 @@
 
  - name: hvindex
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -3291,7 +3291,7 @@
 
  - name: hvlogos
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -3300,7 +3300,7 @@
 
  - name: hypbmsec
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -3309,7 +3309,7 @@
 
  - name: hypcap
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -3318,7 +3318,7 @@
 
  - name: hypdestopt
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -3327,7 +3327,7 @@
 
  - name: hypdoc
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -3336,7 +3336,7 @@
 
  - name: hypdvips
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -3345,7 +3345,7 @@
 
  - name: hyperbar
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -3369,7 +3369,7 @@
 
  - name: hypgotoe
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -3378,7 +3378,7 @@
 
  - name: hyphenat
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -3387,7 +3387,7 @@
 
  - name: hyphsubst
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -3414,7 +3414,7 @@
 
  - name: ibarra
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -3430,7 +3430,7 @@
 
  - name: ifdraft
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -3455,7 +3455,7 @@
 
  - name: ifoddpage
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -3464,7 +3464,7 @@
 
  - name: ifplatform
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -3514,7 +3514,7 @@
 
  - name: import
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -3523,7 +3523,7 @@
 
  - name: incgraph
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -3569,7 +3569,7 @@
 
  - name: intcalc
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -3587,7 +3587,7 @@
 
  - name: intopdf
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -3603,7 +3603,7 @@
 
  - name: iwonamath
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -3623,7 +3623,7 @@
 
  - name: josefin
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -3632,7 +3632,7 @@
 
  - name: junicode
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -3641,7 +3641,7 @@
 
  - name: junicodevf
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -3662,7 +3662,7 @@
 
  - name: kanbun
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -3687,7 +3687,7 @@
 
  - name: keystroke
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -3773,7 +3773,7 @@
  - name: LobsterTwo
    ctan-pkg: lobster2
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -3789,7 +3789,7 @@
 
  - name: labelschanged
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -3804,7 +3804,7 @@
 
  - name: latex2pydata
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -3851,7 +3851,7 @@
 
  - name: leftidx
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -3860,7 +3860,7 @@
 
  - name: leftindex
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -3869,7 +3869,7 @@
 
  - name: lete-sans-math
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -3879,7 +3879,7 @@
  - name: letterspace
    ctan-pkg: microtype
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -3888,7 +3888,7 @@
 
  - name: letterswitharrows
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -3920,7 +3920,7 @@
 
  - name: libertinus-otf
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -3929,7 +3929,7 @@
 
  - name: libertinust1math
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -3959,7 +3959,7 @@
 
  - name: linebreaker
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -3977,7 +3977,7 @@
 
  - name: linguex
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -4010,7 +4010,7 @@
 
  - name: listliketab
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -4019,7 +4019,7 @@
 
  - name: listofitems
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -4043,7 +4043,7 @@
 
  - name: logix
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -4052,7 +4052,7 @@
 
  - name: longdivision
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -4070,7 +4070,7 @@
 
  - name: lpic
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -4105,7 +4105,7 @@
 
  - name: ltxgrid
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -4132,7 +4132,7 @@
 
  - name: lua-typo
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -4150,7 +4150,7 @@
 
  - name: lua-widow-control
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -4159,7 +4159,7 @@
 
  - name: luacode
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -4168,7 +4168,7 @@
 
  - name: lualatex-math
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -4177,7 +4177,7 @@
 
  - name: luamathalign
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -4186,7 +4186,7 @@
 
  - name: luamesh
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -4218,7 +4218,7 @@
 
  - name: luatexko
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -4227,7 +4227,7 @@
 
  - name: luatodonotes
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -4236,7 +4236,7 @@
 
  - name: luavlna
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -4245,7 +4245,7 @@
 
  - name: lucida-otf
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -4277,7 +4277,7 @@
 
  - name: lyluatex
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -4288,7 +4288,7 @@
 
  - name: MnSymbol
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -4306,7 +4306,7 @@
 
  - name: magicnum
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -4346,7 +4346,7 @@
 
  - name: markdown
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -4362,7 +4362,7 @@
 
  - name: mathabx
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -4380,7 +4380,7 @@
 
  - name: mathastext
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -4389,7 +4389,7 @@
 
  - name: mathdesign
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -4463,7 +4463,7 @@
 
  - name: mcaption
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -4497,7 +4497,7 @@
 
  - name: mdsymbol
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -4506,7 +4506,7 @@
 
  - name: media9
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -4515,7 +4515,7 @@
 
  - name: memoize
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -4524,7 +4524,7 @@
 
  - name: mercatormap
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -4533,7 +4533,7 @@
 
  - name: menukeys
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -4549,7 +4549,7 @@
 
  - name: metalogo
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -4558,7 +4558,7 @@
 
  - name: metalogox
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -4567,7 +4567,7 @@
 
  - name: mfirstuc
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -4576,7 +4576,7 @@
 
  - name: mhchem
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -4599,7 +4599,7 @@
 
  - name: midpage
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -4608,7 +4608,7 @@
 
  - name: minibox
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -4617,7 +4617,7 @@
 
  - name: minitoc
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -4731,7 +4731,7 @@
 
  - name: multido
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -4740,7 +4740,7 @@
 
  - name: multiexpand
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -4750,7 +4750,7 @@
  - name: multimedia
    ctan-pkg: beamer
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -4777,7 +4777,7 @@
 
  - name: musixtex
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -4786,7 +4786,7 @@
 
  - name: mwe
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -4804,7 +4804,7 @@
 
  - name: nameauth
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -4852,7 +4852,7 @@
 
  - name: navigator
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -4897,7 +4897,7 @@
 
  - name: newcomputermodern
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -4915,7 +4915,7 @@
 
  - name: newproof
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -4978,7 +4978,7 @@
 
  - name: newtxsf
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -4987,7 +4987,7 @@
 
  - name: newtxtt
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -4996,7 +4996,7 @@
 
  - name: newunicodechar
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -5021,7 +5021,7 @@
 
  - name: nidanfloat
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -5038,7 +5038,7 @@
 
  - name: nomencl
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -5127,7 +5127,7 @@
 
  - name: nth
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -5144,7 +5144,7 @@
 
  - name: numerica
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -5153,7 +5153,7 @@
 
  - name: numerica-plus
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -5162,7 +5162,7 @@
 
  - name: numerica-tables
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -5171,7 +5171,7 @@
 
  - name: numspell
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -5197,7 +5197,7 @@
 
  - name: odsfile
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -5230,7 +5230,7 @@
 
  - name: orcidlink
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -5272,7 +5272,7 @@
 
  - name: PoiretOne
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -5337,7 +5337,7 @@
 
  - name: pagecolor
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -5346,7 +5346,7 @@
 
  - name: pagegrid
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -5355,7 +5355,7 @@
 
  - name: pagenote
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -5364,7 +5364,7 @@
 
  - name: pagesel
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -5373,7 +5373,7 @@
 
  - name: pagella-otf
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -5382,7 +5382,7 @@
 
  - name: pageslts
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -5391,7 +5391,7 @@
 
  - name: paracol
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -5400,7 +5400,7 @@
 
  - name: paralist
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -5409,7 +5409,7 @@
 
  - name: parallel
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -5418,7 +5418,7 @@
 
  - name: parcolumns
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -5427,7 +5427,7 @@
 
  - name: parnotes
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -5436,7 +5436,7 @@
 
  - name: parskip
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -5445,7 +5445,7 @@
 
  - name: pbalance
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -5454,7 +5454,7 @@
 
  - name: pdfcol
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -5463,7 +5463,7 @@
 
  - name: pdfcolfoot
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -5472,7 +5472,7 @@
 
  - name: pdfcolparallel
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -5481,7 +5481,7 @@
 
  - name: pdfcolparcolumns
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -5490,7 +5490,7 @@
 
  - name: pdfcomment
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -5499,7 +5499,7 @@
 
  - name: pdfescape
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -5508,7 +5508,7 @@
 
  - name: pdfmarginpar
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -5517,7 +5517,7 @@
 
  - name: pdfmsym
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -5526,7 +5526,7 @@
 
  - name: pdfoverlay
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -5535,7 +5535,7 @@
 
  - name: pdfrender
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -5561,7 +5561,7 @@
 
  - name: perltex
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -5570,7 +5570,7 @@
 
  - name: perpage
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -5579,7 +5579,7 @@
 
  - name: pfnote
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -5588,7 +5588,7 @@
 
  - name: pgfmorepages
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -5598,7 +5598,7 @@
  - name: pgfpages
    ctan-pkg: pgf
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -5623,7 +5623,7 @@
 
  - name: phonenumbers
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -5632,7 +5632,7 @@
 
  - name: piano
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -5641,7 +5641,7 @@
 
  - name: picins
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -5650,7 +5650,7 @@
 
  - name: picture
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -5659,7 +5659,7 @@
 
  - name: pifont
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -5668,7 +5668,7 @@
 
  - name: piton
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -5677,7 +5677,7 @@
 
  - name: placeins
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -5687,7 +5687,7 @@
  - name: plex-mono
    ctan-pkg: plex
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -5697,7 +5697,7 @@
  - name: plex-sans
    ctan-pkg: plex
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -5707,7 +5707,7 @@
  - name: plex-serif
    ctan-pkg: plex
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -5716,7 +5716,7 @@
 
  - name: pmboxdraw
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -5725,7 +5725,7 @@
 
  - name: polyglossia
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -5734,7 +5734,7 @@
 
  - name: postnotes
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -5743,7 +5743,7 @@
 
  - name: prelim2e
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -5752,7 +5752,7 @@
 
  - name: preview
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -5761,7 +5761,7 @@
 
  - name: prftree
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -5770,7 +5770,7 @@
 
  - name: prooftrees
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -5779,7 +5779,7 @@
 
  - name: psfrag
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -5788,7 +5788,7 @@
 
  - name: pst-pdf
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -5797,7 +5797,7 @@
 
  - name: pst2pdf
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -5815,7 +5815,7 @@
 
  - name: pxpic
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -5824,7 +5824,7 @@
 
  - name: pyluatex
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -5833,7 +5833,7 @@
 
  - name: pythontex
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -5844,7 +5844,7 @@
 
  - name: qrcode
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -5853,7 +5853,7 @@
 
  - name: quattrocento
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -5862,7 +5862,7 @@
 
  - name: quotchap
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -5896,7 +5896,7 @@
 
  - name: realboxes
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -5923,7 +5923,7 @@
 
  - name: refcount
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -5932,7 +5932,7 @@
 
  - name: refstyle
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -5941,7 +5941,7 @@
 
  - name: regexpatch
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -5959,7 +5959,7 @@
 
  - name: reledpar
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -5986,7 +5986,7 @@
 
  - name: repltext
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -5995,7 +5995,7 @@
 
  - name: rerunfilecheck
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -6013,7 +6013,7 @@
 
  - name: returntogrid
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -6044,7 +6044,7 @@
 
  - name: rotchiffre
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -6062,7 +6062,7 @@
 
  - name: rotpages
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -6073,7 +6073,7 @@
 
  - name: sansmath
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -6100,7 +6100,7 @@
 
  - name: scalerel
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -6109,7 +6109,7 @@
 
  - name: schola-otf
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -6118,7 +6118,7 @@
 
  - name: scholax
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -6127,7 +6127,7 @@
 
  - name: scontents
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -6136,7 +6136,7 @@
 
  - name: scrextend
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -6145,7 +6145,7 @@
 
  - name: scrlayer
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -6154,7 +6154,7 @@
 
  - name: scrlayer-fancyhdr
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -6163,7 +6163,7 @@
 
  - name: scrlayer-notecolumn
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -6172,7 +6172,7 @@
 
  - name: scrletter
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    related-issues: [88]
    updated: 2024-07-10
@@ -6188,7 +6188,7 @@
 
  - name: secdot
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -6197,7 +6197,7 @@
 
  - name: sectionbreak
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -6206,7 +6206,7 @@
 
  - name: sectsty
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -6215,7 +6215,7 @@
 
  - name: selectp
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -6224,7 +6224,7 @@
 
  - name: selinput
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -6233,7 +6233,7 @@
 
  - name: selnolig
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -6242,7 +6242,7 @@
 
  - name: sepfootnotes
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -6251,7 +6251,7 @@
 
  - name: setouterhbox
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -6269,7 +6269,7 @@
 
  - name: settobox
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -6295,7 +6295,7 @@
 
  - name: shapepar
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -6317,7 +6317,7 @@
 
  - name: showexpl
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -6326,7 +6326,7 @@
 
  - name: showframe
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -6387,7 +6387,7 @@
 
  - name: simpleicons
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -6405,7 +6405,7 @@
 
  - name: slashed
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -6441,7 +6441,7 @@
 
  - name: soulpos
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -6480,7 +6480,7 @@
 
  - name: spark-otf
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -6489,7 +6489,7 @@
 
  - name: spectral
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -6499,7 +6499,7 @@
  - name: splitidx
    ctan-pkg: splitindex
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -6525,7 +6525,7 @@
 
  - name: stackengine
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -6534,7 +6534,7 @@
 
  - name: stackrel
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -6543,7 +6543,7 @@
 
  - name: stampinclude
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -6552,7 +6552,7 @@
 
  - name: standardsectioning
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -6561,7 +6561,7 @@
 
  - name: steinmetz
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -6602,7 +6602,7 @@
 
  - name: storebox
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -6611,7 +6611,7 @@
 
  - name: stringenc
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -6642,7 +6642,7 @@
 
  - name: subeqn
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -6660,7 +6660,7 @@
 
  - name: subfiles
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -6669,7 +6669,7 @@
 
  - name: superiors
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -6687,7 +6687,7 @@
 
  - name: svg
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -6705,7 +6705,7 @@
 
  - name: systeme
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -6723,7 +6723,7 @@
 
  - name: TheanoModern
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -6732,7 +6732,7 @@
 
  - name: TheanoOldStyle
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -6749,7 +6749,7 @@
 
  - name: tableof
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -6851,7 +6851,7 @@
 
  - name: telprint
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -6867,7 +6867,7 @@
 
  - name: tensind
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -6876,7 +6876,7 @@
 
  - name: tensor
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -6885,7 +6885,7 @@
 
  - name: termes-otf
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -6894,7 +6894,7 @@
 
  - name: tex-locale
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -6903,7 +6903,7 @@
 
  - name: tex4ebook
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -6921,7 +6921,7 @@
 
  - name: texosquery
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -6946,7 +6946,7 @@
 
  - name: textgreek
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -6955,7 +6955,7 @@
 
  - name: textpos
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -7035,7 +7035,7 @@
 
  - name: thepdfnumber
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -7080,7 +7080,7 @@
 
  - name: thumbpdf
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -7089,7 +7089,7 @@
 
  - name: thumbs
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -7159,7 +7159,7 @@
 
  - name: titleref
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -7190,7 +7190,7 @@
 
  - name: tocbasic
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -7252,7 +7252,7 @@
 
  - name: topcapt
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -7261,7 +7261,7 @@
 
  - name: totalcount
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -7283,7 +7283,7 @@
 
  - name: tracklang
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -7292,7 +7292,7 @@
 
  - name: transparent
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -7325,7 +7325,7 @@
 
  - name: twemojis
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -7404,7 +7404,7 @@
 
  - name: uniquecounter
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -7420,7 +7420,7 @@
 
  - name: unravel
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -7505,7 +7505,7 @@
 
  - name: verbdef
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -7531,7 +7531,7 @@
 
  - name: versonotes
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -7549,7 +7549,7 @@
 
  - name: vwcol
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -7583,7 +7583,7 @@
 
  - name: witharrows
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -7592,7 +7592,7 @@
 
  - name: wordcloud
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -7609,7 +7609,7 @@
 
  - name: wrapfig2
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -7618,7 +7618,7 @@
 
  - name: wrapstuff
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -7651,7 +7651,7 @@
 
  - name: xcoffins
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -7669,7 +7669,7 @@
 
  - name: xecjk
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -7678,7 +7678,7 @@
 
  - name: xetexko
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -7687,7 +7687,7 @@
 
  - name: xevlna
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -7696,7 +7696,7 @@
 
  - name: xfakebold
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -7721,7 +7721,7 @@
 
  - name: xhfill
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -7730,7 +7730,7 @@
 
  - name: xint
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -7739,7 +7739,7 @@
 
  - name: xistercian
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -7748,7 +7748,7 @@
 
  - name: xkeyval
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -7757,7 +7757,7 @@
 
  - name: xlop
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -7782,7 +7782,7 @@
 
  - name: xpatch
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -7791,7 +7791,7 @@
 
  - name: xpiano
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -7800,7 +7800,7 @@
 
  - name: xpinyin
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -7822,7 +7822,7 @@
 
  - name: xsavebox
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -7831,7 +7831,7 @@
 
  - name: xsim
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -7847,7 +7847,7 @@
 
  - name: xstring
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -7863,7 +7863,7 @@
 
  - name: xurl
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -7891,7 +7891,7 @@
 
  - name: yfonts-otf
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -7900,7 +7900,7 @@
 
  - name: yhmath
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -7911,7 +7911,7 @@
 
  - name: zhnumber
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -7927,7 +7927,7 @@
 
  - name: zref
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -7936,7 +7936,7 @@
 
  - name: zref-check
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -7945,7 +7945,7 @@
 
  - name: zref-clever
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -7954,7 +7954,7 @@
 
  - name: zref-vario
    type: package
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -7969,7 +7969,7 @@
 
  - name: acmart
    type: class
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -8023,7 +8023,7 @@
 
  - name: combine
    type: class
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -8034,7 +8034,7 @@
 
  - name: exam
    type: class
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -8045,7 +8045,7 @@
 
  - name: IEEEtran
    type: class
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -8056,7 +8056,7 @@
 
  - name: jlreq
    type: class
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -8088,7 +8088,7 @@
  - name: ltugboat
    ctan-pkg: tugboat
    type: class
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -8097,7 +8097,7 @@
 
  - name: ltxdoc
    type: class
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -8129,7 +8129,7 @@
  - name: oblivoir
    ctan-pkg: kotex-oblivoir
    type: class
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tests: false
@@ -8158,7 +8158,7 @@
  - name: revtex4-2
    ctan-pkg: revtex
    type: class
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tasks: needs tests
@@ -8180,7 +8180,7 @@
 
  - name: scrlttr2
    type: class
-   status: unlisted
+   status: unknown
    priority: 9
    related-issues: [88]
    updated: 2024-07-10
@@ -8193,7 +8193,7 @@
 
  - name: standalone
    type: class
-   status: unlisted
+   status: unknown
    priority: 9
    issues:
    tasks: needs tests

--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -9,7 +9,7 @@
 #  type              required   string          "class" or "package" (may need eg tikz or beamer themes in the end?)
 #  status            required   string          Status of package, see list below.
 #  ctan-pkg          optional   string          Name for ctan.org/pkg/?? link if different to name
-#  priority          optional   integer         Priority of work for unknown entries (omitted from table if > 3)
+#  priority          optional   integer         Priority of work for unknown entries (omitted from table if > 2)
 #  comments          optional   markdown-string Free text markdown comments
 #  references        optional   integer-list    List of integers referencing the bibliography in references.yml
 #  issues            optional   integer-list    List of integers referencing primary issues at latex3/tagging-project

--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -248,6 +248,7 @@
  - name: alltt
    type: package
    status: currently-incompatible
+   priority: 2
    issues: [131]
    updated: 2024-07-14
 
@@ -353,6 +354,7 @@
  - name: amsthm
    type: package
    status: currently-incompatible
+   priority: 2
    issues: [83]
    tests: true
    updated: 2024-07-08
@@ -465,6 +467,7 @@
  - name: arydshln
    type: package
    status: currently-incompatible
+   priority: 2
    issues: [193]
    tests: true
    tasks:
@@ -877,6 +880,7 @@
  - name: blkarray
    type: package
    status: currently-incompatible
+   priority: 2
    issues: [181]
    tests: true
    updated: 2024-07-17
@@ -973,6 +977,7 @@
  - name: breqn
    type: package
    status: currently-incompatible
+   priority: 2
    issues: [145]
    tests: yes
    tasks: needs more tests
@@ -1112,6 +1117,7 @@
  - name: caption
    type: package
    status: currently-incompatible
+   priority: 2
    comments: "the configurations from the package are overwritten by the
              tagging code. Issue when hyperref and both listoffigures are used."
    issues: [84]
@@ -1818,6 +1824,7 @@
  - name: doc
    type: package
    status: currently-incompatible
+   priority: 2
    issues: [44]
    updated: 2024-07-06
 
@@ -2043,6 +2050,7 @@
  - name: empheq
    type: package
    status: currently-incompatible
+   priority: 2
    issues: [138]
    tests: true
    updated: 2024-07-14
@@ -2103,6 +2111,7 @@
  - name: enumerate
    type: package
    status: currently-incompatible
+   priority: 2
    references: [1]
    updated: 2024-07-06
 
@@ -2127,6 +2136,7 @@
 
  - name: epic
    status: currently-incompatible
+   priority: 2
    comments: "Works with pdflatex but not lualatex."
    issues: [159]
    tests: true
@@ -2373,6 +2383,7 @@
  - name: fancyvrb
    type: package
    status: currently-incompatible
+   priority: 2
    references: [1]
    tasks: needs tests
    updated: 2024-07-06
@@ -2396,6 +2407,7 @@
  - name: fcolumn
    type: package
    status: currently-incompatible
+   priority: 2
    issues: [161]
    tests: true
    updated: 2024-07-16
@@ -2540,6 +2552,7 @@
  - name: float
    type: package
    status: currently-incompatible
+   priority: 2
    comments: "[H] floats are not yet automatically tagged."
    references: [2]
    tasks: needs tests
@@ -2548,6 +2561,7 @@
  - name: floatpag
    type: package
    status: currently-incompatible
+   priority: 2
    comments: "redefines \\@xfloat"
    issues: [209]
    tests: true
@@ -2857,6 +2871,7 @@
  - name: ftnright
    type: package
    status: currently-incompatible
+   priority: 2
    issues: [110]
    tests: true
    updated: 2024-07-11
@@ -3258,6 +3273,7 @@
  - name: hhline
    type: package
    status: currently-incompatible
+   priority: 2
    comments: breaks with errors
    supported-through: [phase-III,table]
    tasks: needs further tests
@@ -3839,6 +3855,7 @@
  - name: layout
    type: package
    status: currently-incompatible
+   priority: 2
    issues: [111]
    tests: true
    updated: 2024-07-11
@@ -3972,6 +3989,7 @@
  - name: lineno
    type: package
    status: currently-incompatible
+   priority: 2
    issues: [162,210]
    tests: true
    comments: "loses linenumbers and doesn't tag line numbers" 
@@ -4004,6 +4022,7 @@
  - name: listings
    type: package
    status: currently-incompatible
+   priority: 2
    comments: See definition in tagpdfdocu-patches.sty.
    references: [1]
    issues: [70]
@@ -4091,6 +4110,7 @@
  - name: ltablex
    type: package
    status: currently-incompatible
+   priority: 2
    issues: [163]
    tests: true
    updated: 2024-07-17
@@ -4116,6 +4136,7 @@
  - name: ltxtable
    type: package
    status: currently-incompatible
+   priority: 2
    issues: [164]
    tests: true
    updated: 2024-07-17
@@ -4211,6 +4232,7 @@
  - name: luatexja
    type: package
    status: currently-incompatible
+   priority: 2
    comments: overwrites tabular/array commands
    issues: [87]
    updated: 2024-07-06
@@ -4337,6 +4359,7 @@
  - name: marginnote
    type: package
    status: currently-incompatible
+   priority: 2
    issues: [165]
    tests: true
    updated: 2024-07-17
@@ -4624,6 +4647,7 @@
  - name: minted
    type: package
    status: currently-incompatible
+   priority: 2
    comments: Structural warnings and automatic begin / end mismatch errors.
    updated: 2024-07-18
 
@@ -5019,6 +5043,7 @@
  - name: nicematrix
    type: package
    status: currently-incompatible
+   priority: 2
    issues: [179]
    tests: true
    updated: 2024-07-17
@@ -5549,6 +5574,7 @@
  - name: pdfpages
    type: package
    status: currently-incompatible
+   priority: 2
    comments: "Creates duplicated structures as graphics are processed more than once in trial
              typesetting. Correct tagging of multipage includes unclear."
    tasks: needs tests
@@ -5612,6 +5638,7 @@
  - name: pgfplots
    type: package
    status: currently-incompatible
+   priority: 2
    comments: "Relies on tikz so compatibility will come with that of tikz."
    tests: false
    updated: 2024-07-16
@@ -5811,6 +5838,7 @@
  - name: pstricks
    type: package
    status: currently-incompatible
+   priority: 2
    comments: "Tagging passes validation but is suboptimal. Future compatibility
               will only be with lualatex; dvips cannot properly support PDF/UA."
    issues:
@@ -6042,6 +6070,7 @@
  - name: rotating
    type: package
    status: currently-incompatible
+   priority: 2
    issues: [112]
    tests: true
    updated: 2024-07-11
@@ -6283,6 +6312,7 @@
  - name: shadethm
    type: package
    status: currently-incompatible
+   priority: 2
    comments: Obsolete package; tcolorbox recommended.
    issues:
    tests: true
@@ -6350,6 +6380,7 @@
    ctan-pkg: latex-base
    type: package
    status: currently-incompatible
+   priority: 2
    issues: [115]
    tests: true
    updated: 2024-07-11
@@ -6437,6 +6468,7 @@
  - name: soul
    type: package
    status: currently-incompatible
+   priority: 2
    issues: [167]
    tests: true
    updated: 2024-07-17
@@ -6518,6 +6550,7 @@
  - name: spverbatim
    type: package
    status: currently-incompatible
+   priority: 2
    issues: [168]
    tests: true
    updated: 2024-07-17
@@ -6626,6 +6659,7 @@
  - name: subcaption
    type: package
    status: currently-incompatible
+   priority: 2
    comments:  Issue when hyperref and both listoffigures are used.
    issues: [85]
    updated: 2024-07-06
@@ -6678,6 +6712,7 @@
  - name: supertabular
    type: package
    status: currently-incompatible
+   priority: 2
    issues: [169]
    tests: true
    updated: 2024-07-17
@@ -6756,6 +6791,7 @@
  - name: tabls
    type: package
    status: currently-incompatible
+   priority: 2
    issues: [171]
    tests: true
    updated: 2024-07-17
@@ -6804,6 +6840,7 @@
  - name: tabularray
    type: package
    status: currently-incompatible
+   priority: 2
    issues: [177]
    tests: true
    updated: 2024-07-17
@@ -7031,6 +7068,7 @@
  - name: theorem
    type: package
    status: currently-incompatible
+   priority: 2
    issues:
    tests: true
    updated: 2024-07-10
@@ -7047,6 +7085,7 @@
  - name: thmbox
    type: package
    status: currently-incompatible
+   priority: 2
    issues: [172]
    tests: true
    updated: 2024-07-17
@@ -7063,6 +7102,7 @@
  - name: threeparttable
    type: package
    status: currently-incompatible
+   priority: 2
    issues: [173]
    tests: true
    updated: 2024-07-17
@@ -7097,12 +7137,14 @@
  - name: tikz
    type: package
    status: currently-incompatible
+   priority: 2
    references: [2]
    updated: 2024-07-06
 
  - name: tikz-cd
    type: package
    status: currently-incompatible
+   priority: 2
    issues: [30]
    updated: 2024-07-06
 
@@ -7167,12 +7209,14 @@
  - name: titlesec
    type: package
    status: currently-incompatible
+   priority: 2
    issues: [24]
    updated: 2024-07-06
 
  - name: titletoc
    type: package
    status: currently-incompatible
+   priority: 2
    comments: Mentioned in issue.
    issues: [24]
    updated: 2024-07-06
@@ -7216,6 +7260,7 @@
  - name: tocloft
    type: package
    status: currently-incompatible
+   priority: 2
    comments: Packages attempts to redefine `\@starttoc`and fails.
    issues: [74]
    tests: true
@@ -7348,6 +7393,7 @@
  - name: typed-checklist
    type: package
    status: currently-incompatible
+   priority: 2
    issues: [174]
    tests: true
    updated: 2024-07-17
@@ -7390,6 +7436,7 @@
  - name: unicodefonttable
    type: package
    status: currently-incompatible
+   priority: 2
    issues: [175]
    tests: true
    updated: 2024-07-17
@@ -7481,6 +7528,7 @@
  - name: varwidth
    type: package
    status: currently-incompatible
+   priority: 2
    comments: Tagging structure looks ok, but the formatting is wrong when the tagging code is used.
    issues: [71]
    tasks: adjustments in block code needed?
@@ -7554,6 +7602,7 @@
  - name: warpcol
    type: package
    status: currently-incompatible
+   priority: 2
    issues: [186]
    tests: true
    updated: 2024-07-17
@@ -7568,6 +7617,7 @@
  - name: widetable
    type: package
    status: currently-incompatible
+   priority: 2
    issues: [176]
    tests: true
    updated: 2024-07-17
@@ -7600,6 +7650,7 @@
  - name: wrapfig
    type: package
    status: currently-incompatible
+   priority: 2
    comments: generated tagging structure is incorrect
    issues: [40]
    tests: true
@@ -7765,6 +7816,7 @@
  - name: xltabular
    type: package
    status: currently-incompatible
+   priority: 2
    supported-through: [phase-III,firstaid]
    issues: [170]
    tests: true
@@ -7854,6 +7906,7 @@
  - name: xtab
    type: package
    status: currently-incompatible
+   priority: 2
    issues: [183]
    tests: true
    updated: 2024-07-17
@@ -8000,6 +8053,7 @@
    ctan-pkg: amscls
    type: class
    status: currently-incompatible
+   priority: 2
    comments: "See some needed adjustments in project example `amsldoc`"
    tasks: needs further tests
    updated: 2024-07-07
@@ -8015,6 +8069,7 @@
  - name: beamer
    type: class
    status: currently-incompatible
+   priority: 2
    updated: 2024-07-07
 
  - name: book
@@ -8113,6 +8168,7 @@
  - name: memoir
    type: class
    status: currently-incompatible
+   priority: 2
    comments: "Some code showing the needed adjustments can be found in the 
               [bible example](https://github.com/latex3/tagging-project/blob/main/project-examples/ASV/bible.tex)"
    updated: 2024-07-05
@@ -8173,12 +8229,14 @@
  - name: scrartcl
    type: class
    status: currently-incompatible
+   priority: 2
    related-issues: [88]
    updated: 2024-07-10
 
  - name: scrbook
    type: class
    status: currently-incompatible
+   priority: 2
    related-issues: [88]
    updated: 2024-07-10
 
@@ -8192,6 +8250,21 @@
  - name: scrreport
    type: class
    status: currently-incompatible
+   priority: 2
+   related-issues: [88]
+   updated: 2024-07-10
+
+ - name: scrreporta
+   type: class
+   status: currently-incompatible
+   priority: 4
+   related-issues: [88]
+   updated: 2024-07-10
+   
+ - name: scrreporta
+   type: class
+   status: currently-incompatible
+   priority: 6
    related-issues: [88]
    updated: 2024-07-10
 

--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -8261,7 +8261,7 @@
    related-issues: [88]
    updated: 2024-07-10
    
- - name: scrreporta
+ - name: scrreportb
    type: class
    status: currently-incompatible
    priority: 6

--- a/tagging-status/index.md
+++ b/tagging-status/index.md
@@ -24,7 +24,7 @@ td.date {white-space: nowrap;font-size:90%;}
 {% endif %}
 {% endfor %}
 
-This file shows the status of!x! **{{t-s | size }}** LaTeX [Packages](#packages) and [Classes](#classes)
+This file shows the status of **{{t-s | size }}** LaTeX [Packages](#packages) and [Classes](#classes)
 with respect to PDF tagging. `phase-III` is generally needed and not explicitly shown.
 
 The values in the *Status* column have the following meaning:

--- a/tagging-status/index.md
+++ b/tagging-status/index.md
@@ -17,7 +17,7 @@ td.date {white-space: nowrap;font-size:90%;}
 
 # Tagging Status of LaTeX Packages and Classes
 
-{% assign t-s = site.data.tagging-status | where_expzr: "priority", "priority == 2" %}
+{% assign t-s = site.data.tagging-status | where_exp: "status", "status != 'unlisted'" %}
 
 This file shows the status of!! **{{t-s | size }}** LaTeX [Packages](#packages) and [Classes](#classes)
 with respect to PDF tagging. `phase-III` is generally needed and not explicitly shown.

--- a/tagging-status/index.md
+++ b/tagging-status/index.md
@@ -19,7 +19,11 @@ td.date {white-space: nowrap;font-size:90%;}
 
 {% assign t-s = "" | split: "" %}
 {% for p in site.data.tagging-status %}
-{% if p.priority < 3 or p.status != 'unknown' %}
+{% if p.priority < 5
+or p.status == 'compatible'
+or p.status == 'partially-compatible'
+or p.status == 'no-support'
+%}
 {% assign t-s = t-s | push: p %}
 {% endif %}
 {% endfor %}

--- a/tagging-status/index.md
+++ b/tagging-status/index.md
@@ -17,16 +17,17 @@ td.date {white-space: nowrap;font-size:90%;}
 
 # Tagging Status of LaTeX Packages and Classes
 
-This file shows the status of **{{site.data.tagging-status | size }}** LaTeX [Packages](#packages) and [Classes](#classes)
+{% assign tagging-status = site.data.tagging-status | where_expr: "priority", "priority < 3" %}
+This file shows the status of **{{tagging-status | size }}** LaTeX [Packages](#packages) and [Classes](#classes)
 with respect to PDF tagging. `phase-III` is generally needed and not explicitly shown.
 
 The values in the *Status* column have the following meaning:
 
-- `compatible` This package or class works without any issues when tagging is enabled. If there are problems, please open an issue in [the tagging-project repo](https://github.com/latex3/tagging-project/issues). (**{{site.data.tagging-status | where: "status", "compatible" | size }}** entries across all tables)
-- `partially-compatible` The package or class is currently partially compatible, e.g., some parts may not work yet, but with some restrictions it can already be used. See comments for details. (**{{site.data.tagging-status | where: "status", "partially-compatible" | size }}** entries across all tables)
-- `currently-incompatible` The package or class is currently incompatible with the tagging code, but we expect it to be updated eventually. (**{{site.data.tagging-status | where: "status", "currently-incompatible" | size }}** entries across all tables)
-- `no-support` This package or class or class is incompatible with the tagging code and we do *not* believe that it will ever be supported. (**{{site.data.tagging-status | where: "status", "no-support" | size }}** entries across all tables)
-- `unknown` The status of this package or class is not known, because there aren't reliable tests yet. Help with testing to determine the real status is very much appreciated. (**{{site.data.tagging-status | where: "status", "unknown" | size }}** entries across all tables)
+- `compatible` This package or class works without any issues when tagging is enabled. If there are problems, please open an issue in [the tagging-project repo](https://github.com/latex3/tagging-project/issues). (**{{tagging-status | where: "status", "compatible" | size }}** entries across all tables)
+- `partially-compatible` The package or class is currently partially compatible, e.g., some parts may not work yet, but with some restrictions it can already be used. See comments for details. (**{{tagging-status | where: "status", "partially-compatible" | size }}** entries across all tables)
+- `currently-incompatible` The package or class is currently incompatible with the tagging code, but we expect it to be updated eventually. (**{{tagging-status | where: "status", "currently-incompatible" | size }}** entries across all tables)
+- `no-support` This package or class or class is incompatible with the tagging code and we do *not* believe that it will ever be supported. (**{{tagging-status | where: "status", "no-support" | size }}** entries across all tables)
+- `unknown` The status of this package or class is not known, because there aren't reliable tests yet. Help with testing to determine the real status is very much appreciated. (**{{tagging-status | where: "status", "unknown" | size }}** entries across all tables)
 
 To use packages or classes together with the tagging code it is (nearly) always necessary to load at least `phase-III`of the tagging code, i.e., `testphase=phase-III` in `\DocumentMetadata`. To save space in the tables, this is not explicitly mentioned below. However, if a package or class requires other settings there is an explicit remark in the comments column, e.g., `Tagging support: phase-III, table` which means you have to specify `testphase={phase-III,table}`. If `package` is mentioned at this point it means that the package itself provides the necessary tagging support and not one of the modules in `latex-lab`.
 
@@ -39,7 +40,7 @@ If you encounter a problem with a package or class for which there is no issue i
 
 ## Packages
 
-{% assign xpackages = site.data.tagging-status | where: "type", "package" %}
+{% assign xpackages = tagging-status | where: "type", "package" %}
 {% assign xpc = xpackages | where: "status", "compatible" %}
 {% assign xpp = xpackages | where: "status", "partially-compatible" %}
 {% assign xpi = xpackages | where: "status", "currently-incompatible" %}
@@ -61,7 +62,7 @@ The status for the remaining **{{xpu | size }}** packages is `unknown`.
 ## Classes
 
 
-{% assign xpackages = site.data.tagging-status | where: "type", "class" %}
+{% assign xpackages = tagging-status | where: "type", "class" %}
 {% assign xpc = xpackages | where: "status", "compatible" %}
 {% assign xpp = xpackages | where: "status", "partially-compatible" %}
 {% assign xpi = xpackages | where: "status", "currently-incompatible" %}

--- a/tagging-status/index.md
+++ b/tagging-status/index.md
@@ -17,17 +17,18 @@ td.date {white-space: nowrap;font-size:90%;}
 
 # Tagging Status of LaTeX Packages and Classes
 
-{% assign tagging-status = site.data.tagging-status | where_expr: "priority", "priority < 3" %}
-This file shows the status of **{{tagging-status | size }}** LaTeX [Packages](#packages) and [Classes](#classes)
+{% assign t-s = site.data.tagging-status | where_expr: "priority", "priority < 3" %}
+
+This file shows the status of!! **{{t-s | size }}** LaTeX [Packages](#packages) and [Classes](#classes)
 with respect to PDF tagging. `phase-III` is generally needed and not explicitly shown.
 
 The values in the *Status* column have the following meaning:
 
-- `compatible` This package or class works without any issues when tagging is enabled. If there are problems, please open an issue in [the tagging-project repo](https://github.com/latex3/tagging-project/issues). (**{{tagging-status | where: "status", "compatible" | size }}** entries across all tables)
-- `partially-compatible` The package or class is currently partially compatible, e.g., some parts may not work yet, but with some restrictions it can already be used. See comments for details. (**{{tagging-status | where: "status", "partially-compatible" | size }}** entries across all tables)
-- `currently-incompatible` The package or class is currently incompatible with the tagging code, but we expect it to be updated eventually. (**{{tagging-status | where: "status", "currently-incompatible" | size }}** entries across all tables)
-- `no-support` This package or class or class is incompatible with the tagging code and we do *not* believe that it will ever be supported. (**{{tagging-status | where: "status", "no-support" | size }}** entries across all tables)
-- `unknown` The status of this package or class is not known, because there aren't reliable tests yet. Help with testing to determine the real status is very much appreciated. (**{{tagging-status | where: "status", "unknown" | size }}** entries across all tables)
+- `compatible` This package or class works without any issues when tagging is enabled. If there are problems, please open an issue in [the tagging-project repo](https://github.com/latex3/tagging-project/issues). (**{{t-s | where: "status", "compatible" | size }}** entries across all tables)
+- `partially-compatible` The package or class is currently partially compatible, e.g., some parts may not work yet, but with some restrictions it can already be used. See comments for details. (**{{t-s | where: "status", "partially-compatible" | size }}** entries across all tables)
+- `currently-incompatible` The package or class is currently incompatible with the tagging code, but we expect it to be updated eventually. (**{{t-s | where: "status", "currently-incompatible" | size }}** entries across all tables)
+- `no-support` This package or class or class is incompatible with the tagging code and we do *not* believe that it will ever be supported. (**{{t-s | where: "status", "no-support" | size }}** entries across all tables)
+- `unknown` The status of this package or class is not known, because there aren't reliable tests yet. Help with testing to determine the real status is very much appreciated. (**{{t-s | where: "status", "unknown" | size }}** entries across all tables)
 
 To use packages or classes together with the tagging code it is (nearly) always necessary to load at least `phase-III`of the tagging code, i.e., `testphase=phase-III` in `\DocumentMetadata`. To save space in the tables, this is not explicitly mentioned below. However, if a package or class requires other settings there is an explicit remark in the comments column, e.g., `Tagging support: phase-III, table` which means you have to specify `testphase={phase-III,table}`. If `package` is mentioned at this point it means that the package itself provides the necessary tagging support and not one of the modules in `latex-lab`.
 
@@ -40,7 +41,7 @@ If you encounter a problem with a package or class for which there is no issue i
 
 ## Packages
 
-{% assign xpackages = tagging-status | where: "type", "package" %}
+{% assign xpackages = t-s | where: "type", "package" %}
 {% assign xpc = xpackages | where: "status", "compatible" %}
 {% assign xpp = xpackages | where: "status", "partially-compatible" %}
 {% assign xpi = xpackages | where: "status", "currently-incompatible" %}
@@ -62,7 +63,7 @@ The status for the remaining **{{xpu | size }}** packages is `unknown`.
 ## Classes
 
 
-{% assign xpackages = tagging-status | where: "type", "class" %}
+{% assign xpackages = t-s | where: "type", "class" %}
 {% assign xpc = xpackages | where: "status", "compatible" %}
 {% assign xpp = xpackages | where: "status", "partially-compatible" %}
 {% assign xpi = xpackages | where: "status", "currently-incompatible" %}

--- a/tagging-status/index.md
+++ b/tagging-status/index.md
@@ -17,7 +17,7 @@ td.date {white-space: nowrap;font-size:90%;}
 
 # Tagging Status of LaTeX Packages and Classes
 
-{% assign t-s = site.data.tagging-status | where: "priority", "2" %}
+{% assign t-s = site.data.tagging-status | where_expr: "priority", "priority == 2" %}
 
 This file shows the status of!! **{{t-s | size }}** LaTeX [Packages](#packages) and [Classes](#classes)
 with respect to PDF tagging. `phase-III` is generally needed and not explicitly shown.

--- a/tagging-status/index.md
+++ b/tagging-status/index.md
@@ -22,7 +22,7 @@ td.date {white-space: nowrap;font-size:90%;}
 {% if p.priority < 3 or p.status != 'unknown' %}
 {% assign t-s = t-s | push: p %}
 {% endif %}
-{% end-for %}
+{% endfor %}
 
 This file shows the status of!x! **{{t-s | size }}** LaTeX [Packages](#packages) and [Classes](#classes)
 with respect to PDF tagging. `phase-III` is generally needed and not explicitly shown.

--- a/tagging-status/index.md
+++ b/tagging-status/index.md
@@ -22,7 +22,6 @@ td.date {white-space: nowrap;font-size:90%;}
 {% if p.priority < 5
 or p.status == 'compatible'
 or p.status == 'partially-compatible'
-or p.status == 'currently-incompatible'
 or p.status == 'no-support'
 %}
 {% assign t-s = t-s | push: p %}

--- a/tagging-status/index.md
+++ b/tagging-status/index.md
@@ -22,6 +22,7 @@ td.date {white-space: nowrap;font-size:90%;}
 {% if p.priority < 5
 or p.status == 'compatible'
 or p.status == 'partially-compatible'
+or p.status == 'currently-incompatible'
 or p.status == 'no-support'
 %}
 {% assign t-s = t-s | push: p %}

--- a/tagging-status/index.md
+++ b/tagging-status/index.md
@@ -17,7 +17,7 @@ td.date {white-space: nowrap;font-size:90%;}
 
 # Tagging Status of LaTeX Packages and Classes
 
-{% assign t-s = site.data.tagging-status | where_expr: "priority", "priority < 3" %}
+{% assign t-s = site.data.tagging-status | where: "priority", "2" %}
 
 This file shows the status of!! **{{t-s | size }}** LaTeX [Packages](#packages) and [Classes](#classes)
 with respect to PDF tagging. `phase-III` is generally needed and not explicitly shown.

--- a/tagging-status/index.md
+++ b/tagging-status/index.md
@@ -18,7 +18,7 @@ td.date {white-space: nowrap;font-size:90%;}
 # Tagging Status of LaTeX Packages and Classes
 
 {% assign t-s = "" | split: "" %}
-{% for p site.data.tagging-status %}
+{% for p in site.data.tagging-status %}
 {% if p.priority < 3 or p.status != 'unknown' %}
 {% assign t-s = t-s | push: p %}
 {% endif %}

--- a/tagging-status/index.md
+++ b/tagging-status/index.md
@@ -17,7 +17,7 @@ td.date {white-space: nowrap;font-size:90%;}
 
 # Tagging Status of LaTeX Packages and Classes
 
-{% assign t-s = site.data.tagging-status | where_expr: "priority", "priority == 2" %}
+{% assign t-s = site.data.tagging-status | where_expzr: "priority", "priority == 2" %}
 
 This file shows the status of!! **{{t-s | size }}** LaTeX [Packages](#packages) and [Classes](#classes)
 with respect to PDF tagging. `phase-III` is generally needed and not explicitly shown.

--- a/tagging-status/index.md
+++ b/tagging-status/index.md
@@ -17,9 +17,14 @@ td.date {white-space: nowrap;font-size:90%;}
 
 # Tagging Status of LaTeX Packages and Classes
 
-{% assign t-s = site.data.tagging-status | where_exp: "status", "status != 'unlisted'" %}
+{% assign t-s = "" | split: "" %}
+{% for p site.data.tagging-status %}
+{% if p.priority < 3 or p.status != 'unknown' %}
+{% assign t-s = t-s | push: p %}
+{% endif %}
+{% end-for %}
 
-This file shows the status of!! **{{t-s | size }}** LaTeX [Packages](#packages) and [Classes](#classes)
+This file shows the status of!x! **{{t-s | size }}** LaTeX [Packages](#packages) and [Classes](#classes)
 with respect to PDF tagging. `phase-III` is generally needed and not explicitly shown.
 
 The values in the *Status* column have the following meaning:

--- a/tagging-status/status-table.md
+++ b/tagging-status/status-table.md
@@ -23,7 +23,11 @@ Click on the column headings to sort the table by the chosen column.
 <td class="{{p.status}}"><a href="https://ctan.org/pkg/
 {%- if p.ctan-pkg -%}{{p.ctan-pkg}}{%- else -%}{{p.name}}{%- endif -%}
 ">{{p.name}}</a></td>
-<td class="{{p.status}}"{% if p.status == "partially-compatible" %} sorttable_customkey="compatible-partial"{% endif %}>{{p.status}}</td>
+<td class="{{p.status}}"  sorttable_customkey="
+{%- if p.status == "partially-compatible" %}compatible-partial{% else %}{{p.status}}{% endif -%}
+">{{p.status}}
+{%- if p.priority%}<sub>{{p.priority}}</sub>{% endif -%}
+</td>
 <td>
 {{p.comments | markdownify}}
 {%- if p.references %}


### PR DESCRIPTION
This adds a `priority` field to entries, only used if status is `unknown`  it should be an integer between 1 and 9  inclusive and `unknown` entries  are only  listed in the generated table if they have priority 1 or 2.

handling this proved trickier than expected as the `where_expr;` filter (despite being documented as available since jekyll 3.2) doesn't appear to work on gh-pages, which seems to claim it is jekyll 3.9.5 but anyway I think it's working now filtering "by hand" in a for loop.

The resulting display can be seen at

https://davidcarlisle.github.io/tagging-project/tagging-status/

which now shows 547 rather than 951 entries, although all the data is still in the YAML.

See discussion comments from me and Frank at

https://github.com/latex3/tagging-project/pull/214#issuecomment-2241338408

https://github.com/latex3/tagging-project/pull/190#issuecomment-2241548182

The initial assignment of priorities is a bit arbitrary for ease of bulk editing, all unknown entries with an updated date up to 2024-07-15 get priority 2 and all later ones get 9, this ensures that the TLC3 list gets shown as do all later additions with a state other than unknown. Individual packages could be adjusted after the merge.




