### PR TITLE
add hypcap compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -3070,11 +3070,13 @@
 
  - name: hypcap
    type: package
-   status: unknown
+   status: currently-incompatible
+   comments: "The tagging code already moves anchors to the top of floats
+              so this package is unnecessary. Errors if given option
+              `figure`, `table`, etc."
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   updated: 2024-07-21
 
  - name: hypdestopt
    type: package

--- a/tagging-status/testfiles/hypcap/hypcap-01.tex
+++ b/tagging-status/testfiles/hypcap/hypcap-01.tex
@@ -1,0 +1,39 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,table,title,firstaid}
+  }
+
+\documentclass{article}
+\usepackage{hyperref}
+\usepackage[]{hypcap}
+\usepackage{graphicx}
+
+\title{hypcap tagging test}
+
+\begin{document}
+
+% with \capstart
+body text
+\begin{figure}
+\capstart
+\includegraphics[alt={alt text}]{example-image}
+\caption{my caption text}
+\label{fig}
+\end{figure}
+
+\ref{fig}
+
+% without \capstart
+body text
+\begin{figure}
+\includegraphics[alt={alt text}]{example-image}
+\caption{my caption text}
+\label{figB}
+\end{figure}
+
+\ref{figB}
+
+\end{document}

--- a/tagging-status/testfiles/hypcap/hypcap-02.tex
+++ b/tagging-status/testfiles/hypcap/hypcap-02.tex
@@ -1,0 +1,27 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,table,title,firstaid}
+  }
+
+\documentclass{article}
+\usepackage{hyperref}
+\usepackage[figure]{hypcap}
+\usepackage{graphicx}
+
+\title{hypcap tagging test}
+
+\begin{document}
+
+body text
+\begin{figure}
+\includegraphics[alt={alt text}]{example-image}
+\caption{my caption text}
+\label{fig}
+\end{figure}
+
+\ref{fig}
+
+\end{document}


### PR DESCRIPTION
Lists [hypcap](https://www.ctan.org/pkg/hypcap) as "currently-incompatible" and adds two test files. The first test shows that hypcap is unnecessary since the tagging code achieves its purpose by moving the anchor to the top of floats. The second test shows it errors if given one of the package options like `figure` that redefines the float environment.

It's possible "no-support" makes more sense. 