### PR TITLE
mark font packages as compatible

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -346,11 +346,10 @@
 
  - name: andika
    type: package
-   status: unknown
+   status: compatible
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   updated: 2024-07-21
 
  - name: animate
    type: package
@@ -474,11 +473,10 @@
 
  - name: atkinson
    type: package
-   status: unknown
+   status: compatible
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   updated: 2024-07-21
 
  - name: attachfile2
    type: package
@@ -969,6 +967,13 @@
    tests: false
    updated: 2024-07-13
 
+ - name: CooperHewitt
+   type: package
+   status: compatible
+   issues:
+   tests: false
+   updated: 2024-07-21
+
  - name: CormorantGaramond
    type: package
    status: compatible
@@ -1039,11 +1044,10 @@
 
  - name: carlito
    type: package
-   status: unknown
+   status: compatible
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   updated: 2024-07-21
 
  - name: cases
    type: package
@@ -1378,11 +1382,10 @@
 
  - name: concmath-otf
    type: package
-   status: unknown
+   status: compatible
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   updated: 2024-07-21
 
  - name: continue
    type: package
@@ -1401,14 +1404,6 @@
    updated: 2024-07-18
 
  - name: countriesofeurope
-   type: package
-   status: unknown
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
-
- - name: cooperhewitt
    type: package
    status: unknown
    issues:
@@ -1560,14 +1555,6 @@
    issues:
    tests: false
    updated: 2024-07-13
-
- - name: DSSerif
-   type: package
-   status: unknown
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
 
  - name: dashrule
    type: package
@@ -1769,11 +1756,10 @@
 
  - name: ETbb
    type: package
-   status: unknown
+   status: compatible
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   updated: 2024-07-21
 
  - name: easyfig
    type: package
@@ -2080,11 +2066,10 @@
 
  - name: euler-math
    type: package
-   status: unknown
+   status: compatible
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   updated: 2024-07-21
 
  - name: eulervm
    type: package
@@ -2275,11 +2260,10 @@
 
  - name: firamath-otf
    type: package
-   status: unknown
+   status: compatible
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   updated: 2024-07-21
 
  - name: fitbox
    type: package
@@ -2567,11 +2551,10 @@
 
  - name: forum
    type: package
-   status: unknown
+   status: compatible
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   updated: 2024-07-21
 
  - name: fourier
    ctan-pkg: fourier
@@ -2592,19 +2575,17 @@
  - name: fourier-otf
    ctan-pkg: erewhon-math
    type: package
-   status: unknown
+   status: compatible
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   updated: 2024-07-21
 
  - name: fouriernc
    type: package
-   status: unknown
+   status: compatible
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   updated: 2024-07-21
 
  - name: framed
    type: package
@@ -2712,11 +2693,10 @@
 
  - name: gelasio
    type: package
-   status: unknown
+   status: compatible
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   updated: 2024-07-21
 
  - name: gelasiomath
    type: package
@@ -2996,11 +2976,10 @@
 
  - name: heros-otf
    type: package
-   status: unknown
+   status: compatible
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   updated: 2024-07-21
 
  - name: hetarom
    ctan-pkg: xymtex
@@ -3167,11 +3146,10 @@
 
  - name: ibarra
    type: package
-   status: unknown
+   status: compatible
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   updated: 2024-07-21
 
  - name: ifetex
    type: package
@@ -3362,27 +3340,24 @@
 
  - name: josefin
    type: package
-   status: unknown
+   status: compatible
    issues:
    tests: false
-   tasks: needs tests
    updated: 2024-07-18
 
  - name: junicode
    type: package
-   status: unknown
+   status: compatible
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   updated: 2024-07-21
 
  - name: junicodevf
    type: package
-   status: unknown
+   status: compatible
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   updated: 2024-07-21
 
  - name: jurabib
    type: package
@@ -3503,11 +3478,10 @@
  - name: LobsterTwo
    ctan-pkg: lobster2
    type: package
-   status: unknown
+   status: compatible
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   updated: 2024-07-21
 
  - name: l3sys-query
    type: package
@@ -3593,11 +3567,10 @@
 
  - name: lete-sans-math
    type: package
-   status: unknown
+   status: compatible
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   updated: 2024-07-21
 
  - name: letterspace
    ctan-pkg: microtype
@@ -3648,11 +3621,10 @@
 
  - name: libertinust1math
    type: package
-   status: unknown
+   status: compatible
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   updated: 2024-07-21
 
  - name: librebaskerville
    type: package
@@ -3939,11 +3911,10 @@
 
  - name: lucida-otf
    type: package
-   status: unknown
+   status: compatible
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   updated: 2024-07-21
 
  - name: lucidabr
    type: package

--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -76,6 +76,20 @@
    tests: false
    updated: 2024-07-13
 
+ - name: Archivo
+   type: package
+   status: compatible
+   issues:
+   tests: false
+   updated: 2024-07-21
+
+ - name: Arvo
+   type: package
+   status: compatible
+   issues:
+   tests: false
+   updated: 2024-07-21
+
  - name: abraces
    type: package
    status: unknown
@@ -170,6 +184,13 @@
    tests: true
    tasks: more tests needed
    updated: 2024-07-12
+
+ - name: alfaslabone
+   type: package
+   status: compatible
+   issues:
+   tests: false
+   updated: 2024-07-21
 
  - name: algolrevived
    type: package
@@ -417,6 +438,13 @@
    tasks: needs tests
    updated: 2024-07-13
 
+ - name: arev
+   type: package
+   status: compatible
+   issues:
+   tests: false
+   updated: 2024-07-21
+
  - name: arimo
    type: package
    status: compatible
@@ -430,6 +458,13 @@
    supported-through: [phase-III,table]
    issues:
    updated: 2024-07-06
+
+ - name: arsenal
+   type: package
+   status: compatible
+   issues:
+   tests: false
+   updated: 2024-07-21
 
  - name: arydshln
    type: package
@@ -1002,6 +1037,13 @@
    tests: false
    updated: 2024-07-14
 
+ - name: caladea
+   type: package
+   status: compatible
+   issues:
+   tests: false
+   updated: 2024-07-21
+
  - name: calc
    type: package
    status: compatible
@@ -1015,6 +1057,13 @@
    tests: false
    tasks: needs tests
    updated: 2024-07-18
+
+ - name: cantarell
+   type: package
+   status: compatible
+   issues:
+   tests: false
+   updated: 2024-07-21
 
  - name: capt-of
    type: package
@@ -1050,6 +1099,13 @@
    updated: 2024-07-08
 
  - name: carlito
+   type: package
+   status: compatible
+   issues:
+   tests: false
+   updated: 2024-07-21
+
+ - name: cascadia-code
    type: package
    status: compatible
    issues:
@@ -1378,6 +1434,13 @@
    comments: "#90 issue with longtable fixed at the last release"
    issues: [90]
    updated: 2024-07-07
+
+ - name: comfortaa
+   type: package
+   status: compatible
+   issues:
+   tests: false
+   updated: 2024-07-21
 
  - name: comment
    type: package
@@ -1790,6 +1853,13 @@
    issues:
    tests: false
    updated: 2024-07-14
+
+ - name: ebgaramond-maths
+   type: package
+   status: compatible
+   issues:
+   tests: false
+   updated: 2024-07-21
 
  - name: ebproof
    type: package
@@ -2667,6 +2737,13 @@
    tests: false
    updated: 2024-07-13
 
+ - name: Gudea
+   type: package
+   status: compatible
+   issues:
+   tests: false
+   updated: 2024-07-21
+
  - name: gandhi
    type: package
    status: compatible
@@ -2947,6 +3024,13 @@
    updated: 2024-07-14
 
 #------------------------ HHH ----------------------------
+
+ - name: HindMadurai
+   type: package
+   status: compatible
+   issues:
+   tests: false
+   updated: 2024-07-21
 
  - name: hanging
    type: package
@@ -3267,6 +3351,13 @@
    tests: false
    updated: 2024-07-15
 
+ - name: inconsolata-nerd-font
+   type: package
+   status: compatible
+   issues:
+   tests: false
+   updated: 2024-07-21
+
  - name: indentfirst
    type: package
    status: compatible
@@ -3302,6 +3393,13 @@
    tests: false
    tasks: needs tests
    updated: 2024-07-18
+
+ - name: inter
+   type: package
+   status: compatible
+   issues:
+   tests: false
+   updated: 2024-07-21
 
  - name: interval
    type: package
@@ -3602,6 +3700,13 @@
    tests: false
    tasks: needs tests
    updated: 2024-07-15
+
+ - name: lexend
+   type: package
+   status: compatible
+   issues:
+   tests: false
+   updated: 2024-07-21
 
  - name: libertine
    type: package
@@ -3942,6 +4047,13 @@
    tasks: needs tests
    updated: 2024-07-15
 
+ - name: lxfonts
+   type: package
+   status: compatible
+   issues:
+   tests: false
+   updated: 2024-07-21
+
  - name: lyluatex
    type: package
    status: unknown
@@ -3951,6 +4063,13 @@
    updated: 2024-07-18
 
 #------------------------ MMM ----------------------------
+
+ - name: Magra
+   type: package
+   status: compatible
+   issues:
+   tests: false
+   updated: 2024-07-21
 
  - name: MnSymbol
    type: package
@@ -4289,6 +4408,13 @@
    tasks: needs tests
    updated: 2024-07-15
 
+ - name: mlmodern
+   type: package
+   status: compatible
+   issues:
+   tests: false
+   updated: 2024-07-21
+
  - name: montex
    type: package
    status: unknown
@@ -4511,11 +4637,10 @@
 
  - name: newcomputermodern
    type: package
-   status: unknown
+   status: compatible
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   updated: 2024-07-21
 
  - name: newfloat
    type: package
@@ -4593,11 +4718,10 @@
 
  - name: newtxtt
    type: package
-   status: unknown
+   status: compatible
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   updated: 2024-07-21
 
  - name: newunicodechar
    type: package
@@ -4775,6 +4899,13 @@
    tasks: needs tests
    updated: 2024-07-18
 
+ - name: nunito
+   type: package
+   status: compatible
+   issues:
+   tests: false
+   updated: 2024-07-21
+
 #------------------------ OOO ----------------------------
 
  - name: OldStandard
@@ -4783,6 +4914,13 @@
    issues:
    tests: false
    updated: 2024-07-13
+
+ - name: Oswald
+   type: package
+   status: compatible
+   issues:
+   tests: false
+   updated: 2024-07-21
 
  - name: ocgx2
    status: unknown
@@ -4812,6 +4950,13 @@
    tests: false
    tasks: needs tests
    updated: 2024-07-15
+
+ - name: opensans
+   type: package
+   status: compatible
+   issues:
+   tests: false
+   updated: 2024-07-21
 
  - name: optional
    status: unknown
@@ -4861,11 +5006,10 @@
 
  - name: PoiretOne
    type: package
-   status: unknown
+   status: compatible
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   updated: 2024-07-21
 
  - name: PTMono
    ctan-pkg: paratype
@@ -4915,6 +5059,14 @@
    tests: false
    updated: 2024-07-13
 
+ - name: Play
+   ctan-pkg: play-font
+   type: package
+   status: compatible
+   issues:
+   tests: false
+   updated: 2024-07-21
+
  - name: PlayfairDisplay
    ctan-pkg: playfair
    type: package
@@ -4957,11 +5109,10 @@
 
  - name: pagella-otf
    type: package
-   status: unknown
+   status: compatible
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   updated: 2024-07-21
 
  - name: pageslts
    type: package
@@ -5240,29 +5391,26 @@
  - name: plex-mono
    ctan-pkg: plex
    type: package
-   status: unknown
+   status: compatible
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   updated: 2024-07-21
 
  - name: plex-sans
    ctan-pkg: plex
    type: package
-   status: unknown
+   status: compatible
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   updated: 2024-07-21
 
  - name: plex-serif
    ctan-pkg: plex
    type: package
-   status: unknown
+   status: compatible
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   updated: 2024-07-21
 
  - name: pmboxdraw
    type: package
@@ -5389,11 +5537,10 @@
 
  - name: quattrocento
    type: package
-   status: unknown
+   status: compatible
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   updated: 2024-07-21
 
  - name: quotchap
    type: package
@@ -5621,19 +5768,17 @@
 
  - name: schola-otf
    type: package
-   status: unknown
+   status: compatible
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   updated: 2024-07-21
 
  - name: scholax
    type: package
-   status: unknown
+   status: compatible
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   updated: 2024-07-21
 
  - name: scontents
    type: package
@@ -5965,11 +6110,10 @@
 
  - name: spectral
    type: package
-   status: unknown
+   status: compatible
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   updated: 2024-07-21
 
  - name: splitidx
    ctan-pkg: splitindex
@@ -6034,6 +6178,13 @@
    tests: false
    tasks: needs tests
    updated: 2024-07-18
+
+ - name: step
+   type: package
+   status: compatible
+   issues:
+   tests: false
+   updated: 2024-07-21
 
  - name: stfloats
    type: package
@@ -6177,19 +6328,17 @@
 
  - name: TheanoModern
    type: package
-   status: unknown
+   status: compatible
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   updated: 2024-07-21
 
  - name: TheanoOldStyle
    type: package
-   status: unknown
+   status: compatible
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   updated: 2024-07-21
 
  - name: tablefootnote
    type: package
@@ -6335,11 +6484,10 @@
 
  - name: termes-otf
    type: package
-   status: unknown
+   status: compatible
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   updated: 2024-07-21
 
  - name: tex-locale
    type: package
@@ -7031,6 +7179,14 @@
    tests: false
    updated: 2024-07-13
 
+ - name: xcharter-otf
+   ctan-pkg: xcharter-math
+   type: package
+   status: compatible
+   issues:
+   tests: false
+   updated: 2024-07-21
+
  - name: xcite
    type: package
    status: unknown
@@ -7273,11 +7429,10 @@
 
  - name: yfonts-otf
    type: package
-   status: unknown
+   status: compatible
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   updated: 2024-07-21
 
  - name: yhmath
    type: package

--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -391,11 +391,10 @@
  - name: antpolt
    ctan-pkg: poltawski
    type: package
-   status: unknown
+   status: compatible
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-13
+   updated: 2024-07-22
 
  - name: anttor
    ctan-pkg: antt


### PR DESCRIPTION
This marks several packages that do nothing but set up fonts as "compatible" without providing test files, though I did a cursory check with each one. I can add tests if needed. If no more packages should be added to the list please feel free to close, but I figured most of these would get hidden by #216 so no harm in listing their compatibility in the plaintext version.