### PR TITLE
add framed compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -2614,11 +2614,11 @@
 
  - name: framed
    type: package
-   status: unknown
+   status: partially-compatible
+   comments: "Title in `titled-frame` environment is lost."
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   updated: 2024-07-21
 
  - name: french
    ctan-pkg: e-french

--- a/tagging-status/testfiles/framed/framed-01.tex
+++ b/tagging-status/testfiles/framed/framed-01.tex
@@ -1,0 +1,51 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+\usepackage{framed,xcolor}
+
+\colorlet{shadecolor}{red!10}
+\colorlet{TFFrameColor}{blue!10}
+\colorlet{TFTitleColor}{blue}
+
+\begin{document}
+
+text
+
+\begin{framed}
+text
+\end{framed}
+
+\begin{oframed}
+text
+\end{oframed}
+
+\begin{shaded}
+text
+\end{shaded}
+
+\begin{shaded*}
+text
+\end{shaded*}
+
+\begin{leftbar}
+text
+\end{leftbar}
+
+\begin{snugshade}
+text
+\end{snugshade}
+
+\begin{snugshade*}
+text
+\end{snugshade*}
+
+\begin{titled-frame}{Some title}
+text
+\end{titled-frame}
+
+\end{document}


### PR DESCRIPTION
Lists [framed](https://www.ctan.org/pkg/framed) as "partially-compatible" because the frames are correctly ignored but the title in the `titled-frame` environment does not show up in the tags (I'm not sure what the correct tagging would be here). Test file included.