### PR TITLE
add footnpag compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -2557,11 +2557,11 @@
 
  - name: footnpag
    type: package
-   status: unknown
+   status: partially-compatible
+   comments: "Footnote tagging is correct but breaks footnotes in `\\maketitle`."
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   updated: 2024-07-21
 
  - name: forest
    type: package

--- a/tagging-status/testfiles/footnpag/footnpag-01.tex
+++ b/tagging-status/testfiles/footnpag/footnpag-01.tex
@@ -1,0 +1,27 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+\usepackage{footnpag}
+
+\title{footnpag tagging test}
+
+\begin{document}
+
+text\footnote{first note}
+
+text\footnote{second note}
+
+\newpage
+
+text\footnote{third note}
+
+text\footnotemark
+
+\footnotetext{blub}
+
+\end{document}

--- a/tagging-status/testfiles/footnpag/footnpag-02.tex
+++ b/tagging-status/testfiles/footnpag/footnpag-02.tex
@@ -1,0 +1,18 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+\usepackage{footnpag}
+
+\title{footnpag tagging test\footnote{title note}}
+\author{Someone}
+
+\begin{document}
+
+\maketitle
+
+\end{document}


### PR DESCRIPTION
Lists [footnpag](https://www.ctan.org/pkg/footnpag) as "partially-compatible" because the footnote tagging looks correct but it redefines `\maketitle` in a way that breaks footnotes in `\title`. Test files included.