### PR TITLE
add footnoterange compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -2839,7 +2839,7 @@
 
  - name: footnoterange
    type: package
-   status: partially-compatible
+   status: currently-incompatible
    priority: 2
    comments: "Footnote label i-j incorrectly tagged as normal text. hyperref support
               is broken since it relies on the existence of an `Hfootnote` counter

--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -2549,11 +2549,13 @@
 
  - name: footnoterange
    type: package
-   status: unknown
+   status: partially-compatible
+   comments: "Footnote label i-j incorrectly tagged as normal text. hyperref support
+              is broken since it relies on the existence of an `Hfootnote` counter
+              which tagging-version does not provide."
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-14
+   tests: true
+   updated: 2024-07-21
 
  - name: footnpag
    type: package

--- a/tagging-status/testfiles/footnoterange/footnoterange-01.tex
+++ b/tagging-status/testfiles/footnoterange/footnoterange-01.tex
@@ -1,0 +1,22 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{footnoterange}
+
+\begin{document}
+
+text\footnote{normal footnote}
+
+text
+\begin{footnoterange}
+\footnote{first note}%
+\footnote{second note}%
+\footnote{third note}%
+\end{footnoterange}
+
+\end{document}

--- a/tagging-status/testfiles/footnoterange/footnoterange-02.tex
+++ b/tagging-status/testfiles/footnoterange/footnoterange-02.tex
@@ -1,0 +1,30 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{footnoterange}
+\usepackage{hyperref}
+
+\begin{document}
+
+text\footnote{normal footnote}
+
+text
+\begin{footnoterange}
+\footnote{first note}%
+\footnote{second note}%
+\footnote{third note}%
+\end{footnoterange}
+
+text
+\begin{footnoterange*}
+\footnote{first note}%
+\footnote{second note}%
+\footnote{third note}%
+\end{footnoterange*}
+
+\end{document}


### PR DESCRIPTION
Lists [footnoterange](https://www.ctan.org/pkg/footnoterange) as "partially-compatible" since the footnote label "i-j" is incorrectly tagged as normal text and the hyperref support is broken since it relies on the existence of an `Hfootnote` counter which is not provided when the tagging code is loaded.