### PR TITLE
add adjmulticol compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -149,11 +149,10 @@
 
  - name: adjmulticol
    type: package
-   status: unknown
+   status: compatible
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   updated: 2024-07-21
 
  - name: adjustbox
    type: package

--- a/tagging-status/testfiles/adjmulticol/adjmulticol-01.tex
+++ b/tagging-status/testfiles/adjmulticol/adjmulticol-01.tex
@@ -1,0 +1,32 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{book}
+
+\usepackage{adjmulticol}
+\usepackage{kantlipsum}
+
+\begin{document}
+
+\kant[1]
+\begin{adjmulticols}{2}{1cm}{-1cm}
+\kant[2-5]
+text\footnote{footnote in adjmulticols}
+\end{adjmulticols}
+\kant[6]
+
+\newpage
+
+% compare with
+\kant[1]
+\begin{multicols}{2}
+\kant[2-5]
+text\footnote{footnote in multicols}
+\end{multicols}
+\kant[6]
+
+\end{document}


### PR DESCRIPTION
Lists [adjmulticol](https://www.ctan.org/pkg/adjmulticol) as "compatible" and includes a test file. The tagging of `adjmulticols` is the same as that of `multicols`.