### PR TITLE
add autoaligne compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -531,11 +531,13 @@
 
  - name: autoaligne
    type: package
-   status: unknown
+   status: partially-compatible
+   supported-through: [phase-III,math]
+   comments: "Errors with vertical alignment types `h` and `b`.
+              Use of math tagging currently requires support from external tools."
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   updated: 2024-07-21
 
  - name: avant
    ctan-pkg: psnfss

--- a/tagging-status/testfiles/autoaligne/autoaligne-01.tex
+++ b/tagging-status/testfiles/autoaligne/autoaligne-01.tex
@@ -1,0 +1,60 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+
+\usepackage{autoaligne}
+
+\begin{document}
+
+\autoaligne{
+  x-3y+z=2-i\\
+  5x+y-6z=1+5i\\
+  -x+y-z=-3+i}
+
+\bigskip
+
+\autoaligne{
+x =a++c\\
++y =+b-c\\
++ +z=+-4c}
+
+\bigskip
+
+\autoaligne[*g]{
+a+\sqrt2b=0\\
+a+b=10\sqrt2}
+
+\bigskip
+
+Normal \autoaligne{a+2b=1\\a-b=2} \qquad
+\aavcoeff{1.75}étendu \autoaligne{a+2b=1\\a-b=2} 
+
+\aavcoeff{1}
+\bigskip
+
+\bigskip
+
+\def\determinant#1{\begingroup
+\definirseparateurs{\\}{ }{}%
+\definirespacements{.75em}{}%
+\hbox{$\left|\autoaligne[*c]{#1}\right|$}%
+\endgroup
+}
+Un déterminant \determinant{a -b 0\\b 0 a\\0 -a -b}
+
+\bigskip
+
+\def\determinant#1{\begingroup
+\definirseparateurs{\\}{ }{}%
+\definirespacements[3pt,3pt]{.75em}{}%
+\hbox{$\left|\autoaligne[*c]{#1}\right|$}%
+\endgroup
+}
+Un déterminant \determinant{a -b 0\\b 0 a\\0 -a -b}
+
+\end{document}

--- a/tagging-status/testfiles/autoaligne/autoaligne-02.tex
+++ b/tagging-status/testfiles/autoaligne/autoaligne-02.tex
@@ -1,0 +1,31 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math}
+  }
+\documentclass{article}
+\usepackage{autoaligne}
+
+\begin{document}
+
+% this is okay
+Alignement c :
+\autoaligne(c){4=1+1+1+1\\=1+1+2\\=2+2\\=3+1}\medbreak
+
+% these error
+Alignement h :
+\autoaligne(h){4=1+1+1+1\\=1+1+2\\=2+2\\=3+1}\medbreak
+%Alignement b :
+%\autoaligne(b){4=1+1+1+1\\=1+1+2\\=2+2\\=3+1}
+
+%Un calcul :
+%\definirseparateurs{\\}{+||-}{}
+%\autoaligne[*c](h){
+%15+2\times3-4\times5\\
+%15+6-20\\
+%21+-20\\
+%1}
+
+\end{document}


### PR DESCRIPTION
Lists [autoaligne](https://www.ctan.org/pkg/autoaligne) as "partially-compatible" and supported by "phase-III,math". It is only partially compatible because the vertical alignment types `h` and `b` produce a `! Missing $ inserted.` error. Looking at the package code, I think this is because of a use of `\vtop` and `\vbox` in a way the math tagging code does not like. Test files with working and failing examples included.