### PR TITLE
add cprotect compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -1441,10 +1441,10 @@
 
  - name: cprotect
    type: package
-   status: unknown
+   status: currently-incompatible
+   comments: "Breaks TOC and errors in math mode."
    issues:
-   tests: false
-   tasks: needs tests
+   tests: true
    updated: 2024-07-18
 
  - name: crop

--- a/tagging-status/testfiles/cprotect/cprotect-01.tex
+++ b/tagging-status/testfiles/cprotect/cprotect-01.tex
@@ -1,0 +1,33 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+
+\usepackage{cprotect,amsmath}
+
+\begin{document}
+
+\tableofcontents % comment/uncomment
+
+\cprotect\section{Include \verb-\verb- anywhere!}
+
+\section{Normal text}
+
+text\cprotect\footnote{Like this one: \verb-!@#$%^&*()_+-.}
+
+\cprotect\section{Title \cprotect\emph{emphasized} word}
+
+\cprotect[om]\section[Short title \verb-&^-]{Long title \verb-&^%$-}
+
+\cprotEnv\begin{align}
+x&=\begin{cases}
+1 &\text{if }\verb"@#%^&*"\\
+2 &\text{otherwise}
+\end{cases}
+\end{align}
+
+\end{document}

--- a/tagging-status/testfiles/cprotect/cprotect-02.tex
+++ b/tagging-status/testfiles/cprotect/cprotect-02.tex
@@ -1,0 +1,22 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+
+\usepackage{cprotect}
+
+\begin{document}
+
+% this fails
+$\cprotect\sqrt{\verb!abc!}$
+
+% as does this
+\[
+\cprotect[om]\sqrt[\verb-%c-]{\cprotect[mm]\frac{\verb-%a-}{\verb-%b-}}
+\]
+
+\end{document}


### PR DESCRIPTION
Lists [cprotect](https://www.ctan.org/pkg/cprotect) as "currently-incompatible" as it breaks the TOC (first test file) and errors in math mode (second test file).