### PR TITLE
add capt-of compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -1013,11 +1013,11 @@
 
  - name: capt-of
    type: package
-   status: unknown
+   status: currently-incompatible
+   comments: "Incorrect reading order of captions."
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   updated: 2024-07-22
 
  - name: captdef
    type: package

--- a/tagging-status/testfiles/capt-of/capt-of-01.tex
+++ b/tagging-status/testfiles/capt-of/capt-of-01.tex
@@ -1,0 +1,40 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,table,title,firstaid}
+  }
+
+\documentclass{article}
+\usepackage{capt-of,graphicx}
+\usepackage{hyperref}
+
+\title{capt-of tagging test}
+
+\begin{document}
+
+\listoffigures
+
+\section{Body}
+body text
+\begin{center}
+\includegraphics[alt={alt text}]{example-image}
+\captionof{figure}[short capt-of text]{my caption text}
+\end{center}
+
+more body text
+\begin{center}
+\includegraphics[alt={alt text}]{example-image}
+\captionof{figure}[another short capt-of text]{more caption text}
+\end{center}
+
+% compare with
+body text
+\begin{figure}
+\centering
+\includegraphics[alt={alt text}]{example-image}
+\caption[short caption text]{my caption text}
+\end{figure}
+
+\end{document}


### PR DESCRIPTION
Lists [capt-of](https://www.ctan.org/pkg/capt-of) as currently-incompatible and adds a test file. The reading order of the captions is wrong. Even though the caption is not within a float, one would expect it to be immediately before or after the image or table it is attached to, but it always appears at the beginning of the \<Part\>. If multiple are contained within a single \<Part\>, then they seem to appear in reverse numerical order. You can see this by removing the empty line before `more body text` in the test file.