### PR TITLE
add captdef compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -1021,11 +1021,11 @@
 
  - name: captdef
    type: package
-   status: unknown
+   status: currently-incompatible
+   comments: "Incorrect reading order of captions."
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   updated: 2024-07-22
 
  - name: captcont
    type: package

--- a/tagging-status/testfiles/captdef/captdef-01.tex
+++ b/tagging-status/testfiles/captdef/captdef-01.tex
@@ -1,0 +1,39 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,table,title,firstaid}
+  }
+
+\documentclass{article}
+\usepackage{captdef,graphicx}
+\usepackage{hyperref}
+
+\title{captdef tagging test}
+
+\begin{document}
+
+\listoffigures
+
+\section{Body}
+body text
+\begin{center}
+\includegraphics[alt={alt text}]{example-image}
+\figcaption[short captdef text]{my caption text}
+\end{center}
+more body text
+\begin{center}
+\includegraphics[alt={alt text}]{example-image}
+\figcaption[another short captdef text]{more caption text}
+\end{center}
+
+% compare with
+body text
+\begin{figure}
+\centering
+\includegraphics[alt={alt text}]{example-image}
+\caption[short caption text]{my caption text}
+\end{figure}
+
+\end{document}


### PR DESCRIPTION
Lists [captdef](https://www.ctan.org/pkg/captdef) as "currently-incompatible" and gives a test file. The issue is the same as that of capt-of explained in #242.