### PR TITLE
add mathtools compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -4129,9 +4129,12 @@
 
  - name: mathtools
    type: package
-   status: unknown
-   tasks: needs tests
-   updated: 2024-07-06
+   status: partially-compatible
+   supported-through: [phase-III,math]
+   comments: "`mathic` key produces errors. Use of math tagging currently requires support from external tools."
+   issues: [139]
+   tests: true
+   updated: 2024-07-22
 
  - name: mattens
    type: package

--- a/tagging-status/testfiles/mathtools/mathtools-01.tex
+++ b/tagging-status/testfiles/mathtools/mathtools-01.tex
@@ -1,0 +1,56 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{mathtools}
+
+\title{mathtools tagging test - Fine-tuning mathematical layout}
+
+\begin{document}
+
+\[
+X = \sum_{\mathclap{1\le i\le j\le n}} X_{ij}
+\]
+
+\begin{equation}\label{eq:mathclap}
+\sum_{\mathclap{a^2<b^2<c}}\qquad
+\sum_{a^2<b^2<c}
+\end{equation}
+
+\begin{equation*}\label{eq:mathclap-b}
+\sum_{\crampedclap{a^2<b^2<c}}
+\tag{\ref{eq:mathclap}*}
+\end{equation*}
+
+\[
+\sum_{\crampedsubstack{a^2<b^2<c}}\qquad
+\sum_{a^2<b^2<c}
+\]
+
+\[
+V = \sum_{1\le i\le j\le n}^{\infty} V_{ij} \quad
+X = \smashoperator{\sum_{1\le i\le j\le n}^{3456}} X_{ij} \quad
+Y = \smashoperator[r]{\sum\limits_{1\le i\le j\le n}} Y_{ij} \quad
+Z = \smashoperator[l]{\mathop{T}_{1\le i\le j\le n}} Z_{ij}
+\]
+
+\[
+\text{a)} \adjustlimits\lim_{n\to\infty} \max_{p\ge n} \quad
+\text{b)} \adjustlimits\lim_{n\to\infty} \max_{p^2\ge n} \quad
+\text{c)} \adjustlimits\lim_{n\to\infty} \sup_{p^2\ge nK} \quad
+\text{d)} \adjustlimits\limsup_{n\to\infty} \max_{p\ge n}
+\]
+
+\noindent\rule\textwidth{1pt}
+\begin{align*} A &= B \end{align*}
+\noindent\rule\textwidth{1pt}
+\begin{align*}
+\SwapAboveDisplaySkip
+A &= B
+\end{align*}
+
+\end{document}

--- a/tagging-status/testfiles/mathtools/mathtools-02.tex
+++ b/tagging-status/testfiles/mathtools/mathtools-02.tex
@@ -1,0 +1,52 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{mathtools}
+
+\title{mathtools tagging test - Controlling tags}
+
+\newtagform{brackets}{[}{]}
+\newtagform{brackets2}[\textbf]{[}{]}
+
+\begin{document}
+
+\begin{quote}\normalfont\itshape
+\begin{equation*}
+a=b \label{eq:example}\tag*{Q\&A}
+\end{equation*}
+See \ref{eq:example} or is it better with \refeq{eq:example}?
+\end{quote}
+
+\usetagform{brackets2}
+\begin{equation}
+E \neq m c^3
+\end{equation}
+
+\mathtoolsset{showonlyrefs,showmanualtags}
+\usetagform{brackets}
+\begin{gather}
+a=a \label{eq:a} \\
+b=b \label{eq:b} \tag{**}
+\end{gather}
+This should refer to the equation containing $a=a$: \eqref{eq:a}.
+Then a switch of tag forms.
+\usetagform{default}
+\begin{align}
+c&=c \label{eq:c} \\
+d&=d \label{eq:d}
+\end{align}
+This should refer to the equation containing $d=d$: \eqref{eq:d}.
+\begin{equation}
+e=e
+\end{equation}
+Back to normal.\mathtoolsset{showonlyrefs=false}
+\begin{equation}
+f=f
+\end{equation}
+
+\end{document}

--- a/tagging-status/testfiles/mathtools/mathtools-03.tex
+++ b/tagging-status/testfiles/mathtools/mathtools-03.tex
@@ -1,0 +1,23 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{mathtools}
+
+\title{mathtools tagging test - Extensible symbols}
+
+\begin{document}
+
+\[
+A \xLeftarrow[under]{over} B
+\]
+
+$\underbracket{foo\ bar}_{baz}$
+
+$\overbracket{foo\ bar}^{baz}$
+
+\end{document}

--- a/tagging-status/testfiles/mathtools/mathtools-04.tex
+++ b/tagging-status/testfiles/mathtools/mathtools-04.tex
@@ -1,0 +1,133 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{mathtools}
+
+\title{mathtools tagging test - New mathematical building blocks}
+
+\NewDocumentCommand\Framebox{ o O{c} m }{%
+  \IfNoValueTF{#1}{%
+    \framebox{\footnotesize\strut #3}%
+  }{%
+    \framebox[#1][#2]{\footnotesize\strut #3}%
+  }%
+}
+
+\begin{document}
+
+\[
+\begin{pmatrix*}[r]
+-1 & 3 \\
+2 & -4
+\end{pmatrix*}
+\]
+
+\[
+\begin{bsmallmatrix} a & -b \\ -c & d \end{bsmallmatrix}
+\begin{bsmallmatrix*}[r] a & -b \\ -c & d \end{bsmallmatrix*}
+\]
+
+\[
+A = \begin{multlined}[t]
+\Framebox[4cm]{first} \\
+\Framebox[4cm]{last}
+\end{multlined} B
+\]
+
+\[
+\begin{multlined}
+\Framebox[.65\columnwidth]{First line} \\
+\Framebox[.5\columnwidth]{Second line} \\
+\shoveleft{L+E+F+T} \\
+\shoveright{R+I+G+H+T} \\
+\shoveleft[1cm]{L+E+F+T} \\
+\shoveright[\widthof{$R+I+G+H+T$}]{R+I+G+H+T} \\
+\Framebox[.65\columnwidth]{Last line}
+\end{multlined}
+\]
+
+\[
+\begin{multlined}[b][7cm]
+\Framebox[4cm]{first} \\
+\Framebox[4cm]{last}
+\end{multlined} = B
+\]
+
+\[
+\begin{dcases}
+E = m c^2 & c \approx 3.00\times 10^{8}\,\mathrm{m}/\mathrm{s} \\
+\int x-3\, dx & \text{Integral is display style}
+\end{dcases}
+\]
+
+\[
+a= \begin{dcases*}
+E = m c^2 & Nothing to see here \\
+\int x-3\, dx & Integral is display style
+\end{dcases*}
+\]
+
+\[
+\begin{rcases*}
+x^2 & for $x>0$\\
+x^3 & else
+\end{rcases*} \quad \Rightarrow \cdots
+\]
+
+\begin{align*}
+\MoveEqLeft \Framebox[10cm][c]{Long first line}\\
+& = \Framebox[6cm][c]{2nd line}\\
+& \leq \dots
+\end{align*}
+
+\begin{align*}
+\MoveEqLeft[3] \Framebox[10cm][c]{Part 1}\\
+= {} & \Framebox[8cm][c]{2nd line}\\
+& + \Framebox[4cm][c]{last part}
+\end{align*}
+
+\begin{align*}
+\Aboxed{ f(x) & = \int h(x)\, dx} \\
+& = g(x)
+\end{align*}
+
+\begin{align*}
+\setlength\fboxsep{1em}
+\Aboxed{ f(x) &= 0 } & \Aboxed{ g(x) &= b} \\
+\Aboxed{ h(x) } & \Aboxed{ i(x) }
+\end{align*}
+
+\begin{alignat}{2}
+&& \framebox[1.5cm]{} &= \framebox[3cm]{}\\
+\ArrowBetweenLines % \Updownarrow is the default
+&& \framebox[1.5cm]{} &= \framebox[2cm]{}
+\end{alignat}
+
+\begin{alignat*}{2}
+\framebox[1.5cm]{} &= \framebox[3cm]{} &&\\
+\ArrowBetweenLines*[\Downarrow]
+\framebox[1.5cm]{} &= \framebox[2cm]{} &&
+\end{alignat*}
+
+\begin{align*}
+a &= b \\
+& \vdotswithin{=} \\
+& = c \\
+\shortvdotswithin{=}
+& = d
+\end{align*}
+
+\begin{alignat*}{3}
+A&+ B &&= C &&+ D \\
+\MTFlushSpaceAbove
+&\vdotswithin{+} &&&& \vdotswithin{+}
+\MTFlushSpaceBelow
+C &+ D &&= Y &&+K
+\end{alignat*}
+
+\end{document}

--- a/tagging-status/testfiles/mathtools/mathtools-05.tex
+++ b/tagging-status/testfiles/mathtools/mathtools-05.tex
@@ -1,0 +1,28 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{mathtools}
+
+\title{mathtools tagging test - Intertext and short intertext}
+
+\begin{document}
+
+\begin{align}
+a&=b \shortintertext{Some text}
+c&=d \intertext{Some text}
+e&=f
+\end{align}
+
+\mathtoolsset{above-shortintertext-sep=30pt,above-intertext-sep=50pt}
+
+\begin{align}
+a&=b \shortintertext{Some text}
+c&=d \intertext{Some text}
+e&=f
+\end{align}
+\end{document}

--- a/tagging-status/testfiles/mathtools/mathtools-06.tex
+++ b/tagging-status/testfiles/mathtools/mathtools-06.tex
@@ -1,0 +1,28 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{mathtools,amssymb}
+
+\title{mathtools tagging test - Special symbols}
+
+\begin{document}
+
+\[
+  a := b \simcolon c \colondash d
+\]
+\mathtoolsset{centercolon}
+\[
+  a := b
+\]
+$\nuparrow$
+
+$\ndownarrow$
+
+$\bigtimes$
+
+\end{document}

--- a/tagging-status/testfiles/mathtools/mathtools-07.tex
+++ b/tagging-status/testfiles/mathtools/mathtools-07.tex
@@ -1,0 +1,25 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{mathtools}
+
+\title{mathtools tagging test - Mathematics within italic text}
+
+\begin{document}
+
+% errors
+\begin{quote}\itshape
+Compare these lines: \par
+\mathtoolsset{mathic} % or \mathtoolsset{mathic=true}
+Subset of \(V\) and subset of \(A\). \par
+\mathtoolsset{mathic=false}
+Subset of \(V\) and subset of \(A\).
+\par
+\end{quote}
+
+\end{document}

--- a/tagging-status/testfiles/mathtools/mathtools-08.tex
+++ b/tagging-status/testfiles/mathtools/mathtools-08.tex
@@ -1,0 +1,23 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{mathtools}
+
+\title{mathtools tagging test - Left sub/superscripts}
+
+\begin{document}
+
+\[
+{}^{4}_{12}\mathbf{C}^{5+}_{2} \quad
+\prescript{14}{2}{\mathbf{C}}^{5+}_{2} \quad
+\prescript{4}{12}{\mathbf{C}}^{5+}_{2} \quad
+\prescript{14}{}{\mathbf{C}}^{5+}_{2} \quad
+\prescript{}{2}{\mathbf{C}}^{5+}_{2}
+\]
+
+\end{document}

--- a/tagging-status/testfiles/mathtools/mathtools-09.tex
+++ b/tagging-status/testfiles/mathtools/mathtools-09.tex
@@ -1,0 +1,28 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{mathtools}
+
+\title{mathtools tagging test - Spreading equations}
+
+\begin{document}
+
+\begin{spreadlines}{20pt}
+Large spaces between the lines.
+\begin{gather}
+a=b\\
+c=d
+\end{gather}
+\end{spreadlines}
+Back to normal spacing.
+\begin{gather}
+a=b\\
+c=d
+\end{gather}
+
+\end{document}

--- a/tagging-status/testfiles/mathtools/mathtools-10.tex
+++ b/tagging-status/testfiles/mathtools/mathtools-10.tex
@@ -1,0 +1,35 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{mathtools}
+
+\title{mathtools tagging test - Gathered environments}
+
+\begin{document}
+
+\begin{equation}
+\begin{lgathered}
+x=1,\quad x+1=2 \\
+y=2
+\end{lgathered}
+\end{equation}
+
+\newcounter{steplinecnt}
+\newcommand\stepline{\stepcounter{steplinecnt}\thesteplinecnt}
+\newgathered{stargathered}
+{\llap{\stepline}$*$\quad\hfil}% \hfil for centering
+{\hfil}% \hfil for centering
+{\setcounter{steplinecnt}{0}}% reset counter
+\begin{gather}
+\begin{stargathered}
+x=1,\quad x+1=2 \\
+y=2
+\end{stargathered}
+\end{gather}
+
+\end{document}

--- a/tagging-status/testfiles/mathtools/mathtools-11.tex
+++ b/tagging-status/testfiles/mathtools/mathtools-11.tex
@@ -1,0 +1,34 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{mathtools}
+
+\title{mathtools tagging test - Split fractions}
+
+\begin{document}
+
+\[
+\frac{
+\splitfrac{xy + xy + xy + xy + xy}
+{
+\splitfrac{xy + xy + xy + xy + xy}
+{+ xy + xy + xy + xy}
+}
+}
+{z}
+=\frac{
+\splitfrac{xy + xy + xy + xy + xy}
+{
+\splitfrac{\mathstrut xy + xy + xy + xy + xy}
+{+ xy + xy + xy + xy}
+}
+}
+{z}
+\]
+
+\end{document}

--- a/tagging-status/testfiles/mathtools/mathtools-12.tex
+++ b/tagging-status/testfiles/mathtools/mathtools-12.tex
@@ -1,0 +1,27 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{mathtools}
+
+\title{mathtools tagging test - Variable math strut}
+
+\begin{document}
+
+\[ \begin{cases*}
+\frac{ \frac{ x-1 }{ x-\sin x } }{ \sqrt{ 1-x } } & $x>0$ \\
+0 & otherwise
+\end{cases*}
+\qquad\text{vs.}\qquad
+\begin{cases*}
+\frac{ \frac{ \xmathstrut{0.1} x-1 }
+{ \xmathstrut{0.25} x-\sin x } }
+{\xmathstrut{0.4} \sqrt{ 1-x } } & $x>0$ \\
+0 & otherwise
+\end{cases*} \]
+
+\end{document}


### PR DESCRIPTION
Lists [mathtools](https://www.ctan.org/pkg/mathtools) as "partially-compatible" and adds several test files, each corresponding to a subsection of the documentation. Currently only mathtools-07.tex errors and is logged in #139. For the rest the tagging looks okay but of course it should be looked at closely by someone more knowledgeable than me.