### PR TITLE
add incompatible packages

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -765,12 +765,11 @@
 
  - name: biblist
    type: package
-   status: unknown
+   status: currently-incompatible
    priority: 2
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-14
+   issues: [194]
+   tests: true
+   updated: 2024-07-23
 
  - name: bibtopic
    type: package
@@ -1732,12 +1731,11 @@
 
  - name: dblfnote
    type: package
-   status: unknown
+   status: currently-incompatible
    priority: 9
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   issues: [225]
+   tests: true
+   updated: 2024-07-23
 
  - name: dcolumn
    type: package
@@ -2709,12 +2707,11 @@
 
  - name: fonttable
    type: package
-   status: unknown
+   status: currently-incompatible
    priority: 9
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   issues: [224]
+   tests: true
+   updated: 2024-07-23
 
  - name: footmisc
    type: package
@@ -5026,6 +5023,14 @@
    tests: false
    updated: 2024-07-15
 
+ - name: niceframe
+   type: package
+   status: currently-incompatible
+   priority: 9
+   issues: [220]
+   tests: true
+   updated: 2024-07-23
+
  - name: nicematrix
    type: package
    status: currently-incompatible
@@ -5406,12 +5411,11 @@
 
  - name: paracol
    type: package
-   status: unknown
+   status: currently-incompatible
    priority: 9
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   issues: [227]
+   tests: true
+   updated: 2024-07-23
 
  - name: paralist
    type: package
@@ -8114,12 +8118,11 @@
 
  - name: leaflet
    type: class
-   status: unknown
+   status: currently-incompatible
    priority: 2
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-06
+   issues: [239]
+   tests: true
+   updated: 2024-07-23
 
  - name: letter
    type: class

--- a/tagging-status/testfiles/biblist/biblist-01.tex
+++ b/tagging-status/testfiles/biblist/biblist-01.tex
@@ -1,0 +1,19 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,table,title,firstaid}
+  }
+
+\documentclass{article}
+\usepackage{biblist}
+
+\title{biblist tagging test}
+
+\begin{document}
+
+\bibliographystyle{amsalpha}
+\bibliography{typography}
+
+\end{document}

--- a/tagging-status/testfiles/dblfnote/dblfnote-01.tex
+++ b/tagging-status/testfiles/dblfnote/dblfnote-01.tex
@@ -1,0 +1,21 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+
+\usepackage{dblfnote}
+\usepackage{kantlipsum}
+
+\title{dblfnote tagging test}
+
+\begin{document}
+
+\kant[1-3]
+
+text\footnote{\kant[1]}
+
+\end{document}

--- a/tagging-status/testfiles/fonttable/fonttable-01.tex
+++ b/tagging-status/testfiles/fonttable/fonttable-01.tex
@@ -1,0 +1,17 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{fonttable}
+
+\title{fonttable tagging test}
+
+\begin{document}
+
+\fonttable{cmr10}
+
+\end{document}

--- a/tagging-status/testfiles/leaflet/leaflet-01.tex
+++ b/tagging-status/testfiles/leaflet/leaflet-01.tex
@@ -1,0 +1,14 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{leaflet}
+
+\begin{document}
+
+text
+
+\end{document}

--- a/tagging-status/testfiles/niceframe/niceframe-01.tex
+++ b/tagging-status/testfiles/niceframe/niceframe-01.tex
@@ -1,0 +1,21 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+\usepackage{niceframe}
+
+\title{niceframe tagging test}
+
+\begin{document}
+
+\niceframe{text}
+
+%\curlyframe{text}
+
+%\artdecoframe{text}
+
+\end{document}

--- a/tagging-status/testfiles/paracol/paracol-01.tex
+++ b/tagging-status/testfiles/paracol/paracol-01.tex
@@ -1,0 +1,21 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{paracol}
+
+\title{paracol tagging test}
+
+\begin{document}
+
+\begin{paracol}{2}
+some text
+\switchcolumn
+more text
+\end{paracol}
+
+\end{document}


### PR DESCRIPTION
Lists biblist, dblfnote, fonttable, niceframe, paracol, and leaflet as "currently-incompatible", adds test files for each, and links to the corresponding issues.