### PR TITLE
remove duplicate entry

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -1078,6 +1078,7 @@
  - name: CooperHewitt
    type: package
    status: compatible
+   priority: 9
    issues:
    tests: false
    updated: 2024-07-21
@@ -1575,15 +1576,6 @@
    updated: 2024-07-18
 
  - name: countriesofeurope
-   type: package
-   status: unknown
-   priority: 9
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
-
- - name: cooperhewitt
    type: package
    status: unknown
    priority: 9


### PR DESCRIPTION
Removes the duplicate entry for [CooperHewitt](https://www.ctan.org/pkg/cooperhewitt). The actual file name is `CooperHewitt.sty` (with caps).