### PR TITLE
add cfr-lm compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -1245,12 +1245,12 @@
 
  - name: cfr-lm
    type: package
-   status: unknown
+   status: currently-compatible
+   comments: "Inserts or removes spaces between certain letter combinations in tagged text."
    priority: 9
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   updated: 2024-07-23
 
  - name: chancery
    type: package

--- a/tagging-status/testfiles/cfr-lm/cfr-lm-01.tex
+++ b/tagging-status/testfiles/cfr-lm/cfr-lm-01.tex
@@ -1,0 +1,48 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,table,title,firstaid}
+  }
+
+\documentclass{article}
+\usepackage{cfr-lm}
+
+\title{cfr-lm tagging test}
+
+\begin{document}
+
+normal text
+
+Semi-bold and \textsl{semi-bold oblique} serif
+
+\textsf{\fontseries{sbc}\selectfont Semi-bold condensed sans}
+
+\textsb{Semi-bold and \textsl{semi-bold oblique} serif}
+
+\texttt{\textlg{Light typewriter}}
+
+\texttt{Light typewriter}
+
+\textsi{I always avoid a kangaroo.}
+
+\textui{Nobody is despised who can manage a crocodile.}
+
+\textl{123456789}
+
+\textsf{\textl{123456789}}
+
+\texttt{\textl{123456789}}
+
+\texttt{This is variable width typewriter.}
+
+\texttm{This is monowidth typewriter} \texttv{except this bit at the end.}
+
+\normalfont\textti{Kinky Querulous Rhinos X-Ray Exultant Risque Zebras}
+
+\textti{\textsl{Kinky Querulous Rhinos X-Ray Exultant Risque Zebras}}
+
+\zeroslash
+
+\end{document}


### PR DESCRIPTION
Lists [cfr-lm](https://www.ctan.org/pkg/cfr-lm) as "currently-incompatible" because it adds or removes spaces between certain letter combinations at the pdf level (in tags, copy/paste) but not in the output. Test file included.

Edit: Hmm this is actually a problem with pdflatex. Will close for now.