### PR TITLE
add chemarr compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -1316,12 +1316,13 @@
 
  - name: chemarr
    type: package
-   status: unknown
+   status: compatible
+   supported-through: [phase-III,math]
+   comments: "Use of math tagging currently requires support from external tools."
    priority: 9
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   updated: 2024-07-23
 
  - name: chemfig
    type: package

--- a/tagging-status/testfiles/chemarr/chemarr-01.tex
+++ b/tagging-status/testfiles/chemarr/chemarr-01.tex
@@ -1,0 +1,26 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,table,title,firstaid}
+  }
+
+\documentclass{article}
+\usepackage{chemarr}
+
+\title{chemarr tagging test}
+
+\begin{document}
+
+text
+\xrightleftharpoons[\text{below}]{\text{above}}
+text
+
+\[
+  A
+  \xrightleftharpoons[T \geq 400\,\mathrm{K}]{p > 10\,\mathrm{hPa}}
+  B
+\]
+
+\end{document}


### PR DESCRIPTION
Lists [chemarr](https://www.ctan.org/pkg/chemarr) as compatible and adds a test file. It is correctly tagged as Formula even when used in text mode.