### PR TITLE
add postnotes compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -2105,7 +2105,7 @@
  - name: endnotes
    type: package
    status: partially-compatible
-   comments: "Does not error but tagging is not ideal."
+   comments: "Does not error but `\\endnote`s are not tagged as \<Note\>s."
    issues: [135]
    tests: true
    updated: 2024-07-17
@@ -5844,12 +5844,12 @@
 
  - name: postnotes
    type: package
-   status: unknown
+   status: partially-compatible
    priority: 9
+   comments: "Does not error but `\\postnote`s are not tagged as \<Note\>s."
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   updated: 2024-07-23
 
  - name: prelim2e
    type: package

--- a/tagging-status/testfiles/postnotes/postnotes-01.tex
+++ b/tagging-status/testfiles/postnotes/postnotes-01.tex
@@ -1,0 +1,22 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{book}
+\usepackage{postnotes}
+\usepackage{hyperref}
+\begin{document}
+\chapter{First chapter}
+\postnotesection{\section*{Notes to chapter \pnthechapter}}
+Foo.\postnote{Foo note.}
+Bar.\postnote{Bar note.}
+\chapter{Second chapter}
+\postnotesection{\section*{Notes to chapter \pnthechapter}}
+\setcounter{postnote}{0}
+Baz.\postnote{Baz note.}
+Boo.\postnote{Boo note.}
+\printpostnotes
+\end{document}

--- a/tagging-status/testfiles/postnotes/postnotes-02.tex
+++ b/tagging-status/testfiles/postnotes/postnotes-02.tex
@@ -1,0 +1,22 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{book}
+\usepackage{postnotes}
+\postnotesetup{heading={\section*{\pntitle}}}
+\usepackage{hyperref}
+\begin{document}
+\chapter{First chapter}
+Foo.\postnote{Foo note.}
+Bar.\postnote{Bar note.}
+\printpostnotes
+\chapter{Second chapter}
+\setcounter{postnote}{0}
+Baz.\postnote{Baz note.}
+Boo.\postnote{Boo note.}
+\printpostnotes
+\end{document}

--- a/tagging-status/testfiles/postnotes/postnotes-03.tex
+++ b/tagging-status/testfiles/postnotes/postnotes-03.tex
@@ -1,0 +1,25 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{book}
+\usepackage{postnotes}
+\usepackage{hyperref}
+\begin{document}
+\chapter{First chapter}
+\postnote{1}
+\postnote{2}
+\begin{table}[p]
+\caption{Table}
+Table.\postnote[mark=5]{3}
+\end{table}
+\postnote{4}
+\postnote{5}
+\stepcounter{postnote}
+\clearpage
+\postnote{6}
+\printpostnotes
+\end{document}

--- a/tagging-status/testfiles/postnotes/postnotes-04.tex
+++ b/tagging-status/testfiles/postnotes/postnotes-04.tex
@@ -1,0 +1,22 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{book}
+\usepackage{postnotes}
+\usepackage{hyperref}
+\begin{document}
+\chapter{First chapter}
+\postnotesection{\section*{Notes to chapter \pnthechapter}}
+Foo.\postnote{Foo note.}
+Bar.\postnote{Bar note.}
+\chapter{Second chapter}
+\postnotesection{\section*{Notes to chapter \pnthechapter}}
+\setcounter{postnote}{0}
+Baz.\postnote{Baz note.}
+Boo.\postnote{Boo note.}
+\printpostnotes
+\end{document}


### PR DESCRIPTION
Lists [postnotes](https://www.ctan.org/pkg/postnotes) as "partially-compatible" because it does not error but the `\postnote`s are not tagged as \<Note\>s. A similar comment was added to the endnotes entry. Multiple test files included.