### PR TITLE
change sillypage to compatible

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -6496,11 +6496,11 @@
 
  - name: sillypage
    type: package
-   status: partially-compatible
-   comments: "Images are missing alt text."
+   status: compatible
+   comments:
    issues:
    tests: true
-   updated: 2024-07-18
+   updated: 2024-07-24
 
  - name: simpleicons
    type: package


### PR DESCRIPTION
Compatibility added with [sillypage \#16](https://github.com/cereda/sillypage/pull/16). It's missing a priority entry but I'll let someone else decide how important this silly package is :-)