### PR TITLE
add gentombow compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -3009,12 +3009,11 @@
 
  - name: gentombow
    type: package
-   status: unknown
+   status: compatible
    priority: 9
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   updated: 2024-07-24
 
  - name: geometry
    type: package

--- a/tagging-status/testfiles/gentombow/gentombow-01.tex
+++ b/tagging-status/testfiles/gentombow/gentombow-01.tex
@@ -1,0 +1,18 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,table,title,firstaid}
+  }
+
+\documentclass{article}
+\usepackage{gentombow}
+
+\settombowbanner{This text should be ignored.}
+
+\begin{document}
+
+text
+
+\end{document}


### PR DESCRIPTION
Lists [gentombow](https://www.ctan.org/pkg/gentombow) as "compatible" and adds a test file. The crop marks are correctly ignored in the tagging.