### PR TITLE
mark fvextra and showexpl as incompatible

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -2905,12 +2905,13 @@
 
  - name: fvextra
    type: package
-   status: unknown
+   status: currently-incompatible
+   comments: "See fancyvrb."
    priority: 2
    issues:
    tests: false
    tasks: needs tests
-   updated: 2024-07-14
+   updated: 2024-07-24
 
  - name: fwlw
    type: package
@@ -6435,12 +6436,13 @@
 
  - name: showexpl
    type: package
-   status: unknown
+   status: currently-incompatible
+   comments: "See listings."
    priority: 9
    issues:
    tests: false
    tasks: needs tests
-   updated: 2024-07-18
+   updated: 2024-07-24
 
  - name: showframe
    type: package


### PR DESCRIPTION
Marks [fvextra](https://www.ctan.org/pkg/fvextra) and [showexpl](https://www.ctan.org/pkg/showexpl) as "currently-incompatible" since the packages they rely on, fancyvrb and listings, are incompatible.