### PR TITLE
add mleftright compat and math notes

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -1554,6 +1554,8 @@
  - name: concmath-otf
    type: package
    status: compatible
+   supported-through: [phase-III,math]
+   comments: "Use of math tagging currently requires support from external tools."
    issues:
    tests: false
    updated: 2024-07-21
@@ -1983,6 +1985,8 @@
  - name: ebgaramond-maths
    type: package
    status: compatible
+   supported-through: [phase-III,math]
+   comments: "Use of math tagging currently requires support from external tools."
    issues:
    tests: false
    updated: 2024-07-21
@@ -2297,6 +2301,8 @@
  - name: euler-math
    type: package
    status: compatible
+   supported-through: [phase-III,math]
+   comments: "Use of math tagging currently requires support from external tools."
    issues:
    tests: false
    updated: 2024-07-21
@@ -2506,6 +2512,8 @@
  - name: firamath-otf
    type: package
    status: compatible
+   supported-through: [phase-III,math]
+   comments: "Use of math tagging currently requires support from external tools."
    issues:
    tests: false
    updated: 2024-07-21
@@ -2847,6 +2855,8 @@
    ctan-pkg: erewhon-math
    type: package
    status: compatible
+   supported-through: [phase-III,math]
+   comments: "Use of math tagging currently requires support from external tools."
    issues:
    tests: false
    updated: 2024-07-21
@@ -3929,6 +3939,8 @@
  - name: lete-sans-math
    type: package
    status: compatible
+   supported-through: [phase-III,math]
+   comments: "Use of math tagging currently requires support from external tools."
    issues:
    tests: false
    updated: 2024-07-21
@@ -3993,6 +4005,8 @@
  - name: libertinust1math
    type: package
    status: compatible
+   supported-through: [phase-III,math]
+   comments: "Use of math tagging currently requires support from external tools."
    issues:
    tests: false
    updated: 2024-07-21
@@ -4721,12 +4735,11 @@
 
  - name: mleftright
    type: package
-   status: unknown
+   status: compatible
    priority: 2
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-15
+   tests: true
+   updated: 2024-07-24
 
  - name: mlmodern
    type: package
@@ -7512,6 +7525,8 @@
  - name: unicode-math
    type: package
    status: compatible
+   supported-through: [phase-III,math]
+   comments: "Use of math tagging currently requires support from external tools."
    issues:   
    updated: 2024-07-12
 
@@ -7769,6 +7784,8 @@
    ctan-pkg: xcharter-math
    type: package
    status: compatible
+   supported-through: [phase-III,math]
+   comments: "Use of math tagging currently requires support from external tools."
    issues:
    tests: false
    updated: 2024-07-21

--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -4736,6 +4736,8 @@
  - name: mleftright
    type: package
    status: compatible
+   supported-through: [phase-III,math]
+   comments: "Use of math tagging currently requires support from external tools."
    priority: 2
    issues:
    tests: true

--- a/tagging-status/testfiles/mleftright/mleftright-01.tex
+++ b/tagging-status/testfiles/mleftright/mleftright-01.tex
@@ -1,0 +1,24 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,table,title,firstaid}
+  }
+
+\documentclass{article}
+\usepackage{mleftright}
+
+\title{mleftright tagging test}
+
+\begin{document}
+
+$\sin\left(x^2\right), x$
+
+$\sin\mleft(x^2\mright), x$
+
+\mleftright
+
+$\sin\left(x^2\right), x$
+
+\end{document}


### PR DESCRIPTION
Lists mleftright as "compatible" and adds a test file. While I was at it I added the standard math note for various packages that were missing it.