### PR TITLE
add mparhack compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -4769,7 +4769,8 @@
 
  - name: mparhack
    type: package
-   status: compatible
+   status: partially-compatible
+   comments: "Errors with `debug` option."
    priority: 2
    issues:
    tests: true

--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -4769,12 +4769,11 @@
 
  - name: mparhack
    type: package
-   status: unknown
+   status: compatible
    priority: 2
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-15
+   tests: true
+   updated: 2024-07-24
 
  - name: multiaudience
    type: package

--- a/tagging-status/testfiles/mparhack/mparhack-01.tex
+++ b/tagging-status/testfiles/mparhack/mparhack-01.tex
@@ -7,7 +7,7 @@
   }
 
 \documentclass[twoside]{article}
-\usepackage{mparhack}
+\usepackage{mparhack} % errors with [debug]
 
 \title{mparhack tagging test}
 

--- a/tagging-status/testfiles/mparhack/mparhack-01.tex
+++ b/tagging-status/testfiles/mparhack/mparhack-01.tex
@@ -1,0 +1,30 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,table,title,firstaid}
+  }
+
+\documentclass[twoside]{article}
+\usepackage{mparhack}
+
+\title{mparhack tagging test}
+
+\begin{document}
+
+text\marginpar{right text}
+
+text\marginpar[left text]{}
+
+text\marginpar[left text]{right text}
+
+\newpage
+
+text\marginpar{right text}
+
+text\marginpar[left text]{}
+
+text\marginpar[left text]{right text}
+
+\end{document}


### PR DESCRIPTION
Lists [mparhack](https://www.ctan.org/pkg/mparhack) as "compatible" and adds a test file. Whatever mparhack is changing behind the scenes doesn't seem to affect the tagging.