### PR TITLE
add parnotes compat

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -5559,12 +5559,12 @@
 
  - name: parnotes
    type: package
-   status: unknown
+   status: partially-compatible
+   comments: "Does not error but `\\parnote`s are not tagged as `<Note>`s."
    priority: 9
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   updated: 2024-07-25
 
  - name: parskip
    type: package

--- a/tagging-status/testfiles/parnotes/parnotes-01.tex
+++ b/tagging-status/testfiles/parnotes/parnotes-01.tex
@@ -1,0 +1,27 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,table,title,firstaid}
+  }
+
+\documentclass{article}
+\usepackage{parnotes}
+
+\title{parnotes tagging test}
+
+\begin{document}
+
+Some text\parnote[\textasteriskcentered]{asterisked note} and more\parnote{first par note\label{note}} text
+
+\parnotes
+
+\begin{autopn}
+Some text and more\parnote{second par note} text
+
+Some text and more\parnote{third par note} text
+\end{autopn}
+
+\parnoteref{note}
+\end{document}


### PR DESCRIPTION
Lists [parnotes](https://www.ctan.org/pkg/parnotes) as "partially-compatible" as the `\parnote`s are not tagged as \<Note\>s. Test file included.