### PR TITLE
add pifont compat

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -5822,12 +5822,12 @@
 
  - name: pifont
    type: package
-   status: unknown
+   status: partially-compatible
+   comments: "Missing ToUnicode for text symbols. Labels disappear in `dingautolist`."
    priority: 9
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   updated: 2024-07-25
 
  - name: piton
    type: package

--- a/tagging-status/testfiles/pifont/pifont-01.tex
+++ b/tagging-status/testfiles/pifont/pifont-01.tex
@@ -1,0 +1,41 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{pifont}
+
+\title{pifont tagging test}
+
+\begin{document}
+
+\ding{38}
+
+\ding{47}
+
+\begin{itemize}
+\item The first item in the list
+\item The second item in the list
+\item The third item in the list
+\end{itemize}
+
+\begin{dinglist}{43}
+\item The first item in the list
+\item The second item in the list
+\item The third item in the list
+\end{dinglist}
+
+\begin{dingautolist}{192}
+\item The first item
+\item The second item
+\item The third item
+\end{dingautolist}
+
+\dingfill{224}
+
+\dingline{81}
+
+\end{document}


### PR DESCRIPTION
Lists [pifont](https://www.ctan.org/pkg/pifont) as "partially-compatible" for the same reasons as discussed in #272, and since the labels in the `dingautolist` environment disappear when the tagging code is loaded. Test file included.