### PR TITLE
add countriesofeurope compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -1592,12 +1592,12 @@
 
  - name: countriesofeurope
    type: package
-   status: unknown
+   status: partially-compatible
    priority: 9
+   comments: "Missing Alt/ActualText for text symbols."
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   updated: 2024-07-25
 
  - name: courier
    type: package

--- a/tagging-status/testfiles/countriesofeurope/countriesofeurope-01.tex
+++ b/tagging-status/testfiles/countriesofeurope/countriesofeurope-01.tex
@@ -1,0 +1,21 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage[Scale=7.5]{countriesofeurope}
+
+\title{countriesofeurope tagging test}
+
+\begin{document}
+
+text\EUCountry{Austria}
+
+\EUCountry[outline]{Croatia}
+
+\EUCountry[outline,fillcolor=blue!20,linecolor=blue]{Germany}
+
+\end{document}


### PR DESCRIPTION
Lists [countriesofeurope](https://www.ctan.org/pkg/countriesofeurope) as "partially-compatible" because the symbols are missing Alt/ActualText. Test included.