### PR TITLE
add adforn and adfsymbols compat

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -162,14 +162,34 @@
    tasks: needs tests
    updated: 2024-07-13
 
+ - name: adfarrows
+   ctan-pkg: adfsymbols
+   type: package
+   status: partially-compatible
+   priority: 9
+   comments: "Missing ToUnicode for text symbols."
+   issues:
+   tests: true
+   updated: 2024-07-25
+
+ - name: adfbullets
+   ctan-pkg: adfsymbols
+   type: package
+   status: partially-compatible
+   priority: 9
+   comments: "Missing ToUnicode for text symbols."
+   issues:
+   tests: true
+   updated: 2024-07-25
+
  - name: adforn
    type: package
-   status: unknown
+   status: partially-compatible
    priority: 2
+   comments: "Missing ToUnicode for text symbols."
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-13
+   tests: true
+   updated: 2024-07-25
 
  - name: adjmulticol
    type: package

--- a/tagging-status/testfiles/adfarrows/adfarrows-01.tex
+++ b/tagging-status/testfiles/adfarrows/adfarrows-01.tex
@@ -1,0 +1,22 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,table,title,firstaid}
+  }
+
+\documentclass{article}
+\usepackage{adfarrows}
+
+\title{adfarrows tagging test}
+
+\begin{document}
+
+\adfarrow{33}
+
+\adfarrow{43}
+
+\adfarrow[opentail]{se}
+
+\end{document}

--- a/tagging-status/testfiles/adfbullets/adfbullets-01.tex
+++ b/tagging-status/testfiles/adfbullets/adfbullets-01.tex
@@ -1,0 +1,22 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,table,title,firstaid}
+  }
+
+\documentclass{article}
+\usepackage{adfbullets}
+
+\title{adfbullets tagging test}
+
+\begin{document}
+
+\adfbullet{17}
+
+\adfbullet{19}
+
+\adfbullet{23}
+
+\end{document}

--- a/tagging-status/testfiles/adforn/adforn-01.tex
+++ b/tagging-status/testfiles/adforn/adforn-01.tex
@@ -1,0 +1,22 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,table,title,firstaid}
+  }
+
+\documentclass{article}
+\usepackage{adforn}
+
+\title{adforn tagging test}
+
+\begin{document}
+
+\adforn{21}
+
+\adforn{11}
+
+\adforn{49}
+
+\end{document}


### PR DESCRIPTION
Lists adforn, adfarrows, and adfbullets as "partially-compatible" since the symbols are missing ToUnicode values.