### PR TITLE
add bbding compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -690,12 +690,12 @@
 
  - name: bbding
    type: package
-   status: unknown
+   status: partially-compatible
    priority: 9
+   comments: "Missing ToUnicode for text symbols."
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   updated: 2024-07-25
 
  - name: bboldx
    type: package

--- a/tagging-status/testfiles/bbding/bbding-01.tex
+++ b/tagging-status/testfiles/bbding/bbding-01.tex
@@ -1,0 +1,22 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,table,title,firstaid}
+  }
+
+\documentclass{article}
+\usepackage{bbding}
+
+\title{bbding tagging test}
+
+\begin{document}
+
+\ScissorRight
+
+\PlusCenterOpen
+
+\SixFlowerRemovedOpenPetal
+
+\end{document}


### PR DESCRIPTION
Lists [bbding](https://www.ctan.org/pkg/bbding) as partially-compatible since the symbols are missing ToUnicode values.