### PR TITLE
add compatible packages

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -281,12 +281,11 @@
 
  - name: alphalph
    type: package
-   status: unknown
+   status: compatible
    priority: 9
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   updated: 2024-07-25
 
  - name: amsbsy
    type: package
@@ -864,12 +863,11 @@
 
  - name: bigintcalc
    type: package
-   status: unknown
+   status: compatible
    priority: 9
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   updated: 2024-07-25
 
  - name: bigstrut
    type: package
@@ -2187,12 +2185,11 @@
 
  - name: eolgrab
    type: package
-   status: unknown
+   status: compatible
    priority: 9
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   updated: 2024-07-25
 
  - name: epic
    status: currently-incompatible
@@ -2492,12 +2489,11 @@
 
  - name: fibnum
    type: package
-   status: unknown
+   status: compatible
    priority: 9
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   updated: 2024-07-25
 
  - name: figcaps
    type: package
@@ -3512,21 +3508,19 @@
 
  - name: ifdraft
    type: package
-   status: unknown
+   status: compatible
    priority: 9
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   updated: 2024-07-25
 
  - name: iflang
    type: package
-   status: unknown
+   status: compatible
    priority: 2
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-15
+   updated: 2024-07-25
 
  - name: ifluatex
    type: package
@@ -3544,12 +3538,11 @@
 
  - name: ifplatform
    type: package
-   status: unknown
+   status: compatible
    priority: 9
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   updated: 2024-07-25
 
  - name: ifptex
    type: package
@@ -3656,12 +3649,11 @@
 
  - name: intcalc
    type: package
-   status: unknown
+   status: compatible
    priority: 9
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   updated: 2024-07-25
 
  - name: inter
    type: package
@@ -4412,12 +4404,11 @@
 
  - name: magicnum
    type: package
-   status: unknown
+   status: compatible
    priority: 9
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   updated: 2024-07-25
 
  - name: makeidx
    type: package
@@ -4858,12 +4849,11 @@
 
  - name: multiexpand
    type: package
-   status: unknown
+   status: compatible
    priority: 9
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   updated: 2024-07-25
 
  - name: multimedia
    ctan-pkg: beamer
@@ -5257,12 +5247,11 @@
 
  - name: nth
    type: package
-   status: unknown
+   status: compatible
    priority: 9
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   updated: 2024-07-25
 
  - name: ntheorem
    status: unknown
@@ -5654,12 +5643,11 @@
 
  - name: pdfescape
    type: package
-   status: unknown
+   status: compatible
    priority: 9
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   updated: 2024-07-25
 
  - name: pdfmarginpar
    type: package
@@ -6098,12 +6086,11 @@
 
  - name: regexpatch
    type: package
-   status: unknown
+   status: compatible
    priority: 9
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   updated: 2024-07-25
 
  - name: reledmac
    type: package
@@ -6202,12 +6189,11 @@
 
  - name: rotchiffre
    type: package
-   status: unknown
+   status: compatible
    priority: 9
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   updated: 2024-07-25
 
  - name: rotfloat
    type: package
@@ -6769,12 +6755,11 @@
 
  - name: stringenc
    type: package
-   status: unknown
+   status: compatible
    priority: 9
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   updated: 2024-07-25
 
  - name: structuredlog
    type: package
@@ -7196,12 +7181,11 @@
 
  - name: thepdfnumber
    type: package
-   status: unknown
+   status: compatible
    priority: 9
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   updated: 2024-07-25
 
  - name: thmbox
    type: package
@@ -7566,12 +7550,11 @@
 
  - name: uniquecounter
    type: package
-   status: unknown
+   status: compatible
    priority: 9
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   updated: 2024-07-25
 
  - name: universalis
    type: package
@@ -7582,12 +7565,11 @@
 
  - name: unravel
    type: package
-   status: unknown
+   status: compatible
    priority: 9
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   updated: 2024-07-25
 
  - name: upquote
    type: package
@@ -7933,12 +7915,11 @@
 
  - name: xkeyval
    type: package
-   status: unknown
+   status: compatible
    priority: 9
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   updated: 2024-07-25
 
  - name: xlop
    type: package
@@ -7967,12 +7948,11 @@
 
  - name: xpatch
    type: package
-   status: unknown
+   status: compatible
    priority: 9
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   updated: 2024-07-25
 
  - name: xpiano
    type: package
@@ -8032,12 +8012,11 @@
 
  - name: xstring
    type: package
-   status: unknown
+   status: compatible
    priority: 9
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   updated: 2024-07-25
 
  - name: xtab
    type: package


### PR DESCRIPTION
Lists a few packages as "compatible" without providing test files because the packages are either very simple or are unrelated to typesetting. The packages are [alphalph](https://www.ctan.org/pkg/alphalph), [bigintcalc](https://www.ctan.org/pkg/bigintcalc), [eolgrab](https://www.ctan.org/pkg/eolgrab), [fibnum](https://www.ctan.org/pkg/fibnum), [ifdraft](https://www.ctan.org/pkg/ifdraft), [iflang](https://www.ctan.org/pkg/iflang), [ifplatform](https://www.ctan.org/pkg/ifplatform), [intcalc](https://www.ctan.org/pkg/intcalc), [magicnum](https://www.ctan.org/pkg/magicnum), [multiexpand](https://www.ctan.org/pkg/multiexpand), [nth](https://www.ctan.org/pkg/nth), [pdfescape](https://www.ctan.org/pkg/pdfescape), [regexpatch](https://www.ctan.org/pkg/regexpatch), [rotchiffre](https://www.ctan.org/pkg/rotchiffre), [stringenc](https://www.ctan.org/pkg/stringenc), [thepdfnumber](https://www.ctan.org/pkg/thepdfnumber), [uniquecounter](https://www.ctan.org/pkg/uniquecounter), [unravel](https://www.ctan.org/pkg/unravel), [xkeyval](https://www.ctan.org/pkg/xkeyval), [xpatch](https://www.ctan.org/pkg/xpatch), and [xstring](https://www.ctan.org/pkg/xstring).

If any need test files just let me know.