### PR TITLE
add lua-ul compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -4251,12 +4251,12 @@
 
  - name: lua-ul
    type: package
-   status: unknown
+   status: currently-incompatible
    priority: 2
+   comments: "Missing TextDecoration attributes."
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-15
+   tests: true
+   updated: 2024-07-25
 
  - name: lua-widow-control
    type: package

--- a/tagging-status/testfiles/lua-ul/lua-ul-01.tex
+++ b/tagging-status/testfiles/lua-ul/lua-ul-01.tex
@@ -1,0 +1,29 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{lua-ul,luacolor}
+
+\title{lua-ul tagging test}
+
+\begin{document}
+
+some text
+
+\strikeThrough{some text}
+
+\underLine{some text}
+
+\underLine[top=2pt]{some text}
+
+\underLine[color=blue]{some text}
+
+\highLight{some text}
+
+\highLight[red]{some text}
+
+\end{document}


### PR DESCRIPTION
Lists lua-ul as "currently-incompatible" for the reasons discussed in #232. Unlike with cancel, the text is tagged as-is, however there should be TextDecoration attributes to indicate strike-through, underline, and highlight.

(By the way, where can you see attributes for a Span? Is it possible without opening up the uncompressed pdf file?)