### PR TITLE
add lualatex-math compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -4278,12 +4278,11 @@
 
  - name: lualatex-math
    type: package
-   status: unknown
+   status: compatible
    priority: 9
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   updated: 2024-07-25
 
  - name: luamathalign
    type: package

--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -4280,6 +4280,8 @@
    type: package
    status: compatible
    priority: 9
+   supported-through: [phase-III,math]
+   comments: "Use of math tagging currently requires support from external tools."
    issues:
    tests: true
    updated: 2024-07-25

--- a/tagging-status/testfiles/lualatex-math/lualatex-math-01.tex
+++ b/tagging-status/testfiles/lualatex-math/lualatex-math-01.tex
@@ -1,0 +1,34 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+
+\usepackage{mathtools,lualatex-math}
+
+\title{lualatex-math tagging test}
+
+\begin{document}
+
+text
+
+$\frac{1}{2}$
+
+$\genfrac{(}{)}{0pt}{}{a}{b}$
+
+\[
+\sum_{\begin{subarray}{l}
+i\in\Lambda\\ 0<j<n
+\end{subarray}}
+P(i,j)
+\]
+
+\[
+\cramped{x^2} \leftrightarrow x^2 \quad
+\cramped[\scriptstyle]{x^2} \leftrightarrow {\scriptstyle x^2}
+\]
+
+\end{document}


### PR DESCRIPTION
Lists [lualatex-math](https://www.ctan.org/pkg/lualatex-math) as compatible and adds a test file. None of its patches seem to affect tagging.