### PR TITLE
add pagenote compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -5526,12 +5526,12 @@
 
  - name: pagenote
    type: package
-   status: unknown
+   status: partially-compatible
    priority: 9
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   comments: "Does not error but `\\pagenote`s are not tagged as `<Note>`s."
+   tests: true
+   updated: 2024-07-25
 
  - name: pagesel
    type: package

--- a/tagging-status/testfiles/pagenote/pagenote-01.tex
+++ b/tagging-status/testfiles/pagenote/pagenote-01.tex
@@ -1,0 +1,28 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{pagenote}
+\makepagenote
+
+\title{pagenote tagging test}
+
+\begin{document}
+
+\section{Body Part One}
+
+first text\pagenote{first pagenote}
+
+second text\pagenote{second pagenote}
+
+\section{Body Part Two}
+
+third text\pagenote{third pagenote}
+
+\printnotes
+
+\end{document}

--- a/tagging-status/testfiles/pagenote/pagenote-02.tex
+++ b/tagging-status/testfiles/pagenote/pagenote-02.tex
@@ -1,0 +1,30 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{report}
+\usepackage{pagenote}
+\makepagenote
+
+\title{pagenote tagging test}
+
+\begin{document}
+
+\chapter{Body Part One}
+
+first text\pagenote{first pagenote}
+
+second text\pagenote{second pagenote}
+
+\printnotes*
+
+\chapter{Body Part Two}
+
+third text\pagenote{third pagenote}
+
+\printnotes*
+
+\end{document}


### PR DESCRIPTION
Lists [pagenote](https://www.ctan.org/pkg/pagenote) as partially-compatible because the `\pagenote`s are not tagged as \<Note\>s. Tests included.