### PR TITLE
add telprint compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -7025,12 +7025,12 @@
 
  - name: telprint
    type: package
-   status: unknown
+   status: currently-incompatible
    priority: 9
+   comments: "Produces empty `<Formula>`s."
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   updated: 2024-07-25
 
  - name: tempora
    type: package

--- a/tagging-status/testfiles/telprint/telprint-01.tex
+++ b/tagging-status/testfiles/telprint/telprint-01.tex
@@ -1,0 +1,21 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{telprint}
+
+\title{telprint tagging test}
+
+\begin{document}
+
+\telprint{0761/12345}
+
+\telprint{01234/567-89}
+
+\telprint{+49 (6221) 297}
+
+\end{document}


### PR DESCRIPTION
Lists [telprint](https://www.ctan.org/pkg/telprint) as "currently-incompatible" because it produces empty `<Formula>`s in the tags.