### PR TITLE
add incompatible packages

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -852,12 +852,13 @@
 
  - name: bicaption
    type: package
-   status: unknown
+   status: currently-incompatible
    priority: 9
+   comments: "Relies on currently incompatible caption package."
    issues:
    tests: false
    tasks: needs tests
-   updated: 2024-07-18
+   updated: 2024-07-26
 
  - name: bidi
    type: package
@@ -3791,12 +3792,11 @@
 
  - name: keystroke
    type: package
-   status: unknown
+   status: currently-incompatible
    priority: 9
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   issues: [265]
+   tests: true
+   updated: 2024-07-26
 
  - name: keyval
    type: package
@@ -4206,12 +4206,11 @@
 
  - name: ltcaption
    type: package
-   status: unknown
+   status: currently-incompatible
    priority: 2
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-15
+   issues: [256]
+   tests: true
+   updated: 2024-07-26
 
  - name: ltxgrid
    type: package
@@ -4442,11 +4441,12 @@
 
  - name: manyfoot
    type: package
-   status: unknown
+   status: currently-incompatible
    priority: 2
-   tasks: needs tests
+   issues: [289]
+   tests: true
    comments: To be supported or not?
-   updated: 2024-07-06
+   updated: 2024-07-26
 
  - name: marcellus
    type: package
@@ -4588,12 +4588,11 @@
 
  - name: mcaption
    type: package
-   status: unknown
+   status: currently-incompatible
    priority: 9
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   issues: [292]
+   tests: true
+   updated: 2024-07-26
 
  - name: mcite
    type: package
@@ -5567,12 +5566,11 @@
 
  - name: paralist
    type: package
-   status: unknown
+   status: currently-incompatible
    priority: 9
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   issues: [273]
+   tests: true
+   updated: 2024-07-26
 
  - name: parallel
    type: package
@@ -5585,12 +5583,11 @@
 
  - name: parcolumns
    type: package
-   status: unknown
+   status: currently-incompatible
    priority: 9
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   issues: [281]
+   tests: true
+   updated: 2024-07-26
 
  - name: parnotes
    type: package
@@ -5628,12 +5625,11 @@
 
  - name: pdfcolfoot
    type: package
-   status: unknown
+   status: currently-incompatible
    priority: 9
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   issues: [297]
+   tests: true
+   updated: 2024-07-26
 
  - name: pdfcolparallel
    type: package
@@ -5841,12 +5837,11 @@
 
  - name: piton
    type: package
-   status: unknown
+   status: currently-incompatible
    priority: 9
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   issues: [260]
+   tests: true
+   updated: 2024-07-26
 
  - name: placeins
    type: package
@@ -6536,12 +6531,11 @@
 
  - name: sidecap
    type: package
-   status: unknown
+   status: currently-incompatible
    priority: 2
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-15
+   issues: [290]
+   tests: true
+   updated: 2024-07-26
 
  - name: sillypage
    type: package

--- a/tagging-status/testfiles/keystroke/keystroke-01.tex
+++ b/tagging-status/testfiles/keystroke/keystroke-01.tex
@@ -1,0 +1,16 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,table,title,firstaid}
+  }
+
+\documentclass{article}
+\usepackage{keystroke}
+
+\begin{document}
+
+\keystroke{A}
+
+\end{document}

--- a/tagging-status/testfiles/ltcaption/ltcaption-01.tex
+++ b/tagging-status/testfiles/ltcaption/ltcaption-01.tex
@@ -1,0 +1,22 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,table,title,firstaid}
+  }
+
+\documentclass{article}
+\usepackage{longtable,ltcaption}
+
+\title{ltcaption tagging test}
+
+\begin{document}
+
+\begin{longtable}[l]{cc}
+\caption{caption text} \\
+A & B \\
+C & D
+\end{longtable}
+
+\end{document}

--- a/tagging-status/testfiles/manyfoot/manyfoot-01.tex
+++ b/tagging-status/testfiles/manyfoot/manyfoot-01.tex
@@ -1,0 +1,28 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,table,title,firstaid}
+  }
+
+\documentclass{article}
+
+\usepackage[para]{manyfoot}
+\usepackage{kantlipsum}
+
+\title{manyfoot tagging test}
+
+\DeclareNewFootnote{A}[alph]
+\DeclareNewFootnote[para]{B}[roman]
+
+
+\begin{document}
+
+text\footnote{normal footnote}
+
+text\footnoteA{A-type footnote}
+
+%text\footnoteB{B-type footnote}
+
+\end{document}

--- a/tagging-status/testfiles/mcaption/mcaption-01.tex
+++ b/tagging-status/testfiles/mcaption/mcaption-01.tex
@@ -1,0 +1,33 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{mcaption}
+\usepackage{graphicx}
+
+\title{mcaption tagging test}
+
+\begin{document}
+
+normal text
+
+\begin{figure}
+\begin{margincap}
+\centering
+\includegraphics{example-image}
+\caption[short caption text]{long caption text}
+\end{margincap}
+\end{figure}
+
+% compare with
+\begin{figure}
+\centering
+\includegraphics{example-image}
+\caption[short caption text]{long caption text}
+\end{figure}
+
+\end{document}

--- a/tagging-status/testfiles/paralist/paralist-01.tex
+++ b/tagging-status/testfiles/paralist/paralist-01.tex
@@ -1,0 +1,43 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,table,title,firstaid}
+  }
+
+\documentclass{article}
+\usepackage{paralist}
+
+\title{paralist tagging test}
+
+\begin{document}
+
+% optional argument does nothing
+\begin{enumerate}[(i)]
+\item first
+\item second
+\end{enumerate}
+
+% errors
+\begin{asparaenum}
+\item Every ...
+\item The next ...
+\end{asparaenum}
+
+% errors
+\begin{compactenum}
+\item Every ...
+\item The next ...
+\end{compactenum}
+
+% errors
+... of an enumerated environment that
+\begin{inparaenum}[(a)]
+\item can be used within paragraphs,
+\item takes care of enumeration and
+\item has items that can be referenced.
+\end{inparaenum}
+Another posting mentioned ...
+
+\end{document}

--- a/tagging-status/testfiles/parcolumns/parcolumns-01.tex
+++ b/tagging-status/testfiles/parcolumns/parcolumns-01.tex
@@ -1,0 +1,22 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+
+\usepackage{parcolumns}
+
+\title{parcolumns tagging test}
+
+\begin{document}
+
+\begin{parcolumns}{2}
+\colchunk{Left text.}
+\colchunk{Right text.}
+\colplacechunks
+\end{parcolumns}
+
+\end{document}

--- a/tagging-status/testfiles/pdfcolfoot/pdfcolfoot-01.tex
+++ b/tagging-status/testfiles/pdfcolfoot/pdfcolfoot-01.tex
@@ -1,0 +1,20 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{kantlipsum,xcolor}
+\usepackage{pdfcolfoot}
+
+\title{pdfcolfoot tagging test}
+
+\begin{document}
+
+\kant[1-3]
+
+text\footnote{\color{blue}\kant[4]}
+
+\end{document}

--- a/tagging-status/testfiles/piton/piton-01.tex
+++ b/tagging-status/testfiles/piton/piton-01.tex
@@ -1,0 +1,35 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+
+\usepackage{piton}
+
+\begin{document}
+
+text
+\begin{Piton}
+ from math import pi
+
+ def arctan(x,n=10):
+    """Compute the mathematical value of arctan(x)
+
+    n is the number of terms in the sum
+    """
+     if x < 0:
+         return -arctan(-x) # recursive call
+     elif x > 1: 
+         return pi/2 - arctan(1/x) 
+     else: 
+         s = 0
+         for k in range(n):
+             s += (-1)**k/(2*k+1)*x**(2*k+1)
+         return s 
+\end{Piton}
+text
+
+\end{document}

--- a/tagging-status/testfiles/sidecap/sidecap-01.tex
+++ b/tagging-status/testfiles/sidecap/sidecap-01.tex
@@ -1,0 +1,29 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,table,title,firstaid}
+  }
+
+\documentclass{article}
+
+\usepackage{sidecap}
+
+\title{sidecap tagging test}
+
+\begin{document}
+
+normal text
+
+\begin{SCfigure}[10]
+text
+\caption{sideways caption}
+\end{SCfigure}
+
+\begin{figure}
+text
+\caption{normal caption}
+\end{figure}
+
+\end{document}


### PR DESCRIPTION
Lists bicaption, keystroke, ltcaption, manyfoot, mcaption, paralist, parcolumns, pdfcolfoot, piton, and sidecap as "currently-incompatible". For all but bicaption, the corresponding issue is linked and a test added. bicaption is incompatible because it relies on the currently incompatible caption package.