### PR TITLE
add pmboxdraw compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -5883,12 +5883,12 @@
 
  - name: pmboxdraw
    type: package
-   status: unknown
+   status: currently-incompatible
    priority: 9
+   comments: "Symbols are not correctly mapped to Unicode."
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   updated: 2024-07-26
 
  - name: polyglossia
    type: package

--- a/tagging-status/testfiles/pmboxdraw/pmboxdraw-01.tex
+++ b/tagging-status/testfiles/pmboxdraw/pmboxdraw-01.tex
@@ -1,0 +1,30 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{pmboxdraw,xcolor}
+
+\title{pmboxdraw tagging test}
+
+\begin{document}
+
+\textupblock
+
+\textSFxxi
+
+\textltshade
+
+\pmboxdrawuni{252B}
+
+\begin{verbatim}
+        ┌─┐
+q_0: |0>┤M├
+        └╥┘
+ c_0: 0 ═╩═
+\end{verbatim}
+
+\end{document}


### PR DESCRIPTION
Lists [pmboxdraw](https://www.ctan.org/pkg/pmboxdraw) as currently-incompatible because the symbols are not mapped to Unicode. With lualatex the symbols don't appear at all in verbatim.