### PR TITLE
add ulem compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -7531,12 +7531,12 @@
 
  - name: ulem
    type: package
-   status: unknown
+   status: currently-incompatible
    priority: 2
+   comments: "Missing TextDecoration attributes."
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-15
+   tests: true
+   updated: 2024-07-26
 
  - name: underoverlap
    type: package

--- a/tagging-status/testfiles/ulem/ulem-01.tex
+++ b/tagging-status/testfiles/ulem/ulem-01.tex
@@ -1,0 +1,31 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+\usepackage{ulem}
+
+\title{ulem tagging test}
+
+\begin{document}
+
+normal text
+
+\uline{important}
+
+\uuline{urgent}
+
+\uwave{boat}
+
+\sout{wrong}
+
+\xout{removed}
+
+\dashuline{dashing}
+
+\dotuline{dotty}
+
+\end{document}


### PR DESCRIPTION
Lists [ulem](https://www.ctan.org/pkg/ulem) as currently-incompatible because the text-modifying commands are missing TextDecoration attributes. Also, the drawing commands are not suppressed in the tagging.