### PR TITLE
add underoverlap compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -7540,12 +7540,13 @@
 
  - name: underoverlap
    type: package
-   status: unknown
+   status: compatible
    priority: 2
+   supported-through: [phase-III,math]
+   comments: "Use of math tagging currently requires support from external tools."
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-15
+   tests: true
+   updated: 2024-07-26
 
  - name: underscore
    type: package

--- a/tagging-status/testfiles/underoverlap/underoverlap-01.tex
+++ b/tagging-status/testfiles/underoverlap/underoverlap-01.tex
@@ -1,0 +1,19 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+\usepackage{underoverlap}
+
+\title{underoverlap tagging test}
+
+\begin{document}
+
+\[ a + \UOLoverbrace{b +}[c + d]^x \UOLunderbrace{+ e}_y + f \]
+
+\[ a + \UOLoverbrace{b +}[c]^x \UOLunderbrace{+}[d]_y \UOLoverbrace{+ e}^z + f \]
+
+\end{document}


### PR DESCRIPTION
Lists [underoverlap](https://www.ctan.org/pkg/underoverlap) as compatible with the math comment and adds a test file.