### PR TITLE
add underscore compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -7549,12 +7549,11 @@
 
  - name: underscore
    type: package
-   status: unknown
+   status: compatible
    priority: 2
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-15
+   tests: true
+   updated: 2024-07-26
 
  - name: unicode-math
    type: package

--- a/tagging-status/testfiles/underscore/underscore-01.tex
+++ b/tagging-status/testfiles/underscore/underscore-01.tex
@@ -1,0 +1,21 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+\usepackage{underscore}
+%\usepackage[T1]{fontenc}
+% ^ needed with pdflatex
+
+\title{underscore tagging test}
+
+\begin{document}
+
+activation_energy $E_a$
+
+activation\_energy $E_a$
+
+\end{document}


### PR DESCRIPTION
Lists [underscore](https://www.ctan.org/pkg/underscore) as compatible and adds a test file. The font must contain `_` for the underscore to be properly mapped to unicode but that's also true of the default `\_`.