### PR TITLE
add verbdef compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -7676,12 +7676,11 @@
 
  - name: verbdef
    type: package
-   status: unknown
+   status: compatible
    priority: 9
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   updated: 2024-07-26
 
  - name: verse
    type: package

--- a/tagging-status/testfiles/verbdef/verbdef-01.tex
+++ b/tagging-status/testfiles/verbdef/verbdef-01.tex
@@ -1,0 +1,35 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+\usepackage{verbdef}
+
+\title{verbdef tagging test}
+
+\verbdef\demo|demonstration text %^_|
+\verbdef\demotwo{second demonstration text %^_}
+\verbdef*\stardemo|with visible spaces %^_|
+
+\begin{document}
+
+\tableofcontents
+
+\bigskip
+
+normal text
+
+\demo
+
+\demotwo
+
+\stardemo
+
+\verb|normal verb %^_|
+     
+\section{\demo}
+
+\end{document}


### PR DESCRIPTION
Lists [verbdef](https://www.ctan.org/pkg/verbdef) as compatible and adds a test file. It's tagged the same as `\verb`; that is, as normal text.