### PR TITLE
add wordcloud compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -7765,12 +7765,12 @@
 
  - name: wordcloud
    type: package
-   status: unknown
+   status: currently-incompatible
    priority: 9
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   comments: "Generates empty tags; should probably be tagged as Figure."
+   tests: true
+   updated: 2024-07-26
 
  - name: wrapfig
    type: package

--- a/tagging-status/testfiles/wordcloud/wordcloud-01.tex
+++ b/tagging-status/testfiles/wordcloud/wordcloud-01.tex
@@ -1,0 +1,19 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+\usepackage{wordcloud}
+
+\title{wordcloud tagging test}
+
+\begin{document}
+
+normal text
+
+\wordcloud[scale=1,rotate=45,margin=0.5pt]{(Wordcloud,10);(METAPOST,6);(\LaTeX,7);(Lua,4);(algorithm,3);(code,2);(mathematics,2);(CTAN,2);(mplib,4);(LuaTeX,4);(\texttt{latexmp},3);(graphism,2)}
+
+\end{document}


### PR DESCRIPTION
Lists [wordcloud](https://www.ctan.org/pkg/wordcloud) as currently incompatible because it generates empty tags and should be tagged as a Figure, I think.