### PR TITLE
add wrapstuff compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -7792,12 +7792,13 @@
 
  - name: wrapstuff
    type: package
-   status: unknown
+   status: partially-compatible
    priority: 9
+   comments: "The `width` and `type` keys produce parent-child warnings, so
+              `\caption` cannot be used in the `wrapstuff` environment."
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   updated: 2024-07-26
 
 #------------------------ XXX ----------------------------
 

--- a/tagging-status/testfiles/wrapstuff/wrapstuff-01.tex
+++ b/tagging-status/testfiles/wrapstuff/wrapstuff-01.tex
@@ -1,0 +1,57 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+
+\usepackage{wrapstuff}
+\usepackage{graphicx}
+
+\title{wrapstuff tagging test}
+
+\begin{document}
+
+\begin{wrapstuff}[c,top=1]
+\includegraphics[width=\dimeval{\linewidth/3},alt={alt text}]{example-image}
+\end{wrapstuff}
+
+In the quaint village of Greenwood, nestled at the edge of a whispering forest,
+a unique tradition has been thriving for centuries. Every spring, the villagers
+gather to celebrate the Festival of Blooms, a vibrant event marked by an
+explosion of colors and scents. The festival centers around the competition of
+floral arrangements, where participants from all age groups display their
+creativity with flowers handpicked from the surrounding woods. The air is filled
+with the sweet fragrance of wild roses, lilacs, and jasmine, mingling with the
+sound of laughter and folk music. Children dart between stalls, their faces
+painted with petal motifs, while elders share stories of festivals past. The
+highlight of the event is the crowning of the Bloom Queen, a title bestowed upon
+the creator of the most breathtaking floral display. This tradition, more than
+just a celebration, is a testament to the village's deep connection with nature
+and its cycles
+
+\def\lorem{%
+Just then her head struck against the roof of the hall:
+in fact she was now more than nine feet high, and she
+at once took up the little golden key and hurried off
+to the garden door.\par
+Poor Alice! It was as much as she could do, lying down
+on one side, to look through into the garden with one eye;
+but to get through was more hopeless than ever:
+she sat down and began to cry again.}
+\begin{wrapstuff}[c,column=par]
+\includegraphics[width=3cm,alt={alt text}]{example-image.pdf}
+\end{wrapstuff}
+\lorem
+\begin{wrapstuff}[c]
+\includegraphics[width=3cm,alt={alt text}]{example-image.pdf}
+\end{wrapstuff}
+\lorem
+\begin{wrapstuff}[c,column=false]
+\includegraphics[width=3cm,alt={alt text}]{example-image.pdf}
+\end{wrapstuff}
+\lorem
+
+\end{document}

--- a/tagging-status/testfiles/wrapstuff/wrapstuff-02.tex
+++ b/tagging-status/testfiles/wrapstuff/wrapstuff-02.tex
@@ -1,0 +1,38 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+
+\usepackage{wrapstuff}
+\usepackage{graphicx}
+
+\title{wrapstuff tagging test - width key}
+
+\begin{document}
+
+\def\lorem{%
+Just then her head struck against the roof of the hall:
+in fact she was now more than nine feet high, and she
+at once took up the little golden key and hurried off
+to the garden door.\par
+Poor Alice! It was as much as she could do, lying down
+on one side, to look through into the garden with one eye;
+but to get through was more hopeless than ever:
+she sat down and began to cry again.}
+
+\begin{wrapstuff}[c,width=4cm]
+\includegraphics[width=3cm,alt={alt text}]{example-image.pdf}
+\end{wrapstuff}
+\lorem
+
+\begin{wrapstuff}[c,width=4cm,type=figure]
+\includegraphics[width=3cm,alt={alt text}]{example-image.pdf}
+\caption{A caption for a wrapped figure}
+\end{wrapstuff}
+\lorem
+
+\end{document}


### PR DESCRIPTION
Lists the [wrapstuff](https://www.ctan.org/pkg/wrapstuff) package (English doc [here](https://www.ctan.org/pkg/wrapstuff-doc-en)) as partially-compatible. The tagging for the first example actually looks okay, but I'm not 100\% sure. The second example shows that the `wrapstuff` environment can't be used with `\caption` as the necessary `width` key produces parent-child warnings.