### PR TITLE
add xhfill compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -7980,12 +7980,12 @@
 
  - name: xhfill
    type: package
-   status: unknown
+   status: currently-incompatible
    priority: 9
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   comments: "Drawn rules should be tagged as Artifacts."
+   tests: true
+   updated: 2024-07-26
 
  - name: xint
    type: package

--- a/tagging-status/testfiles/xhfill/xhfill-01.tex
+++ b/tagging-status/testfiles/xhfill/xhfill-01.tex
@@ -1,0 +1,30 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+
+\usepackage{xhfill,xcolor}
+
+\title{xhfill tagging test}
+
+\begin{document}
+
+blah\xrfill{1pt}blub
+
+blah\xrfill{3pt}blub
+
+blah\xrfill[-12pt]{12pt}blub
+
+blah\xrfill{1pt}[blue]blub blah\xrfill{2pt}[cyan]blub
+
+blah \xhrulefill{cyan}{1cm} blub
+
+blah \xhrectanglefill{0.5cm}{1pt} blub
+
+blah\xdotfill{1pt}[blue]blah\xdotfill{2pt}[red]blub
+
+\end{document}


### PR DESCRIPTION
Lists [xhfill](https://www.ctan.org/pkg/xhfill) as currently incompatible since the rules it draws should be tagged as Artifacts.