### PR TITLE
add xistercian compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -7998,12 +7998,12 @@
 
  - name: xistercian
    type: package
-   status: unknown
+   status: partially-compatible
    priority: 9
+   comments: "Missing ToUnicode or ActualText for symbols."
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   updated: 2024-07-26
 
  - name: xkeyval
    type: package

--- a/tagging-status/testfiles/xistercian/xistercian-01.tex
+++ b/tagging-status/testfiles/xistercian/xistercian-01.tex
@@ -1,0 +1,20 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+
+\usepackage{xistercian}
+
+\title{xistercian tagging test}
+
+\pagenumbering{cistercian}
+
+\begin{document}
+
+\cisterciannum{14}
+
+\end{document}


### PR DESCRIPTION
Lists [xistercian](https://www.ctan.org/pkg/xistercian) as partially-compatible because the symbols are missing ToUnicode or ActualText values.