### PR TITLE
add xlop compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -8015,12 +8015,12 @@
 
  - name: xlop
    type: package
-   status: unknown
+   status: currently-incompatible
    priority: 9
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   comments: "Does not produce sensible tagging."
+   tests: true
+   updated: 2024-07-26
 
  - name: xltabular
    type: package

--- a/tagging-status/testfiles/xlop/xlop-01.tex
+++ b/tagging-status/testfiles/xlop/xlop-01.tex
@@ -1,0 +1,48 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+
+\usepackage{xlop}
+
+\title{xlop tagging test}
+
+\begin{document}
+
+\opadd{45,05}{78,4}
+
+\opadd[decimalsepsymbol={,},
+  voperator=bottom,
+  carryadd=false]{45.05}{78.4}
+
+\opdiv[style=text,period]{1}{49}
+
+\opadd*{45.05}{78.4}{r}%
+The first figure after dot of
+$45.05+78.4$ is
+\opgetdecimaldigit{r}{1}{d}%
+$\opprint{d}$.
+
+\opadd*{45.05}{78.4}{r}%
+The sum $45.05+78.4$ is
+\opcmp{r}{100}%
+\ifopgt greater than
+\else\ifoplt less than
+\else equal to
+\fi\fi
+$100$.
+
+top\quad
+\opadd[voperation=top]{45}{172}
+
+center\quad
+\opadd[voperation=center]{45}{172}
+
+bottom\quad
+\opadd[voperation=bottom]{45}{172}
+   
+\end{document}


### PR DESCRIPTION
Lists [xlop](https://www.ctan.org/pkg/xlop) as currently-incompatible because the tagging is a mix of empty formulas and numbers in text and math. Not sure how this should be correctly tagged.