### PR TITLE
add piano and xpiano compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -5837,12 +5837,12 @@
 
  - name: piano
    type: package
-   status: unknown
+   status: partially-compatible
    priority: 9
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   comments: "Missing Alt text for graphic."
+   tests: true
+   updated: 2024-07-26
 
  - name: picins
    type: package
@@ -8048,12 +8048,12 @@
 
  - name: xpiano
    type: package
-   status: unknown
+   status: partially-compatible
    priority: 9
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   comments: "Missing Alt text for graphic."
+   tests: true
+   updated: 2024-07-26
 
  - name: xpinyin
    type: package

--- a/tagging-status/testfiles/piano/piano-01.tex
+++ b/tagging-status/testfiles/piano/piano-01.tex
@@ -1,0 +1,18 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+
+\usepackage{piano}
+
+\title{piano tagging test}
+
+\begin{document}
+
+\keyboard[Co][Eo][Gso][Ct][Et]
+   
+\end{document}

--- a/tagging-status/testfiles/xpiano/xpiano-01.tex
+++ b/tagging-status/testfiles/xpiano/xpiano-01.tex
@@ -1,0 +1,34 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+
+\usepackage{xpiano}
+
+\title{xpiano tagging test}
+
+\begin{document}
+
+\keyboard{Co,Eo,Gso,Ct,Et}
+
+\keyboard{C,E,Giss,C',E'}
+
+\keyboard{C,E,Gs,C',E'}
+
+\keyboard{0,4,8,0',4'}
+
+\keyboard[
+  single,
+  ext,
+  size=1cm,
+  font=\small,
+  numbers,
+  ratio=0.67,
+  10=$t$, 11=$e$,
+  ]{C,Cs,D,Ds,E,F,Fs,G,Gs,A,As,B,C'}
+
+\end{document}


### PR DESCRIPTION
Lists the [piano](https://www.ctan.org/pkg/piano) and [xpiano](https://www.ctan.org/pkg/xpiano) packages as partially compatible because the `picture`s they define are missing Alt text.