### PR TITLE
add xy compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -8137,12 +8137,14 @@
  - name: xy
    ctan-pkg: xypic
    type: package
-   status: unknown
+   status: partially-compatible
    priority: 2
+   supported-through: [phase-III,math]
+   comments: "In text mode, no tagging occurs for `\\xymatrix`.
+              Use of math tagging currently requires support from external tools."
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-15
+   tests: true
+   updated: 2024-07-26
 
 #------------------------ YYY ----------------------------
 

--- a/tagging-status/testfiles/xy/xy-01.tex
+++ b/tagging-status/testfiles/xy/xy-01.tex
@@ -1,0 +1,41 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+
+\usepackage[all]{xy}
+
+\title{xy tagging test}
+
+\begin{document}
+
+text
+
+\xymatrix{
+U \ar@/_/[ddr]_y \ar@/^/[drr]^x
+\ar@{.>}[dr]|-{(x,y)} \\
+& X \times_Z Y \ar[d]^q \ar[r]_p
+& X \ar[d]_f \\
+& Y \ar[r]^g & Z }
+
+$\xymatrix@1{
+A\times B\times C\times D \ar[r]^-{+} &B
+}$
+
+\entrymodifiers={++[o][F-]}
+\SelectTips{cm}{}
+\xymatrix @-1pc {
+*\txt{start} \ar[r]
+& 0 \ar@(r,u)[]^b \ar[r]_a
+& 1 \ar[r]^b \ar@(r,d)[]_a
+& 2 \ar[r]^b
+\ar `dr_l[l] `_ur[l] _(.2)a [l]
+&*++[o][F=]{3}
+\ar `ur^l[lll]`^dr[lll]^b [lll]
+\ar `dr_l[ll] `_ur[ll] [ll] }
+
+\end{document}


### PR DESCRIPTION
Lists [xy](https://www.ctan.org/pkg/xypic) as partially-compatible because in text mode, no tagging occurs for an `\xymatrix`. Test included. Perhaps currently-incompatible is better.