### PR TITLE
add sectionbreak compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -6405,12 +6405,12 @@
 
  - name: sectionbreak
    type: package
-   status: unknown
+   status: partially-compatible
    priority: 9
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   comments: "Section break marks are tagged; should probably be Artifacts."
+   tests: true
+   updated: 2024-07-26
 
  - name: sectsty
    type: package

--- a/tagging-status/testfiles/sectionbreak/sectionbreak-01.tex
+++ b/tagging-status/testfiles/sectionbreak/sectionbreak-01.tex
@@ -1,0 +1,24 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+
+\usepackage[asterism]{sectionbreak}
+
+\title{sectionbreak tagging test}
+
+\begin{document}
+
+Section separated by three exclamation marks.
+\sectionbreak[!!!]
+Section separated by asterism section mark requested in \texttt{\textbackslash usepackage}.
+\sectionbreak
+Section separated by a rule.
+\sectionbreakmark{\rule{10em}{3pt}}
+\sectionbreak
+
+\end{document} 


### PR DESCRIPTION
Lists [sectionbreak](https://www.ctan.org/pkg/sectionbreak) as partially-compatible because currently the section break marks are tagged, while they should probably be Artifacts.