### PR TITLE
add sectsty compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -6414,12 +6414,12 @@
 
  - name: sectsty
    type: package
-   status: unknown
+   status: partially-compatible
    priority: 9
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   comments: "`\\sectionrule` produces errors."
+   tests: true
+   updated: 2024-07-26
 
  - name: selectp
    type: package

--- a/tagging-status/testfiles/sectsty/sectsty-01.tex
+++ b/tagging-status/testfiles/sectsty/sectsty-01.tex
@@ -1,0 +1,25 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+
+\usepackage{sectsty}
+
+\title{sectsty tagging test}
+
+\subsectionfont{\itshape}
+\sectionfont{\sffamily\nohang\centering}
+
+\begin{document}
+
+\section{Some section heading}
+
+\subsection{Some subsection heading}
+
+normal text
+
+\end{document} 

--- a/tagging-status/testfiles/sectsty/sectsty-02.tex
+++ b/tagging-status/testfiles/sectsty/sectsty-02.tex
@@ -1,0 +1,25 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+
+\usepackage{sectsty}
+
+\title{sectsty tagging test}
+
+\subsectionfont{\sffamily}
+\sectionfont{\sectionrule{3ex}{3pt}{-1ex}{1pt}} % errors
+
+\begin{document}
+
+\section{Some section heading}
+
+\subsection{Some subsection heading}
+
+normal text
+
+\end{document} 

--- a/tagging-status/testfiles/sectsty/sectsty-03.tex
+++ b/tagging-status/testfiles/sectsty/sectsty-03.tex
@@ -1,0 +1,24 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{book}
+
+\usepackage{sectsty}
+
+\title{sectsty tagging test}
+
+\allsectionsfont{\sffamily}
+
+\begin{document}
+
+\part{my part}
+\chapter{blub}
+\section{Some section heading}
+\subsection{Some subsection heading}
+normal text
+
+\end{document} 


### PR DESCRIPTION
Lists [sectsty](https://www.ctan.org/pkg/sectsty) as partially compatible. With basic examples the only problem I see is `\sectionrule` errors (second test file). It directly redefines the sectioning commands but still in terms of `\@startsection` so the tagging seems okay.