### PR TITLE
add sepfootnotes compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -6450,12 +6450,12 @@
 
  - name: sepfootnotes
    type: package
-   status: unknown
+   status: partially-compatible
    priority: 9
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   comments: "Endnotes are not tagged as `<Note>`s.
+   tests: true
+   updated: 2024-07-26
 
  - name: setouterhbox
    type: package

--- a/tagging-status/testfiles/sepfootnotes/sepfootnotes-01.tex
+++ b/tagging-status/testfiles/sepfootnotes/sepfootnotes-01.tex
@@ -1,0 +1,21 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+
+\usepackage{sepfootnotes}
+
+\title{sepfootnotes tagging test - 1}
+
+\sepfootnotecontent{Plato}{Socrates’s pupil.}
+\begin{document}
+text\footnote{a normal footnote}
+
+This was first brought up by the great Plato.\sepfootnote{Plato}
+
+text\footnote{another normal footnote}
+\end{document}

--- a/tagging-status/testfiles/sepfootnotes/sepfootnotes-02.tex
+++ b/tagging-status/testfiles/sepfootnotes/sepfootnotes-02.tex
@@ -1,0 +1,18 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+
+\usepackage{sepfootnotes}
+
+\title{sepfootnotes tagging test - 2}
+
+\newfootnotes{a}
+\anotecontent{Plato}{Socrates’s pupil.}
+\begin{document}
+This was first brought up by the great Plato.\anote{Plato}
+\end{document}

--- a/tagging-status/testfiles/sepfootnotes/sepfootnotes-03.tex
+++ b/tagging-status/testfiles/sepfootnotes/sepfootnotes-03.tex
@@ -1,0 +1,18 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+
+\usepackage{sepfootnotes}
+
+\title{sepfootnotes tagging test - 3}
+
+\newsymbolfootnotes{symbol}
+\symbolnotecontent{Plato}{Socrates’s pupil.}
+\begin{document}
+This was first brought up by the great Plato.\symbolnote{Plato}
+\end{document}

--- a/tagging-status/testfiles/sepfootnotes/sepfootnotes-04.tex
+++ b/tagging-status/testfiles/sepfootnotes/sepfootnotes-04.tex
@@ -1,0 +1,20 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+
+\usepackage{sepfootnotes}
+
+\title{sepfootnotes tagging test - 4}
+
+\newendnotes{x}
+\xnotecontent{Plato}{Socrates’s pupil.}
+\begin{document}
+This was first brought up by the great Plato.\xnote{Plato}
+\section*{Notes}
+\thexnotes
+\end{document}

--- a/tagging-status/testfiles/sepfootnotes/sepfootnotes-05.tex
+++ b/tagging-status/testfiles/sepfootnotes/sepfootnotes-05.tex
@@ -1,0 +1,23 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+
+\usepackage{sepfootnotes}
+
+\title{sepfootnotes tagging test - 5}
+
+\newfootnotes{a}
+\newendnotes{x}
+\xnotecontent{Homer}{The greatest of ancient poets.}
+\anotecontent{Plato}{Socrates’s pupil.}
+\begin{document}
+This was first brought up by the great Plato.\anote{Plato}
+But an antecedent is to be found in Homer.\xnote{Homer}
+\section*{Notes}
+\thexnotes
+\end{document}


### PR DESCRIPTION
Lists [sepfootnotes](https://www.ctan.org/pkg/sepfootnotes) as partially-compatible. The footnote tagging looks correct but the endnotes are not tagged as `<Note>`s. Tests included.