### PR TITLE
add simpleicons compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -6598,12 +6598,12 @@
 
  - name: simpleicons
    type: package
-   status: unknown
+   status: partially-compatible
    priority: 9
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   comments: "Symbols need Alt/ActualText."
+   tests: true
+   updated: 2024-07-26
 
  - name: siunitx
    type: package

--- a/tagging-status/testfiles/simpleicons/simpleicons-01.tex
+++ b/tagging-status/testfiles/simpleicons/simpleicons-01.tex
@@ -1,0 +1,20 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+
+\usepackage{simpleicons}
+
+\title{simpleicons tagging test}
+
+\begin{document}
+
+\simpleicon{aircanada}
+
+\simpleicon{aol}
+
+\end{document}


### PR DESCRIPTION
Lists [simpleicons](https://www.ctan.org/pkg/simpleicons) as partially-compatible as the symbols need Alt or ActualText.