### PR TITLE
add incompat pkgs

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -6889,13 +6889,12 @@
 
  - name: qrcode
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in: [tlc3]
    priority: 2
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   issues: [328]
+   tests: true
+   updated: 2024-07-28
 
  - name: quattrocento
    type: package
@@ -6908,13 +6907,12 @@
 
  - name: quotchap
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in: [tlc3]
    priority: 2
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   issues: [329]
+   tests: true
+   updated: 2024-07-28
 
 #------------------------ RRR ----------------------------
 
@@ -6971,13 +6969,12 @@
 
  - name: refcheck
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in: [tlc3]
    priority: 2
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-15
+   issues: [330]
+   tests: true
+   updated: 2024-07-28
 
  - name: refcount
    type: package
@@ -7389,13 +7386,12 @@
 
  - name: shadow
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in: [tlc3]
    priority: 2
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-15
+   issues: [336]
+   tests: true
+   updated: 2024-07-28
 
  - name: shapepar
    type: package
@@ -8861,13 +8857,12 @@
 
  - name: vwcol
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in:
    priority: 9
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   issues: [315]
+   tests: true
+   updated: 2024-07-28
 
 #------------------------ WWW ----------------------------
 
@@ -9187,13 +9182,12 @@
 
  - name: xsavebox
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in:
    priority: 9
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   issues: [325]
+   tests: true
+   updated: 2024-07-28
 
  - name: xsim
    type: package

--- a/tagging-status/testfiles/qrcode/qrcode-01.tex
+++ b/tagging-status/testfiles/qrcode/qrcode-01.tex
@@ -1,0 +1,20 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+
+\usepackage{qrcode,hyperref}
+
+\title{qrcode tagging test}
+
+\begin{document}
+
+text
+\qrcode[height=0.5in]{http://www.ctan.org}
+more text
+
+\end{document}

--- a/tagging-status/testfiles/quotchap/quotchap-01.tex
+++ b/tagging-status/testfiles/quotchap/quotchap-01.tex
@@ -1,0 +1,29 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{report}
+
+\usepackage{quotchap}
+
+\title{quotchap tagging test}
+
+\begin{document}
+
+\begin{savequote}[45mm]
+---When shall we three meet again
+in thunder, lightning, or in rain?
+
+---When the hurlyburly’s done,
+when the battle’s lost and won.
+\qauthor{Shakespeare, Macbeth}
+Cookies! Give me some cookies!
+\qauthor{Cookie Monster}
+\end{savequote}
+
+\chapter{Classic Sesame Street}
+
+\end{document}

--- a/tagging-status/testfiles/refcheck/refcheck-01.tex
+++ b/tagging-status/testfiles/refcheck/refcheck-01.tex
@@ -1,0 +1,32 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+
+\usepackage{refcheck}
+
+\title{refcheck tagging test}
+
+\begin{document}
+
+\begin{equation} \label{eq1}
+a=b
+\end{equation}
+\begin{equation} \label{eq2}
+c=d
+\end{equation}
+\eqref{eq1}, \eqref{eq2}.
+
+\cite{book1}, \cite{book3}
+
+\begin{thebibliography}{9}
+\bibitem{book1}A book.
+\bibitem{book2}Another book.
+\bibitem{book3}Third book.
+\end{thebibliography}
+
+\end{document}

--- a/tagging-status/testfiles/shadow/shadow-01.tex
+++ b/tagging-status/testfiles/shadow/shadow-01.tex
@@ -1,0 +1,20 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+
+\usepackage{shadow}
+
+\title{shadow tagging test}
+
+\begin{document}
+
+\shabox{text}
+
+\shabox{a long sentence a long sentence a long sentence a long sentence a long sentence a long sentence a long sentence}
+
+\end{document}

--- a/tagging-status/testfiles/vwcol/vwcol-01.tex
+++ b/tagging-status/testfiles/vwcol/vwcol-01.tex
@@ -1,0 +1,19 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+\usepackage{vwcol,kantlipsum}
+
+\title{vwcol tagging test}
+
+\begin{document}
+
+\begin{vwcol}[widths={0.3,0.2,0.5}]
+\kant[1]
+\end{vwcol}
+
+\end{document}

--- a/tagging-status/testfiles/xsavebox/xsavebox-01.tex
+++ b/tagging-status/testfiles/xsavebox/xsavebox-01.tex
@@ -1,0 +1,35 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+
+\usepackage{xsavebox}
+
+\title{xsavebox tagging test}
+
+\begin{document}
+
+% \savebox,\usebox not supported yet
+\newsavebox{\blah}
+\savebox{\blah}{content with spaces}
+normal text \usebox\blah
+
+% this loses spaces at pdf level
+\xsavebox{xblah}{content with spaces}
+normal text \xusebox{xblah}
+
+% produces parent-child warnings
+\begin{xlrbox}{SavedPar}
+\begin{minipage}[b]{1in}
+silly boxed paragraph that no one will ever use
+\end{minipage}
+\end{xlrbox}
+
+% below is not necessary to get warnings
+%normal text and \xusebox{SavedPar}
+
+\end{document}


### PR DESCRIPTION
Lists vwcol, xsavebox, qrcode, quotchap, refcheck, and shadow as "currently-incompatible" with a test and link to the relevant issue.

I held off on pdfmsym since the discussion in #298 seems to lean towards removing it from the list.