### PR TITLE
add font packages

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -101,6 +101,16 @@
    tests: false
    updated: 2024-07-21
 
+ - name: aboensis
+   type: package
+   status: currently-incompatible
+   included-in:
+   priority: 9
+   issues:
+   comments: "Text not correctly mapped to unicode."
+   tests: true
+   updated: 2024-07-29
+
  - name: abraces
    type: package
    status: unknown
@@ -1893,6 +1903,15 @@
    issues:
    tests: false
    updated: 2024-07-21
+
+ - name: comicneue
+   type: package
+   status: compatible
+   included-in:
+   priority: 9
+   issues:
+   tests: false
+   updated: 2024-07-29
 
  - name: comment
    type: package
@@ -5245,6 +5264,16 @@
    tests: true
    updated: 2024-07-11
 
+ - name: manfnt
+   type: package
+   status: partially-compatible
+   included-in:
+   priority: 9
+   issues:
+   comments: "Text symbols missing ToUnicode/Alt/ActualText."
+   tests: true
+   updated: 2024-07-29
+
  - name: manyfoot
    type: package
    status: currently-incompatible
@@ -7434,13 +7463,37 @@
 
  - name: sansmath
    type: package
-   status: unknown
+   status: compatible
    included-in:
+   supported-through: [phase-III,math]
+   comments: "Use of math tagging currently requires support from external tools."
    priority: 9
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   updated: 2024-07-29
+
+ - name: sansmathaccent
+   type: package
+   status: compatible
+   included-in:
+   supported-through: [phase-III,math]
+   comments: "Use of math tagging currently requires support from external tools."
+   priority: 9
+   issues:
+   tests: true
+   updated: 2024-07-29
+
+ - name: sansmathfonts
+   type: package
+   status: partially-compatible
+   included-in:
+   supported-through: [phase-III,math]
+   comments: "Use of math tagging currently requires support from external tools."
+   priority: 9
+   issues:
+   comments: "Symbols in math mode are not mapped correctly to unicode."
+   tests: true
+   updated: 2024-07-29
 
  - name: savetrees
    type: package
@@ -7652,6 +7705,17 @@
    tests: false
    tasks: needs tests
    updated: 2024-07-18
+
+ - name: sfmath
+   type: package
+   status: compatible
+   included-in:
+   supported-through: [phase-III,math]
+   comments: "Use of math tagging currently requires support from external tools."
+   priority: 9
+   issues:
+   tests: true
+   updated: 2024-07-29
 
  - name: shadethm
    type: package
@@ -9611,6 +9675,15 @@
    tests: false
    tasks: needs tests
    updated: 2024-07-18
+
+ - name: ysabeau
+   type: package
+   status: compatible
+   included-in:
+   priority: 9
+   issues:
+   tests: false
+   updated: 2024-07-29
 
 #------------------------ ZZZ ----------------------------
 

--- a/tagging-status/testfiles/aboensis/aboensis-01.tex
+++ b/tagging-status/testfiles/aboensis/aboensis-01.tex
@@ -1,0 +1,19 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+
+\usepackage{aboensis}
+\usepackage{kantlipsum}
+
+\title{aboensis tagging test}
+
+\begin{document}
+
+\abcursivefamily\kant[1]
+
+\end{document}

--- a/tagging-status/testfiles/manfnt/manfnt-01.tex
+++ b/tagging-status/testfiles/manfnt/manfnt-01.tex
@@ -1,0 +1,49 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+
+\usepackage{manfnt}
+
+\title{manfnt tagging test}
+
+\begin{document}
+
+\ExplSyntaxOn
+\tl_map_inline:nn
+  {
+    \dbend
+    \manboldkidney
+    \manconcentriccircles
+    \manconcentricdiamond
+    \mancone
+    \mancube
+    \manerrarrow
+    \manfilledquartercircle
+    \manhpennib
+    \manimpossiblecube
+    \mankidney
+    \manlhpenkidney
+    \manpenkidney
+    \manquadrifolium
+    \manquartercircle
+    \manrotatedquadrifolium
+    \manrotatedquartercircle
+    \manstar
+    \mantiltpennib
+    \mantriangledown
+    \mantriangleright
+    \mantriangleup
+    \manvpennib
+    \textdbend
+    \textlhdbend
+    \textreversedvideodbend
+  }
+  { #1 \quad \cs_to_str:N #1 \par }
+\ExplSyntaxOff
+
+\end{document}

--- a/tagging-status/testfiles/sansmath/sansmath-01.tex
+++ b/tagging-status/testfiles/sansmath/sansmath-01.tex
@@ -1,0 +1,30 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+
+\usepackage{sansmath}
+
+\title{sansmath tagging test}
+
+\begin{document}
+
+text
+
+$\sum_{i=1}^j\alpha_i$
+
+\[a+b=c\]
+
+\begin{sansmath}
+text
+
+$\sum_{i=1}^j\alpha_i$
+
+\[a+b=c\]
+\end{sansmath}
+
+\end{document}

--- a/tagging-status/testfiles/sansmathaccent/sansmathaccent-01.tex
+++ b/tagging-status/testfiles/sansmathaccent/sansmathaccent-01.tex
@@ -1,0 +1,23 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+
+\usepackage{sfmath}
+\usepackage{sansmathaccent}
+
+\title{sansmathaccent tagging test}
+
+\begin{document}
+
+$\tilde{M}$
+
+$\dot{u}$
+
+$\hat{T}$
+
+\end{document}

--- a/tagging-status/testfiles/sansmathfonts/sansmathfonts-01.tex
+++ b/tagging-status/testfiles/sansmathfonts/sansmathfonts-01.tex
@@ -1,0 +1,26 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+
+\usepackage[I]{sansmathfonts}
+
+\title{sansmathfonts tagging test}
+
+\begin{document}
+
+\[\Im \mathop{\mathrm{exp}}(i\omega)=\sin(\omega) \]
+
+text I\textsf{I}
+
+$\sum_{i=1}^j\alpha_i$
+
+\[a+b=c\]
+
+$\mathserif{abc}abc$
+
+\end{document}

--- a/tagging-status/testfiles/sfmath/sfmath-01.tex
+++ b/tagging-status/testfiles/sfmath/sfmath-01.tex
@@ -1,0 +1,25 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+
+\usepackage{sfmath}
+
+\title{sfmath tagging test}
+
+\begin{document}
+
+\begin{equation}
+  \prod_{j\geq 0}
+  \left(\sum_{k\geq 0}a_{jk} z^k\right) 
+= \sum_{k\geq 0} z^n
+  \left( \sum_{{k_0,k_1,\ldots\geq 0}
+          \atop{k_0+k_1+\ldots=n}    }
+        a{_0k_0}a_{1k_1}\ldots  \right) 
+\end{equation}
+
+\end{document}


### PR DESCRIPTION
Lists [comicneue](https://www.ctan.org/pkg/comicneue) and [ysabeau](https://www.ctan.org/pkg/ysabeau) as compatible without adding tests.

Lists [sansmath](https://www.ctan.org/pkg/sansmath), [sansmathaccent](https://www.ctan.org/pkg/sansmathaccent), and [sfmath](https://www.ctan.org/pkg/sfmath) as compatible with test files.

Lists [aboensis](https://www.ctan.org/pkg/aboensis) as currently-incompatible because the text is not properly mapped to unicode.

Lists [manfnt](https://www.ctan.org/pkg/manfnt) as partially-compatible because the symbols are missing ToUnicode/Alt/ActualText.

Lists [sansmathfonts](https://www.ctan.org/pkg/sansmathfonts) as partially-compatible because the math in the `<Formula>` tags is not mapped to unicode correctly. I'm not sure if this matters since the content of the `<Formula>` tags is not supposed to be read directly.