### PR TITLE
add math packages

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -103,13 +103,14 @@
 
  - name: abraces
    type: package
-   status: unknown
+   status: compatible
    included-in: [tlc3]
    priority: 2
+   supported-through: [phase-III,math]
+   comments: "Use of math tagging currently requires support from external tools."
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-13
+   tests: true
+   updated: 2024-07-29
 
  - name: abstract
    type: package
@@ -142,13 +143,15 @@
 
  - name: accents
    type: package
-   status: unknown
+   status: compatible
    included-in: [tlc3, arxiv01]
    priority: 2
+   supported-through: [phase-III,math]
+   comments: "amsmath must be loaded before accents.
+              Use of math tagging currently requires support from external tools."
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-13
+   tests: true
+   updated: 2024-07-29
 
  - name: accsupp
    type: package
@@ -330,13 +333,14 @@
 
  - name: aligned-overset
    type: package
-   status: unknown
+   status: compatible
    included-in:
    priority: 9
+   supported-through: [phase-III,math]
+   comments: "Use of math tagging currently requires support from external tools."
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   updated: 2024-07-29
 
  - name: alltt
    type: package
@@ -409,12 +413,12 @@
  - name: amsgen
    ctan-pkg: amsmath
    type: package
-   status: unknown
+   status: compatible
    included-in: [arxiv10]
    priority: 4
    issues:
    tests: false
-   updated: 2024-07-28
+   updated: 2024-07-29
 
  - name: amsmath
    type: package
@@ -481,12 +485,14 @@
  - name: amsxtra
    ctan-pkg: latex-amsmath
    type: package
-   status: unknown
+   status: compatible
    included-in: [tlc3, arxiv1]
    priority: 2
+   supported-through: [phase-III,math]
+   comments: "Use of math tagging currently requires support from external tools."
    issues:
-   tasks: needs tests
-   updated: 2024-07-06
+   tests: true
+   updated: 2024-07-29
 
  - name: andika
    type: package
@@ -860,12 +866,14 @@
 
  - name: bbm
    type: package
-   status: unknown
+   status: compatible
    included-in: [arxiv5]
    priority: 4
+   supported-through: [phase-III,math]
+   comments: "Use of math tagging currently requires support from external tools."
    issues:
-   tests: false
-   updated: 2024-07-28
+   tests: true
+   updated: 2024-07-29
 
  - name: bboldx
    type: package
@@ -1516,13 +1524,14 @@
 
  - name: centernot
    type: package
-   status: unknown
+   status: compatible
    included-in: [arxiv01]
    priority: 6
+   supported-through: [phase-III,math]
+   comments: "Use of math tagging currently requires support from external tools."
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   updated: 2024-07-29
 
  - name: cfr-lm
    type: package
@@ -2220,13 +2229,14 @@
 
  - name: derivative
    type: package
-   status: unknown
+   status: compatible
    included-in:
    priority: 9
+   supported-through: [phase-III,math]
+   comments: "Use of math tagging currently requires support from external tools."
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   updated: 2024-07-29
 
  - name: diagbox
    type: package
@@ -2240,13 +2250,14 @@
 
  - name: diffcoeff
    type: package
-   status: unknown
+   status: compatible
    included-in: [tlc3]
    priority: 2
+   supported-through: [phase-III,math]
+   comments: "Use of math tagging currently requires support from external tools."
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-14
+   tests: true
+   updated: 2024-07-29
 
  - name: dingbat
    type: package
@@ -2708,13 +2719,15 @@
 
  - name: esint
    type: package
-   status: unknown
+   status: compatible
    included-in: [tlc3, arxiv01]
    priority: 2
+   supported-through: [phase-III,math]
+   comments: "amsmath must be loaded before esint.
+              Use of math tagging currently requires support from external tools."
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-14
+   tests: true
+   updated: 2024-07-29
 
  - name: eso-pic
    type: package
@@ -2850,13 +2863,14 @@
 
  - name: extarrows
    type: package
-   status: unknown
+   status: compatible
    included-in: [tlc3, arxiv01]
    priority: 2
+   supported-through: [phase-III,math]
+   comments: "Use of math tagging currently requires support from external tools."
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-14
+   tests: true
+   updated: 2024-07-29
 
  - name: extdash
    type: package
@@ -2903,13 +2917,14 @@
 
  - name: faktor
    type: package
-   status: unknown
+   status: compatible
    included-in: [arxiv01]
    priority: 6
+   supported-through: [phase-III,math]
+   comments: "Use of math tagging currently requires support from external tools."
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   updated: 2024-07-29
 
  - name: fancybox
    type: package
@@ -3877,13 +3892,15 @@
  - name: grmath
    ctan-pkg: babel-greek
    type: package
-   status: unknown
+   status: compatible
    included-in: [tlc3]
    priority: 2
+   supported-through: [phase-III,math]
+   comments: "amsmath must be loaded before grmath.
+              Use of math tagging currently requires support from external tools."
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-14
+   tests: true
+   updated: 2024-07-29
 
 #------------------------ HHH ----------------------------
 
@@ -4373,13 +4390,14 @@
 
  - name: interval
    type: package
-   status: unknown
+   status: compatible
    included-in: [tlc3]
    priority: 2
+   supported-through: [phase-III,math]
+   comments: "Use of math tagging currently requires support from external tools."
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-15
+   tests: true
+   updated: 2024-07-29
 
  - name: intopdf
    type: package
@@ -4402,13 +4420,14 @@
 
  - name: iwonamath
    type: package
-   status: unknown
+   status: compatible
    included-in:
    priority: 9
+   supported-through: [phase-III,math]
+   comments: "Use of math tagging currently requires support from external tools."
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   updated: 2024-07-29
 
 #------------------------ JJJ ----------------------------
 

--- a/tagging-status/testfiles/abraces/abraces-01.tex
+++ b/tagging-status/testfiles/abraces/abraces-01.tex
@@ -1,0 +1,68 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+
+\usepackage{xcolor}
+\usepackage{abraces,amsmath}
+
+\title{abraces tagging test}
+
+\newcommand{\FnD}{%
+  \textrm{The quick brown fox jumped over the lazy dog}}
+\newlength{\bracecusplen}
+\settowidth{\bracecusplen}{$\braceru\bracelu$}
+ 
+\begin{document}
+
+$\aoverbrace{\FnD}$
+
+$\aunderbrace{\FnD}$
+
+$\aoverbrace[L3U1R]{\FnD}$
+
+$\aunderbrace[l2D1r000@{\bracecolor{blue!70!black}}l1D2r]{\FnD}$
+
+$\aunderbrace[l1D2U2D1r]{\FnD}$
+
+$\aoverbrace[L1R]{\FnD}$
+
+$\aunderbrace[L1U3R]{\FnD}$
+
+$\aunderbrace['6,0l3D3r0,6']{\FnD}$
+
+$\aoverbrace[L5*{3}{01}05U50*{3}{10}5R]{\FnD}$
+
+$\aunderbrace[l1@{\hspace{5em}}2D2@{~\ldots~}1r]{\FnD}$
+
+$\aunderbrace[l1R@{\color{red!80!white}}L1r]{\FnD}$
+
+$\aoverbrace[,1D!{5em},]{\FnD}$
+
+$\aoverbrace[L1U2R]{\FnD}^{\text{one-third of the way}}$
+
+$\aoverbrace[L1U1D1U1R]{\FnD}^{\text{left} & \text{right}}$
+
+$\aoverbrace[L1U1D1U1R]{\FnD}[L*{3}{1U}1R]^{\text{left} & \text{middle} & \text{right}}$
+
+\newbracespec{u}{@{\hspace{-.5\bracecusplen}}U@{\hspace{-.5\bracecusplen}}}%
+\newbracespec{d}{@{\hspace{-.5\bracecusplen}}D@{\hspace{-.5\bracecusplen}}}%
+$\aunderbrace
+  [00l2@{\hspace{-\bracecusplen}}1r]{% \aunderbrace brace script
+    \aoverbrace
+      [L1@{\hspace{-\bracecusplen}}1R000]% \aoverbrace brace script
+      {\FnD}% stuff
+      [1u13]% \aoverbrace script spec
+      ^{2/5}% \aoverbrace upper script
+  }
+  [43d3]% \aunderbrace script spec
+  _{3/5}$% \aunderbrace lower script
+
+\newbracespec{a}{@{\hspace{-.5\bracecusplen}}D}%
+\newbracespec{z}{D@{\hspace{-.5\bracecusplen}}}%
+$\aunderbrace[l1r]{\FnD}[a1z]_{\text{\rlap{far left}} & \text{\llap{far right}}}$      
+\end{document}

--- a/tagging-status/testfiles/accents/accents-01.tex
+++ b/tagging-status/testfiles/accents/accents-01.tex
@@ -1,0 +1,37 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+
+\usepackage{amsmath} % have to load amsmath before
+\usepackage{accents}
+
+\title{accents tagging test}
+
+\DeclareMathAccent{\wtilde}{\mathord}{largesymbols}{"65}
+
+\begin{document}
+
+$\accentset{\star}{d}$
+
+$\accentset{\diamond}{h}$
+
+$\tilde{\accentset{\circ}{\phi}}$
+
+$\underaccent{\hat}{x}$
+
+$\underaccent{\bar}{\gamma}$
+
+$\underaccent{\triangleright}{q}$
+
+$\underaccent{\tilde}{\mathcal{A}}$
+
+$\underaccent{\wtilde}{V}$
+
+$\undertilde{CV}$
+
+\end{document}

--- a/tagging-status/testfiles/aligned-overset/aligned-overset-01.tex
+++ b/tagging-status/testfiles/aligned-overset/aligned-overset-01.tex
@@ -1,0 +1,22 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+
+\usepackage{aligned-overset}
+
+\title{aligned-overset tagging test}
+
+\begin{document}
+
+\begin{align}
+f(x)\overset{\text{Def}}&=x+x \label{first}\\
+&=2x
+\end{align}
+
+\eqref{first}
+\end{document}

--- a/tagging-status/testfiles/amsxtra/amsxtra-01.tex
+++ b/tagging-status/testfiles/amsxtra/amsxtra-01.tex
@@ -1,0 +1,34 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+
+\usepackage{amsxtra}
+
+\title{amsxtra tagging test}
+
+\accentedsymbol{\vx}{\vec{x}}
+
+\begin{document}
+
+$a\sphat$
+
+$a\sptilde$
+
+$a\spbreve$
+
+$a\spcheck$
+
+$a\spdddot$
+
+$a\spddot$
+
+$a\spdot$
+
+$\vx$
+
+\end{document}

--- a/tagging-status/testfiles/bbm/bbm-01.tex
+++ b/tagging-status/testfiles/bbm/bbm-01.tex
@@ -1,0 +1,22 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+
+\usepackage{bbm}
+
+\title{bbm tagging test}
+
+\begin{document}
+
+$\mathbbm{text}$
+
+$\mathbbmss{text}$
+
+$\mathbbmtt{text}$
+
+\end{document}

--- a/tagging-status/testfiles/centernot/centernot-01.tex
+++ b/tagging-status/testfiles/centernot/centernot-01.tex
@@ -1,0 +1,28 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+
+\usepackage{centernot}
+
+\title{centernot tagging test}
+
+\begin{document}
+
+$\centernot\parallel$
+
+$\centernot\longrightarrow$
+
+$\centernot =$
+
+% compare with
+$\not\parallel$
+
+$\not\longrightarrow$
+
+$\not =$
+\end{document}

--- a/tagging-status/testfiles/derivative/derivative-01.tex
+++ b/tagging-status/testfiles/derivative/derivative-01.tex
@@ -1,0 +1,37 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+
+\usepackage{derivative}
+
+\title{derivative tagging test}
+
+\begin{document}
+
+$\pdv{f}{x,y}$
+
+$\pdv*{f}{x,y}$
+
+$\pdv{f}!{x,y}$
+
+$\pdv{f}/!{x,y}$
+
+$\pdv{f}{x,y}_{(x_1,y_1)}^{(x_2,y_2)}$
+
+\[\odv{f}{x} \quad \mdv{f}{x} \quad \fdv{f}{x} \quad \adv{f}{x} \quad \jdv{f}{x}\]
+
+$\odif{x,y,z}$
+
+$\odif*[sep-var-var=0]{x,y,z}$
+
+$\odif{s_1,s_2...,s_n}$
+
+$\pdv[sort-method=symbol, order={kn-c,2a-3b}]{f}{x,y}$
+
+\[\slashfrac{y_f}{x} \quad \slashfrac[Bigg]{y_f}{x}\]
+\end{document}

--- a/tagging-status/testfiles/diffcoeff/diffcoeff-01.tex
+++ b/tagging-status/testfiles/diffcoeff/diffcoeff-01.tex
@@ -1,0 +1,23 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+
+\usepackage{diffcoeff}
+
+\title{diffcoeff tagging test}
+
+\begin{document}
+
+\[ \diff[2]{\ln\sin x}{\sin x}[\pi] \quad
+   \diffp[n+1]{F}{x}                \quad
+   \diff*{(ax^2+bx+c)}{x}           \]
+
+\[ \dl P = \diffp Px \dl x + \diffp Py \dl y
+           + \diffp Pz \dl z                  \]
+
+\end{document}

--- a/tagging-status/testfiles/esint/esint-01.tex
+++ b/tagging-status/testfiles/esint/esint-01.tex
@@ -1,0 +1,42 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+
+\usepackage{amsmath} % must be loaded before esint
+\usepackage{esint}
+
+\title{esint tagging test}
+
+\begin{document}
+
+\[\int_0^1f(x)dx\]
+\ExplSyntaxOn
+\tl_map_inline:nn
+  {
+    \int
+    \iint
+    \iiint
+    \iiiint
+    \idotsint
+    \oint
+    \oiint
+    \varoiint
+    \sqint
+    \sqiint
+    \ointctrclockwise
+    \ointclockwise
+    \varointclockwise
+    \varointctrclockwise
+    \fint
+    \landupint
+    \landdownint
+  }
+  { $#1$ \quad \cs_to_str:N #1 \par }
+\ExplSyntaxOff
+
+\end{document}

--- a/tagging-status/testfiles/extarrows/extarrows-01.tex
+++ b/tagging-status/testfiles/extarrows/extarrows-01.tex
@@ -1,0 +1,22 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+
+\usepackage{extarrows}
+
+\title{extarrows tagging test}
+
+\begin{document}
+
+$X\xlongequal[sub]{sup}Y$
+
+$X\xLongleftrightarrow[sub]{sup}Y$
+
+$X\xlongleftarrow[sub]{sup}Y$
+
+\end{document}

--- a/tagging-status/testfiles/faktor/faktor-01.tex
+++ b/tagging-status/testfiles/faktor/faktor-01.tex
@@ -1,0 +1,20 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+
+\usepackage{amssymb,faktor}
+
+\title{faktor tagging test}
+
+\begin{document}
+
+$\faktor{a}{b}$
+
+\[\faktor{\sum_{i=1}^n k[X]}{\sum_{i=1}^n k[X] \cdot \theta_i}\]
+
+\end{document}

--- a/tagging-status/testfiles/grmath/grmath-01.tex
+++ b/tagging-status/testfiles/grmath/grmath-01.tex
@@ -1,0 +1,25 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+
+\usepackage[greek]{babel}
+\usepackage{amsmath} % must be loaded before grmath
+\usepackage{grmath}
+
+\title{grmath tagging test}
+
+\begin{document}
+
+$x=\log(y)$
+
+$x=\cos(y)$
+
+$x=\arcsin(y)$
+
+$x=\lcm(3,10)$
+\end{document}

--- a/tagging-status/testfiles/interval/interval-01.tex
+++ b/tagging-status/testfiles/interval/interval-01.tex
@@ -1,0 +1,41 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+
+\usepackage{interval}
+
+\title{interval tagging test}
+
+\begin{document}
+
+\begin{align*}
+& A\in\interval{a}{b}              \\
+& A\in\interval[open]{a}{b}        \\
+& A\in\interval[open left]{a}{b}   \\      
+& A\in\interval[open right,
+  scaled]{a}{\frac{1}{2}b}=B       \\     
+& A\in\interval[scaled=\big]{a}{b} \\
+& A\in\ointerval[scaled]{%
+  \tfrac{1}{3}}{\tfrac{1}{2}}
+\end{align*}
+
+\intervalconfig{
+  soft open fences,
+  separator symbol=;,
+}
+\begin{align*}
+& A\in\interval{a}{b}              \\
+& A\in\interval[open]{a}{b}        \\
+& A\in\interval[open left]{a}{b}   \\      
+& A\in\interval[open right,
+  scaled]{a}{\frac{1}{2}b}=B       \\     
+& A\in\interval[scaled=\big]{a}{b} \\
+& A\in\rinterval{a}{b}
+\end{align*}
+
+\end{document}

--- a/tagging-status/testfiles/iwonamath/iwonamath-01.tex
+++ b/tagging-status/testfiles/iwonamath/iwonamath-01.tex
@@ -1,0 +1,75 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+\usepackage[default]{lato}
+\usepackage{amsmath,amssymb,bm}
+\usepackage[scale=1.15]{iwonamath}
+\DefineIwonaMathVersion{name=iwonacondensed, condensed}
+\DefineIwonaMathVersion{name=iwonalight, light}
+\DefineIwonaMathVersion{name=iwonalightcondensed, light, condensed}
+\newcommand\ibinom[2]{\genfrac\lbrace\rbrace{0pt}{}{#1}{#2}} 
+\long\def\sample{%
+  First some large operators both in text:
+\smash{$ \iiint\limits_{\mathcal{Q}} f(x,y,z)\,dx\,dy\,dz $}
+and
+$\prod_{\gamma\in\Gamma_{\widetilde{C}}} \partial(\widetilde{X}_\gamma)$;
+and also on display:
+
+\begin{equation}
+\begin{split}
+\iiiint\limits_{\mathbf{Q}} f(w,x,y,z)\,dw\,dx\,dy\,dz  &\leq
+\oint_{\bm{\partial Q}} f' \left( \max \left\lbrace
+\frac{\lVert w \rVert}{\lvert w^2 + x^2 \rvert} ;
+\frac{\lVert z \rVert}{\lvert y^2 + z^2 \rvert} ;
+\frac{\lVert w \oplus z \rVert}{\lVert x \oplus y \rVert}
+\right\rbrace\right)
+\\
+&\precapprox \biguplus_{\mathbb{Q} \Subset \bar{\mathbf{Q}}}
+  \left[ f^{\ast} \left(
+    \frac{\left\lmoustache\mathbb{Q}(t)\right\rmoustache}
+         {\sqrt {1 - t^2}}
+  \right)\right]_{t=\alpha}^{t=\vartheta}
+  - ( \Delta + \nu - v )^3
+\end{split}
+\end{equation}
+
+For $x$ in the open interval $ \left] -1, 1 \right[ $
+the infinite sum in Equation~(2) is convergent;
+however, this does not hold
+throughout the closed interval $ \left[ -1, 1 \right] $.
+\begin{align}
+  (1 - x)^{-k} &=
+   1 + \sum_{j=1}^{\infty} (-1)^j \ibinom{k}{j} x^j
+    \text{\quad for $k \in \mathbb{N}$; $k \neq 0$.}
+\end{align}}
+
+\title{iwonamath tagging test}
+
+\begin{document}
+In all examples we use Iwona scaled 1.15
+
+\section*{Iwona regular}
+
+\sample
+
+\section*{Iwona condensed}
+
+\mathversion{iwonacondensed}
+\sample
+
+\section*{Iwona light}
+
+\mathversion{iwonalight}
+\sample
+
+\section*{Iwona light condensed}
+
+\mathversion{iwonalightcondensed}
+\sample
+
+\end{document}


### PR DESCRIPTION
Lists the math specific packages [abraces](https://www.ctan.org/pkg/abraces), [accents](https://www.ctan.org/pkg/accents), [aligned-overset](https://www.ctan.org/pkg/aligned-overset), amsgen, amsxtra, [bbm](https://www.ctan.org/pkg/bbm), [centernot](https://www.ctan.org/pkg/centernot), [derivative](https://www.ctan.org/pkg/derivative), [diffcoeff](https://www.ctan.org/pkg/diffcoeff), [esint](https://www.ctan.org/pkg/esint), [extarrows](https://www.ctan.org/pkg/extarrows), [faktor](https://www.ctan.org/pkg/faktor), grmath, [interval](https://www.ctan.org/pkg/interval), and [iwonamath](https://www.ctan.org/pkg/iwonamath) as compatible and adds test files for all but amsgen, which is not a user-facing package.

The only question marks are accents, esint, and grmath, since they require that amsmath be loaded before the package in order to not error or function correctly. Since `testphase=math` defers loading until begindocument, amsmath has to be explicitly loaded before them. A comment was added for each in the yml file but still listed as compatible.