### PR TITLE
add nicefrac compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -6097,12 +6097,13 @@
 
  - name: nicefrac
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in: [arxiv5]
    priority: 4
    issues:
-   tests: false
-   updated: 2024-07-28
+   comments: "Text-mode fractions are implemented as a sequence of formulas."
+   tests: true
+   updated: 2024-07-29
 
  - name: niceframe
    type: package

--- a/tagging-status/testfiles/nicefrac/nicefrac-01.tex
+++ b/tagging-status/testfiles/nicefrac/nicefrac-01.tex
@@ -1,0 +1,26 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+
+\usepackage{nicefrac}
+
+\title{nicefrac tagging test}
+ 
+\begin{document}
+
+\bfseries\itshape\nicefrac{1}{2}
+
+\bfseries\itshape$\nicefrac{1}{2}$
+
+\nicefrac[\texttt]{1}{2}
+
+\nicefrac[\texttt]{\textit{1}}{2}
+
+$\nicefrac[\mathcal]{A}{B}$
+
+\end{document}


### PR DESCRIPTION
Lists nicefrac as currently-incompatible because it implements text-mode fractions as a sequence of formulas. Test included