### PR TITLE
More math packages

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -4736,13 +4736,14 @@
 
  - name: letterswitharrows
    type: package
-   status: unknown
+   status: compatible
    included-in:
    priority: 9
+   supported-through: [phase-III,math]
+   comments: "Use of math tagging currently requires support from external tools."
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   updated: 2024-07-29
 
  - name: lettrine
    type: package
@@ -5088,13 +5089,14 @@
 
  - name: luamathalign
    type: package
-   status: unknown
+   status: compatible
    included-in:
    priority: 9
+   supported-through: [phase-III,math]
+   comments: "Use of math tagging currently requires support from external tools."
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   updated: 2024-07-29
 
  - name: luamesh
    type: package
@@ -5334,12 +5336,13 @@
 
  - name: mathalpha
    type: package
-   status: unknown
+   status: compatible
    included-in: [tlc3]
    priority: 2
+   supported-through: [phase-III,math]
+   comments: "Use of math tagging currently requires support from external tools."
    issues:
-   tests: false
-   tasks: needs tests
+   tests: true
    updated: 2024-07-15
 
  - name: mathastext
@@ -5364,13 +5367,14 @@
 
  - name: mathdots
    type: package
-   status: unknown
+   status: compatible
    included-in: [tlc3, arxiv01]
    priority: 2
+   supported-through: [phase-III,math]
+   comments: "Use of math tagging currently requires support from external tools."
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-15
+   tests: true
+   updated: 2024-07-29
 
  - name: mathpazo
    type: package

--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -6380,13 +6380,14 @@
 
  - name: old-arrows
    type: package
-   status: unknown
+   status: compatible
    included-in:
    priority: 2
+   supported-through: [phase-III,math]
+   comments: "Use of math tagging currently requires support from external tools."
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-15
+   tests: true
+   updated: 2024-07-29
 
  - name: onepagem
    type: package
@@ -6438,13 +6439,14 @@
 
  - name: oubraces
    type: package
-   status: unknown
+   status: compatible
    included-in: [tlc3]
    priority: 2
+   supported-through: [phase-III,math]
+   comments: "Use of math tagging currently requires support from external tools."
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-15
+   tests: true
+   updated: 2024-07-29
 
  - name: overlock
    type: package
@@ -6612,7 +6614,7 @@
    tasks: needs tests
    updated: 2024-07-18
 
- - name: palantino
+ - name: palatino
    type: package
    status: compatible
    included-in: [tlc3]

--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -7523,13 +7523,14 @@
 
  - name: scalerel
    type: package
-   status: unknown
+   status: compatible
    included-in: [arxiv01]
    priority: 6
+   supported-through: [phase-III,math]
+   comments: "Use of math tagging currently requires support from external tools."
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   updated: 2024-07-29
 
  - name: schola-otf
    type: package
@@ -8026,13 +8027,14 @@
 
  - name: stackrel
    type: package
-   status: unknown
+   status: compatible
    included-in: [arxiv01]
    priority: 6
+   supported-through: [phase-III,math]
+   comments: "Use of math tagging currently requires support from external tools."
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   updated: 2024-07-29
 
  - name: stampinclude
    type: package
@@ -8056,13 +8058,15 @@
 
  - name: steinmetz
    type: package
-   status: unknown
+   status: partially-compatible
    included-in:
    priority: 9
+   supported-through: [phase-III,math]
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   comments: "Picture used to draw symbol should be Artifact.
+              Use of math tagging currently requires support from external tools."
+   tests: true
+   updated: 2024-07-29
 
  - name: step
    type: package
@@ -8148,23 +8152,25 @@
 
  - name: subdepth
    type: package
-   status: unknown
+   status: compatible
    included-in: [tlc3]
    priority: 2
+   supported-through: [phase-III,math]
+   comments: "Use of math tagging currently requires support from external tools."
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-15
+   tests: true
+   updated: 2024-07-29
 
  - name: subeqn
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in:
    priority: 9
    issues:
+   comments: "Incompatible with amsmath which is loaded by `testphase=math`."
    tests: false
    tasks: needs tests
-   updated: 2024-07-18
+   updated: 2024-07-29
 
  - name: subfig
    type: package
@@ -9092,13 +9098,14 @@
 
  - name: upgreek
    type: package
-   status: unknown
+   status: compatible
    included-in:
    priority: 9
+   supported-through: [phase-III,math]
+   comments: "Use of math tagging currently requires support from external tools."
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-28
+   tests: true
+   updated: 2024-07-29
 
  - name: upquote
    type: package
@@ -9675,13 +9682,14 @@
 
  - name: yhmath
    type: package
-   status: unknown
+   status: compatible
    included-in: [arxiv01]
    priority: 6
+   supported-through: [phase-III,math]
+   comments: "Use of math tagging currently requires support from external tools."
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   updated: 2024-07-29
 
  - name: ysabeau
    type: package

--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -5436,13 +5436,14 @@
 
  - name: mattens
    type: package
-   status: unknown
+   status: compatible
    included-in: [tlc3]
    priority: 2
+   supported-through: [phase-III,math]
+   comments: "Use of math tagging currently requires support from external tools."
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-15
+   tests: true
+   updated: 2024-07-29
 
  - name: mcaption
    type: package

--- a/tagging-status/testfiles/letterswitharrows/letterswitharrows-01.tex
+++ b/tagging-status/testfiles/letterswitharrows/letterswitharrows-01.tex
@@ -1,0 +1,26 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+
+\usepackage[presets={abc,ABC,cAcBcC,vec-cev}]{letterswitharrows}
+
+\title{letterswitharrows tagging test}
+ 
+\begin{document}
+
+\[ \va, \vb, \vc, \dv, \mv, F_\tv \]
+
+\[ \vA, \vB, \vC, \Dv, \Ev, F_\Gv \]
+
+\[ \vcA, \vcB, \vcC, \cDv, \cEv, F_\cGv \]
+
+\[ \vec{\mathbf{x}} := \cev{AB} \qquad \langle \vw, \vright \rangle = 42 \]
+
+$\arrowoverset{ABC}$
+
+\end{document}

--- a/tagging-status/testfiles/luamathalign/luamathalign-01.tex
+++ b/tagging-status/testfiles/luamathalign/luamathalign-01.tex
@@ -1,0 +1,31 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+
+\usepackage{luamathalign}
+
+\title{luamathalign tagging test}
+ 
+\begin{document}
+
+\begin{align*}
+\sqrt{1-3x+3x^2+(\AlignHere x-1)^3}\\
+=\sqrt{1-3x+3x^2+{\AlignHere x}^3-3x^2+3x-1}\\
+=\sqrt{\AlignHere x^3}
+\end{align*}
+
+\begin{align}
+aaaa &= 1 &&\text{for $X$} \\
+bbbb &= 1 &&\text{for $Y$} \\
+\left. \begin{aligned}
+c \SetAlignmentPoint-2 &= 1 \\
+d &= 12
+\end{aligned} \right\}&&\text{for $Z$}
+\end{align}
+
+\end{document}

--- a/tagging-status/testfiles/mathalpha/mathalpha-01.tex
+++ b/tagging-status/testfiles/mathalpha/mathalpha-01.tex
@@ -1,0 +1,27 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+
+\usepackage[cal=boondoxo,calscaled=1.15,
+  bb=fourier,bbscaled=.96,
+  frak=euler]
+  {mathalpha}
+
+\title{mathalpha tagging test}
+ 
+\begin{document}
+
+$ABC\mathcal{ABC}$
+
+$ABC\mathbfcal{ABC}$
+
+$ABC\mathbb{ABC}$
+
+$ABC\mathfrak{ABC}$
+
+\end{document}

--- a/tagging-status/testfiles/mathdots/mathdots-01.tex
+++ b/tagging-status/testfiles/mathdots/mathdots-01.tex
@@ -1,0 +1,24 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+
+\usepackage{mathdots}
+
+\title{mathdots tagging test}
+ 
+\begin{document}
+
+$\ddots${\large$\ddots$}
+
+$\vdots\quad 2^{\vdots}$
+
+$\iddots\quad 2^{\iddots}$
+
+$\dddot{X}\quad \ddddot{X}$
+
+\end{document}

--- a/tagging-status/testfiles/mattens/mattens-01.tex
+++ b/tagging-status/testfiles/mattens/mattens-01.tex
@@ -1,0 +1,28 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+
+\usepackage{mattens}
+
+\title{mattens tagging test}
+ 
+\begin{document}
+
+$\bS[\dot]{f}^a_b$
+
+\[
+\aS{e} \quad \aS*{e} \quad
+\Sb{x} \quad \Sb*{x} \quad
+\aCSa{z} \quad \aCSa*{z}
+\]
+
+\begin{equation*}
+\oint\limits_{\bS{r}^s(\xi)} \dotsi
+\end{equation*}
+
+\end{document}

--- a/tagging-status/testfiles/old-arrows/old-arrows-01.tex
+++ b/tagging-status/testfiles/old-arrows/old-arrows-01.tex
@@ -1,0 +1,24 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+
+\usepackage{old-arrows}
+
+\title{old-arrows tagging test}
+ 
+\begin{document}
+
+$A\to B$
+
+$\overleftarrow{AB}$
+
+$\xrightarrow{ABCDEF}$
+
+$\varprojlim_i A_i$
+
+\end{document}

--- a/tagging-status/testfiles/oubraces/oubraces-01.tex
+++ b/tagging-status/testfiles/oubraces/oubraces-01.tex
@@ -1,0 +1,23 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+
+\usepackage{oubraces}
+
+\title{oubraces tagging test}
+ 
+\begin{document}
+
+\[
+ \overunderbraces{&\br{2}{x}& &\br{2}{y}}%
+    {a + b +&c + d +&e + f&+&g + h&+ i + j&+ k + l + m}%
+    {&  &\br{3}{z}}
+  = \pi r^2
+\]
+
+\end{document}

--- a/tagging-status/testfiles/scalerel/scalerel-01.tex
+++ b/tagging-status/testfiles/scalerel/scalerel-01.tex
@@ -1,0 +1,46 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+
+\usepackage{scalerel}
+
+\title{scalerel tagging test}
+
+\def\preblob{\displaystyle\sum_{i=0}^3}
+\def\blob{\displaystyle\frac{\displaystyle\frac{x^3}{z+r^3}}%
+{\displaystyle\frac{y}{x^2}}%
+}
+
+\begin{document}
+
+$\preblob\blob$
+
+$\scalerel{\preblob}{\blob}$
+
+$\scalerel[3ex]{\preblob}{\blob}$
+
+$\scalerel[3ex]{\triangleleft}{\blob}
+\scalerel*[3ex]{\triangleright}{\blob}$
+
+$\left\{\blob\right.$ and $\stretchrel[550]{\{}{\blob}$
+
+$\stretchrel[350]{\int}{\blob} dx$
+
+$\scaleto{\blob}{80pt}$
+
+$\stretchto[175]{\Phi}{60pt}$
+
+$\scaleleftright[3ex]{\prod}{\blob}{\coprod}$
+
+$\stretchleftright[450]{.}{\blob}{\in}$
+
+$\otimes\hstretch{3}{\otimes}\hstretch{0.5}{\otimes}$
+
+$\otimes\vstretch{3}{\otimes}\vstretch{0.5}{\otimes}$
+
+\end{document}

--- a/tagging-status/testfiles/stackrel/stackrel-01.tex
+++ b/tagging-status/testfiles/stackrel/stackrel-01.tex
@@ -1,0 +1,18 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+
+\usepackage{stackrel}
+
+\title{stackrel tagging test}
+
+\begin{document}
+
+$A \stackbin[\text{and}]{}{+} B \stackrel[x]{!}{=} C$
+
+\end{document}

--- a/tagging-status/testfiles/steinmetz/steinmetz-01.tex
+++ b/tagging-status/testfiles/steinmetz/steinmetz-01.tex
@@ -1,0 +1,36 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+
+\usepackage{steinmetz}
+
+\title{steinmetz tagging test}
+
+\begin{document}
+
+$A\phase{\alpha}$
+
+$A\phase{30^{\circ}}$
+
+$A\phase[0]{\alpha}$
+
+$A\phase[1]{\alpha}$
+
+$A\phase[2]{\alpha}$
+
+$A\phase[3]{\alpha}$
+
+$A\phase[0]{\frac{\alpha}{2}}$
+
+$A\phase[1]{\frac{\alpha}{2}}$
+
+$A\phase[2]{\frac{\alpha}{2}}$
+
+$A\phase[3]{\frac{\alpha}{2}}$
+
+\end{document}

--- a/tagging-status/testfiles/subdepth/subdepth-01.tex
+++ b/tagging-status/testfiles/subdepth/subdepth-01.tex
@@ -1,0 +1,18 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+
+\usepackage{subdepth}
+
+\title{subdepth tagging test}
+
+\begin{document}
+
+$M_n\quad M'_n$
+
+\end{document}

--- a/tagging-status/testfiles/upgreek/upgreek-01.tex
+++ b/tagging-status/testfiles/upgreek/upgreek-01.tex
@@ -1,0 +1,22 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+
+\usepackage{upgreek}
+
+\title{upgreek tagging test}
+
+\begin{document}
+
+$\alpha\upalpha$
+
+$\mu\upmu$
+
+$\Lambda\Uplambda$
+
+\end{document}

--- a/tagging-status/testfiles/yhmath/yhmath-01.tex
+++ b/tagging-status/testfiles/yhmath/yhmath-01.tex
@@ -1,0 +1,25 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+
+\usepackage{yhmath}
+
+\title{yhmath tagging test}
+
+\begin{document}
+
+$\begin{pmatrix} a & b\\ c & d\end{pmatrix}$
+\[\begin{pmatrix} a & b\\ c & d\end{pmatrix}\]
+$\begin{amatrix} a & b\\ c & d\end{amatrix}$
+
+\[\sqrt{\sqrt{\sqrt{\sqrt{\sqrt{\sqrt{\sqrt{\sqrt{\sqrt{\sqrt{\sqrt{\sqrt{\sqrt x}}}}}}}}}}}}\]
+
+$\adots\ring{X}$
+
+$\widetriangle{ABC}\wideparen{ABC}\widering{ABC}$
+\end{document}


### PR DESCRIPTION
Lists letterswitharrows, luamathalign, mathalpha, mathdots, mattens, old-arrows, oubraces, scalerel, stackrel, subdepth, upgreek, and yhmath as compatible and adds test files.

Lists steinmetz as partially-compatible because it needs to tag the picture used to draw the math symbol as Artifact.

Lists subeqn as currently-incompatible because it is incompatible with amsmath, as it defines a `subequations` environment.

Also fixes a typo palantino->palatino.