### PR TITLE
add incompat pkgs

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -1476,13 +1476,12 @@
 
  - name: cases
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in: [tlc3, arxiv01]
    priority: 2
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-14
+   issues: [347]
+   tests: true
+   updated: 2024-07-29
 
  - name: catchfile
    type: package
@@ -2002,13 +2001,12 @@
 
  - name: crop
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in: [tlc3]
    priority: 2
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-14
+   issues: [341]
+   tests: true
+   updated: 2024-07-29
 
  - name: csquotes
    type: package
@@ -4164,13 +4162,13 @@
 
  - name: IEEEtrantools
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in:
    priority: 9
-   issues:
-   tests: false
+   issues: [350]
+   tests: true
    tasks: needs tests
-   updated: 2024-07-28
+   updated: 2024-07-29
 
  - name: InriaSans
    ctan-pkg: inriafonts
@@ -4517,13 +4515,13 @@
 
  - name: keyfloat
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in: [tlc3]
    priority: 2
-   issues:
-   tests: false
+   issues: [344]
+   tests: true
    tasks: needs tests
-   updated: 2024-07-15
+   updated: 2024-07-29
 
  - name: keystroke
    type: package
@@ -7394,13 +7392,12 @@
 
  - name: resizegather
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in: [tlc3]
    priority: 2
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-15
+   issues: [352]
+   tests: true
+   updated: 2024-07-29
 
  - name: returntogrid
    type: package
@@ -9541,7 +9538,7 @@
    status: currently-incompatible
    included-in: [tlc3]
    priority: 2
-   supported-through: [phase-III,firstaid]
+   supported-through: [phase-III,table]
    issues: [170]
    tests: true
    updated: 2024-07-17
@@ -9880,13 +9877,13 @@
 
  - name: IEEEtran
    type: class
-   status: unknown
+   status: currently-incompatible
    included-in: [arxiv5]
    priority: 4
-   issues:
+   issues: [350]
    tests: false
    tasks: needs tests
-   updated: 2024-07-17
+   updated: 2024-07-29
 
 #------------------------ JJJ ----------------------------
 

--- a/tagging-status/testfiles/IEEEtrantools/IEEEtrantools-01.tex
+++ b/tagging-status/testfiles/IEEEtrantools/IEEEtrantools-01.tex
@@ -1,0 +1,21 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+
+\usepackage{IEEEtrantools}
+
+\title{IEEEtrantools tagging test}
+ 
+\begin{document}
+
+\begin{IEEEeqnarray}{rCl}
+Z&=&x_1 + x_2 + x_3 + x_4 + x_5 + x_6\IEEEnonumber\\
+&&+\:a + b%
+\end{IEEEeqnarray}
+
+\end{document}

--- a/tagging-status/testfiles/cases/cases-01.tex
+++ b/tagging-status/testfiles/cases/cases-01.tex
@@ -1,0 +1,21 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+
+\usepackage{cases}
+
+\title{cases tagging test}
+
+\begin{document}
+
+\begin{numcases}{|x|=}
+x, & for $x \geq 0$\\
+-x, & for $x < 0$
+\end{numcases}
+
+\end{document}

--- a/tagging-status/testfiles/crop/crop-01.tex
+++ b/tagging-status/testfiles/crop/crop-01.tex
@@ -1,0 +1,21 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,table,title,firstaid}
+  }
+
+\documentclass{article}
+\usepackage{geometry}
+\geometry{paperwidth=2in,
+          paperheight=6pc,
+          margin=5mm}
+
+\usepackage[cam,a5,center,axes]{crop}
+
+\title{crop tagging test}
+
+\begin{document}
+Some text
+\end{document}

--- a/tagging-status/testfiles/keyfloat/keyfloat-01.tex
+++ b/tagging-status/testfiles/keyfloat/keyfloat-01.tex
@@ -1,0 +1,17 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,table,title,firstaid}
+  }
+
+\documentclass{article}
+\usepackage{keyfloat}
+
+\title{keyfloat tagging test}
+
+\begin{document}
+text
+\keyfig{}{example-image}
+\end{document}

--- a/tagging-status/testfiles/resizegather/resizegather-01.tex
+++ b/tagging-status/testfiles/resizegather/resizegather-01.tex
@@ -1,0 +1,31 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+
+\usepackage{resizegather}
+
+\title{resizegather tagging test}
+
+\setlength\textwidth{4cm}
+
+\begin{document}
+
+\begin{equation}
+a+b+c+d+e+f+g = X
+\end{equation}
+
+\begin{displaymath}
+a+b+c+d+e+f+g = X
+\end{displaymath}
+
+\begin{gather}
+a+b+c+d+e+f+g = X \\
+a+b+c+d+e+f+g+h = Y
+\end{gather}
+
+\end{document}


### PR DESCRIPTION
Lists cases, crop, IEEEtrantools, IEEEtran, keyfloat, and resizegather as currently-incompatible and links to the corresponding issue.

Fixes a wrong module in "supported-by" for xltabular.