### PR TITLE
add icon and logo packages

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -134,13 +134,13 @@
 
  - name: academicons
    type: package
-   status: unlisted
+   status: partially-compatible
    included-in:
    priority: 9
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   comments: "Symbols need Alt/ActualText."
+   tests: true
+   updated: 2024-07-29
 
  - name: accanthis
    type: package
@@ -1515,13 +1515,13 @@
 
  - name: ccicons
    type: package
-   status: unknown
+   status: partially-compatible
    included-in:
    priority: 9
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   comments: "Symbols need Alt/ActualText."
+   tests: true
+   updated: 2024-07-29
 
  - name: cellspace
    type: package
@@ -3020,6 +3020,15 @@
    tasks: needs tests
    updated: 2024-07-18
 
+ - name: fetamont
+   type: package
+   status: compatible
+   included-in:
+   priority: 9
+   issues:
+   tests: true
+   updated: 2024-07-29
+
  - name: fewerfloatpages
    type: package
    status: unknown
@@ -4012,13 +4021,13 @@
 
  - name: hologo
    type: package
-   status: unknown
+   status: partially-compatible
    included-in:
    priority: 9
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-17
+   comments: Some logos need ActualText.
+   tests: true
+   updated: 2024-07-29
 
  - name: hvfloat
    type: package
@@ -4042,13 +4051,13 @@
 
  - name: hvlogos
    type: package
-   status: unknown
+   status: partially-compatible
    included-in:
    priority: 9
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   comments: Some logos need ActualText.
+   tests: true
+   updated: 2024-07-29
 
  - name: hypbmsec
    type: package

--- a/tagging-status/testfiles/academicons/academicons-01.tex
+++ b/tagging-status/testfiles/academicons/academicons-01.tex
@@ -1,0 +1,19 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+\usepackage{academicons}
+
+\title{academicons tagging test}
+
+\begin{document}
+
+\aiicon{arxiv}
+
+\aiicon{ieee}
+
+\end{document}

--- a/tagging-status/testfiles/ccicons/ccicons-01.tex
+++ b/tagging-status/testfiles/ccicons/ccicons-01.tex
@@ -1,0 +1,21 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+\usepackage{ccicons}
+
+\title{ccicons tagging test}
+
+\begin{document}
+
+\ccLogo
+
+\ccShareAlike
+
+\ccbync
+
+\end{document}

--- a/tagging-status/testfiles/fetamont/fetamont-01.tex
+++ b/tagging-status/testfiles/fetamont/fetamont-01.tex
@@ -1,0 +1,25 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+\usepackage{fetamont}
+
+\title{fetamont tagging test}
+
+\begin{document}
+
+\MF
+
+\MP
+
+\MT
+
+\textffm{text}
+
+\textffmw{text}
+
+\end{document}

--- a/tagging-status/testfiles/hologo/hologo-01.tex
+++ b/tagging-status/testfiles/hologo/hologo-01.tex
@@ -1,0 +1,30 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,table,title,firstaid}
+  }
+
+\documentclass{article}
+\usepackage{hologo}
+
+\title{hologo tagging test}
+
+\begin{document}
+
+\hologo{AmSLaTeX}
+
+\hologo{ConTeXt}
+
+\hologo{eTeX}
+
+\hologo{HanTheThanh}
+
+\hologo{KOMAScript}
+
+\hologo{METAFONT}
+
+\hologo{XeLaTeX}
+
+\end{document}

--- a/tagging-status/testfiles/hvlogos/hvlogos-01.tex
+++ b/tagging-status/testfiles/hvlogos/hvlogos-01.tex
@@ -1,0 +1,30 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+\usepackage{hvlogos}
+
+\title{hvlogos tagging test}
+
+\begin{document}
+
+\ALEPH
+
+\eTeX
+
+\LaTeXe
+
+\LuaMetaTeX
+
+\NTS
+
+\xypic
+
+\hvLaTeX[-0.1em][-0.07em]
+\LaTeX
+
+\end{document}


### PR DESCRIPTION
Lists [academicons](https://www.ctan.org/pkg/academicons), [ccicons](https://www.ctan.org/pkg/ccicons), [hologo](https://www.ctan.org/pkg/hologo), and [hvlogos](https://www.ctan.org/pkg/hvlogos) as partially-compatible because some of the symbols/logos need ToUnicode or ActualText values. Tests added for each.

Lists [fetamont](https://www.ctan.org/pkg/fetamont) as compatible and adds a test.