### PR TITLE
add newproof compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -6001,13 +6001,13 @@
 
  - name: newproof
    type: package
-   status: unknown
+   status: partially-compatible
    included-in:
    priority: 9
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   comments: "Implements proofs as lists so tagging is not ideal."
+   tests: true
+   updated: 2024-07-30
 
  - name: newpxmath
    ctan-pkg: newpx

--- a/tagging-status/testfiles/newproof/newproof-01.tex
+++ b/tagging-status/testfiles/newproof/newproof-01.tex
@@ -1,0 +1,49 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,table,title,firstaid}
+  }
+
+\documentclass{article}
+\usepackage{newproof}
+
+\title{newproof tagging test}
+
+\newproof{solution}{Solution.}{blub}
+
+\newtheorem{theorem}{Theorem}
+
+\begin{document}
+
+\begin{proof}
+A proof.
+\end{proof}
+
+\begin{proof}[B. L. User]
+A named proof.
+\end{proof}
+
+\begin{proof}
+Yet another.
+\end{proof}
+
+\begin{solution}
+A solution.
+\end{solution}
+
+\begin{solution}[B. L. User]
+A named solution.
+\end{solution}
+
+\begin{solution}
+Yet another.\qed
+\end{solution}
+
+% compare with
+\begin{theorem}
+A proof.
+\end{theorem}
+
+\end{document}


### PR DESCRIPTION
Lists [newproof](https://www.ctan.org/pkg/newproof) as partially-compatible because it implements proofs as lists, so the tagging is not ideal. Compare with the tagging of a theorem which uses `<Sect>` and `<Caption>`.