### PR TITLE
add twemojis compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -9008,13 +9008,13 @@
 
  - name: twemojis
    type: package
-   status: unknown
+   status: partially-compatible
    included-in:
    priority: 9
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   comments: Symbols missing ToUnicode/Alt text.
+   tests: true
+   updated: 2024-07-30
 
  - name: txfonts
    type: package

--- a/tagging-status/testfiles/twemojis/twemojis-01.tex
+++ b/tagging-status/testfiles/twemojis/twemojis-01.tex
@@ -1,0 +1,21 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+\usepackage{twemojis}
+
+\title{twemojis tagging test}
+
+\begin{document}
+
+\twemoji{1f483}
+
+\twemoji{grinning face with smiling eyes}
+
+\twemoji{smiling_imp}
+
+\end{document}


### PR DESCRIPTION
Lists [twemojis](https://www.ctan.org/pkg/twemojis) as partially-compatible because the symbols are missing ToUnicode values (they are actually images included with `\includegraphics` so maybe Alt text is better).