### PR TITLE
add textcase compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -8526,13 +8526,13 @@
 
  - name: textcase
    type: package
-   status: unknown
+   status: compatible
    included-in: [tlc3, arxiv1]
    priority: 2
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-15
+   comments: "This package is obsolete. Use the kernel `\MakeUppercase` and `\MakeLowercase`."
+   tests: true
+   updated: 2024-07-30
 
  - name: textcomp
    type: package

--- a/tagging-status/testfiles/textcase/textcase-01.tex
+++ b/tagging-status/testfiles/textcase/textcase-01.tex
@@ -1,0 +1,18 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+\usepackage{textcase}
+
+\title{textcase tagging test}
+
+\begin{document}
+
+\MakeTextUppercase{abc\ae\ \( a = b \) and $\alpha \neq a$
+or even \ensuremath{x=y} and $\ensuremath{x=y}$}
+
+\end{document}


### PR DESCRIPTION
Lists textcase as compatible with a note about it being obsolete. Test included.