### PR TITLE
add transparent compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -8961,13 +8961,13 @@
 
  - name: transparent
    type: package
-   status: unknown
+   status: compatible
    included-in: [arxiv01]
    priority: 6
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-17
+   comments: Transparency across page breaks only works with luatex and pdftex.
+   tests: true
+   updated: 2024-07-30
 
  - name: trig
    type: package

--- a/tagging-status/testfiles/transparent/transparent-01.tex
+++ b/tagging-status/testfiles/transparent/transparent-01.tex
@@ -1,0 +1,23 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+\usepackage{transparent,kantlipsum}
+
+\title{transparent tagging test}
+
+\begin{document}
+
+\kant[1-3]
+
+\transparent{0.5} \kant[4]
+
+\kant[5-6]
+
+\texttransparent{0}{\kant[7-8]}
+
+\end{document}


### PR DESCRIPTION
Lists transparent as compatible and adds a test. A note is added about transparency across page breaks only working with luatex and pdftex.