### PR TITLE
add turnthepage compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -8998,13 +8998,12 @@
 
  - name: turnthepage
    type: package
-   status: unknown
+   status: compatible
    included-in: [tlc3]
    priority: 2
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-15
+   tests: true
+   updated: 2024-07-30
 
  - name: twemojis
    type: package

--- a/tagging-status/testfiles/turnthepage/turnthepage-01.tex
+++ b/tagging-status/testfiles/turnthepage/turnthepage-01.tex
@@ -1,0 +1,18 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+\usepackage[english]{turnthepage}
+\usepackage{kantlipsum}
+
+\title{turnthepage tagging test}
+
+\begin{document}
+
+\kant[1-15]
+
+\end{document}


### PR DESCRIPTION
Lists [turnthepage](https://www.ctan.org/pkg/turnthepage) as compatible and adds a test. The text is correctly tagged as an artifact.