### PR TITLE
add xpinyin compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -9578,7 +9578,7 @@
 
  - name: xpinyin
    type: package
-   status: partially-compatible
+   status: currently-incompatible
    included-in:
    priority: 9
    issues:

--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -9578,13 +9578,13 @@
 
  - name: xpinyin
    type: package
-   status: unknown
+   status: partially-compatible
    included-in:
    priority: 9
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   comments: "Missing correct Ruby annotation. Only works with pdftex and xetex."
+   updated: 2024-07-30
 
  - name: xr
    type: package

--- a/tagging-status/testfiles/xpinyin/xpinyin-01.tex
+++ b/tagging-status/testfiles/xpinyin/xpinyin-01.tex
@@ -1,0 +1,34 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+\usepackage{ctex}
+\usepackage{xpinyin}
+\iftutex
+\setmainfont{Libertinus Serif}
+\setCJKmainfont{SimSun}
+\else
+\usepackage[T1]{fontenc}
+\usepackage{lmodern}
+\fi
+\begin{document}
+\xpinyin*{汉语拼音示例}
+
+\begin{pinyinscope}
+列位看官：你道此书从何而来？说起根由，虽近荒唐，细按则深有趣味。
+待在下将此来历注明\footnote{虽近荒唐}，方使阅者\xpinyin{了}{liao3}然不惑。
+\end{pinyinscope}
+
+\xpinyin{长}{chang2}
+
+\xpinyin*{\xpinyin{重}{zhong4}要}
+
+\pinyin{lv2zi}
+
+\pinyin{nv3hai2zi}
+
+\end{document}


### PR DESCRIPTION
Lists [xpinyin](https://www.ctan.org/pkg/xpinyin) as currently-incompatible because the text it produces needs Ruby annotations. As is the tagging is not totally unreasonable but it only supports pdftex and xetex.