### PR TITLE
add incompatible packages

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -644,13 +644,13 @@
 
  - name: asciilist
    type: package
-   status: unknown
+   status: partially-compatible
    included-in: [tlc3]
    priority: 2
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-13
+   issues: [357]
+   tests: true
+   comments: "`\\AsciiListFromFile(s)` and `\\AsciiDocListFromFile(s)` error."
+   updated: 2024-07-31
 
  - name: askinclude
    type: package
@@ -4366,13 +4366,12 @@
 
  - name: index
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in: [tlc3, arxiv01]
    priority: 2
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-15
+   issues: [367]
+   tests: true
+   updated: 2024-07-31
 
  - name: indxcite
    type: package
@@ -5726,13 +5725,12 @@
 
  - name: moreverb
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in: [tlc3, arxiv01]
    priority: 2
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-15
+   issues: [361]
+   tests: true
+   updated: 2024-07-31
 
  - name: morewrites
    type: package
@@ -6161,13 +6159,12 @@
 
  - name: nidanfloat
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in:
    priority: 9
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   issues: [362]
+   tests: true
+   updated: 2024-07-31
 
  - name: nmbib
    type: package
@@ -8277,13 +8274,12 @@
 
  - name: systeme
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in:
    priority: 9
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   issues: [358]
+   tests: true
+   updated: 2024-07-31
 
 #------------------------ TTT ----------------------------
 
@@ -8426,13 +8422,12 @@
 
  - name: tasks
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in: [tlc3]
    priority: 2
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-15
+   issues: [370]
+   tests: true
+   updated: 2024-07-31
 
  - name: tcolorbox
    type: package
@@ -8997,13 +8992,12 @@
 
  - name: truncate
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in: [tlc3]
    priority: 2
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-15
+   issues: [374]
+   tests: true
+   updated: 2024-07-31
 
  - name: turnthepage
    type: package

--- a/tagging-status/testfiles/asciilist/asciilist-01.tex
+++ b/tagging-status/testfiles/asciilist/asciilist-01.tex
@@ -1,0 +1,28 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,table,title,firstaid}
+  }
+\begin{filecontents*}[overwrite]{AsciiContents.example}
+ * item
+   - sub-item
+ * another item
+\end{filecontents*}
+
+\documentclass{article}
+\usepackage{asciilist}
+
+\title{asciilist tagging test}
+
+\begin{document}
+
+\begin{enumerate}
+\item bla
+\item blub
+\end{enumerate}
+
+\AsciiListFromFile{auto}{AsciiList.example}
+
+\end{document}

--- a/tagging-status/testfiles/index/index-01.tex
+++ b/tagging-status/testfiles/index/index-01.tex
@@ -1,0 +1,23 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{book}
+\usepackage{index}
+
+\makeindex
+
+\newindex{aut}{adx}{and}{Name Index}
+
+\begin{document}
+
+%\chapter{Chapter header\index{chapter}} % this is okay
+\chapter{Chapter header\index[aut]{chapter}} % this is wrong
+\section{Section header\index[aut]{section}} % this is okay
+
+\printindex[aut]
+
+\end{document}

--- a/tagging-status/testfiles/index/index-02.tex
+++ b/tagging-status/testfiles/index/index-02.tex
@@ -1,0 +1,21 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+\usepackage{index}
+
+\makeindex
+
+\begin{document}
+
+\tableofcontents
+
+\section{Section header\index{blub}}
+
+\printindex
+
+\end{document}

--- a/tagging-status/testfiles/index/index-03.tex
+++ b/tagging-status/testfiles/index/index-03.tex
@@ -1,0 +1,21 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+\usepackage{index}
+
+\makeindex
+
+\proofmodetrue
+
+\begin{document}
+
+text\index{blub}
+
+\printindex
+
+\end{document}

--- a/tagging-status/testfiles/moreverb/moreverb-01.tex
+++ b/tagging-status/testfiles/moreverb/moreverb-01.tex
@@ -1,0 +1,24 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,table,title,firstaid}
+  }
+
+\documentclass{article}
+
+\usepackage{moreverb}
+
+\title{moreverb tagging test}
+
+\begin{document}
+
+\begin{listing}{1}
+&*( <{^_ a	bc
+\end{listing}
+\begin{listing}{1}
+&*(< {^_ a	bc
+\end{listing}
+
+\end{document}

--- a/tagging-status/testfiles/moreverb/moreverb-02.tex
+++ b/tagging-status/testfiles/moreverb/moreverb-02.tex
@@ -1,0 +1,21 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,table,title,firstaid}
+  }
+
+\documentclass{article}
+
+\usepackage{moreverb}
+
+\title{moreverb tagging test}
+
+\begin{document}
+
+\begin{boxedverbatim}
+&*( <{^_ a	bc
+\end{boxedverbatim}
+
+\end{document}

--- a/tagging-status/testfiles/nidanfloat/nidanfloat-01.tex
+++ b/tagging-status/testfiles/nidanfloat/nidanfloat-01.tex
@@ -1,0 +1,23 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III} % comment/uncomment
+  }
+
+\documentclass[twocolumn]{article}
+\usepackage{nidanfloat}
+\usepackage{graphicx}
+
+\begin{document}
+
+normal text
+
+\begin{figure*}[b]
+\centering
+\includegraphics[alt={my alt text}]{example-image}
+\caption{my caption text}
+\end{figure*}
+
+\end{document}

--- a/tagging-status/testfiles/systeme/systeme-01.tex
+++ b/tagging-status/testfiles/systeme/systeme-01.tex
@@ -1,0 +1,17 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+\usepackage{systeme}
+
+\title{systeme tagging test}
+  
+\begin{document}
+
+\systeme{2a-3b+4c=2,a+8b+5c=8,-a+2b+c=-5}
+
+\end{document}

--- a/tagging-status/testfiles/tasks/tasks-01.tex
+++ b/tagging-status/testfiles/tasks/tasks-01.tex
@@ -1,0 +1,24 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+\usepackage{tasks}
+
+\title{tasks tagging test}
+
+\def\sample{This is some sample text we will use to create a somewhat
+longer text spanning a few lines.}
+\def\Sample{\sample\ \sample\par\sample}
+
+\begin{document}
+
+\begin{tasks}(2)
+\task \Sample
+\task \Sample
+\end{tasks}
+
+\end{document}

--- a/tagging-status/testfiles/truncate/truncate-01.tex
+++ b/tagging-status/testfiles/truncate/truncate-01.tex
@@ -1,0 +1,22 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III},
+  }
+\documentclass{article}
+\usepackage{truncate} % bad
+%\usepackage[hyphenate]{truncate} % good
+%\usepackage[breakwords]{truncate} % bad
+%\usepackage[breakall]{truncate} % bad
+
+\title{truncate tagging test}
+
+\begin{document}
+
+\truncate{122pt}{This text has been truncated}
+
+\truncate{122pt}{This text has been~truncated}
+
+\end{document}


### PR DESCRIPTION
Lists index, moreverb, nidanfloat, systeme, tasks, and truncate as incompatible, links to the corresponding issue, and adds tests.

Lists asciilist as partially-compatible since only a small part of the package doesn't work, and it is easily fixed by the package author.