### PR TITLE
add chemgreek compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -1653,13 +1653,12 @@
 
  - name: chemgreek
    type: package
-   status: unknown
+   status: compatible
    included-in:
    priority: 9
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   updated: 2024-07-31
 
  - name: chemmacros
    type: package

--- a/tagging-status/testfiles/chemgreek/chemgreek-01.tex
+++ b/tagging-status/testfiles/chemgreek/chemgreek-01.tex
@@ -1,0 +1,34 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+\usepackage{chemgreek}
+\usepackage{fontspec}
+\usepackage{textgreek}
+
+\setmainfont{Libertinus Serif}
+
+\title{chemgreek tagging test}
+
+\begin{document}
+
+\selectchemgreekmapping{default}
+default mapping: \chemphi\ and \chemPhi, $\phi$ and $\Phi$
+
+\printchemgreekalphabet
+
+\selectchemgreekmapping{fontspec}
+fontspec mapping: \chemphi\ and \chemPhi, $\phi$ and $\Phi$
+
+\printchemgreekalphabet
+
+\selectchemgreekmapping{textgreek}
+textgreek mapping: \chemphi\ and \chemPhi, $\phi$ and $\Phi$
+
+\printchemgreekalphabet
+
+\end{document}


### PR DESCRIPTION
Lists [chemgreek](https://www.ctan.org/pkg/chemgreek) as compatible and adds a test. No matter which mapping is chosen, the symbols are tagged as math which I suppose is correct even though they are used in things like "β-decay". Most people would probably write this as `$\beta$-decay` so the result is the same.