### PR TITLE
add pdfrender compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -6838,6 +6838,7 @@
    included-in:
    priority: 9
    issues:
+   comments: Only works with luatex and pdftex.
    tests: true
    updated: 2024-07-31
 

--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -6834,13 +6834,12 @@
 
  - name: pdfrender
    type: package
-   status: unknown
+   status: compatible
    included-in:
    priority: 9
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   updated: 2024-07-31
 
  - name: pdftexcmds
    type: package

--- a/tagging-status/testfiles/pdfrender/pdfrender-01.tex
+++ b/tagging-status/testfiles/pdfrender/pdfrender-01.tex
@@ -1,0 +1,21 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+
+\usepackage{pdfrender,xcolor}
+
+\title{pdfrender tagging test}
+
+\begin{document}
+
+text
+
+{\color{green}
+\textpdfrender{TextRenderingMode=2,StrokeColor=black,LineWidth=0.2pt}{text}}
+
+\end{document}


### PR DESCRIPTION
Lists [pdfrender](https://www.ctan.org/pkg/pdfrender) as compatible with a comment that it only works with luatex and pdftex and adds a test. I wanted to add more examples but I couldn't get any of the options to do anything except these...