### PR TITLE
add fnpos compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -3298,11 +3298,13 @@
 
  - name: fnpos
    type: package
-   status: compatible
+   status: partially-compatible
    included-in:
    priority: 9
    issues:
+   comments: Redefines `\\@makecol`.
    tests: true
+   tasks: Revisit once OR is altered.
    updated: 2024-07-31
 
  - name: fnumprint

--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -3298,13 +3298,12 @@
 
  - name: fnpos
    type: package
-   status: unknown
+   status: compatible
    included-in:
    priority: 9
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   updated: 2024-07-31
 
  - name: fnumprint
    type: package

--- a/tagging-status/testfiles/fnpos/fnpos-01.tex
+++ b/tagging-status/testfiles/fnpos/fnpos-01.tex
@@ -1,0 +1,48 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass[twocolumn]{article} % seems fine with or without twocolumn
+
+\usepackage{fnpos}
+\usepackage{graphicx}
+\usepackage[nopar]{kantlipsum}
+
+% these are defaults with fnpos
+%\makeFNbottom
+%\makeFNbelow
+
+\begin{document}
+
+\kant[1]\footnote{\kant[2]}
+\begin{figure}[b]
+\includegraphics[alt=alt text,scale=0.5]{example-image}
+\caption{First image}
+\end{figure}
+\kant[3]
+
+\kant[4]\footnote{\kant[5]}
+\begin{figure}[b]
+\includegraphics[alt=alt text,scale=0.5]{example-image}
+\caption{Second image}
+\end{figure}
+\kant[6]
+
+\kant[7]\footnote{\kant[8]}
+\begin{figure}[b]
+\includegraphics[alt=alt text,scale=0.5]{example-image}
+\caption{Third image}
+\end{figure}
+\kant[9]
+
+\kant[10]\footnote{\kant[11]}
+\begin{figure}[b]
+\includegraphics[alt=alt text,scale=0.5]{example-image}
+\caption{Fourth image}
+\end{figure}
+\kant[12]
+
+\end{document}


### PR DESCRIPTION
Lists [fnpos](https://www.ctan.org/pkg/fnpos) as compatible and adds a test. The package redefines `\@makecol` which seems dangerous but I couldn't get it to break or mess up the tagging for multicol or twocolumn.