### PR TITLE
add fnpct compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -3288,13 +3288,13 @@
 
  - name: fnpct
    type: package
-   status: unknown
+   status: compatible
    included-in: [tlc3]
    priority: 2
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-14
+   comments: "`ranges` option does not work with hyperref."
+   tests: true
+   updated: 2024-07-31
 
  - name: fnpos
    type: package

--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -3288,7 +3288,7 @@
 
  - name: fnpct
    type: package
-   status: compatible
+   status: partially-compatible
    included-in: [tlc3]
    priority: 2
    issues:

--- a/tagging-status/testfiles/fnpct/fnpct-01.tex
+++ b/tagging-status/testfiles/fnpct/fnpct-01.tex
@@ -1,0 +1,35 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+\usepackage{fnpct}
+
+\title{fnpct tagging test}
+
+\begin{document}
+
+The three little pigs built their houses out of straw\footnote*{not to be
+confused with hay}, sticks  \footnote{or lumber according to some sources}
+and bricks\footnote{probably fired clay bricks}.
+
+The three little pigs built their houses out of straw\footnote{not to be
+confused with hay}, sticks\footnote{or lumber according to some sources}
+and bricks\footnote{probably fired clay bricks}\footnote{or something else}.
+
+\setfnpct{ranges}
+The three little pigs built their houses out of
+straw\footnote{not to be confused with hay},
+sticks\footnote{or lumber according to some sources}
+and bricks\footnote{probably fired clay bricks}%
+\footnote{or something else}\footnote{what do I know}.
+
+\setfnpct{ add-trailing-token = !{bang} }
+The three little pigs built their houses out of straw\footnote{not to be
+confused with hay}? Sticks\footnote{or lumber according to some sources}
+and bricks\footnote{probably fired clay bricks}!
+
+\end{document}


### PR DESCRIPTION
Lists [fnpct](https://www.ctan.org/pkg/fnpct) as compatible with a note that the `ranges` option does not work with hyperref.