### PR TITLE
change fontawesome5 status

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -3318,12 +3318,13 @@
 
  - name: fontawesome5
    type: package
-   status: compatible
+   status: partially-compatible
    included-in: [tlc3]
    priority: 2
    issues:
-   tests: false
-   updated: 2024-07-14
+   tests: true
+   comments: Symbols missing ToUnicode/ActualText.
+   updated: 2024-07-31
 
  - name: fontaxes
    type: package

--- a/tagging-status/testfiles/fontawesome5/fontawesome5-01.tex
+++ b/tagging-status/testfiles/fontawesome5/fontawesome5-01.tex
@@ -1,0 +1,27 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+\usepackage{fontawesome5}
+
+\title{fontawesome5 tagging test}
+
+\begin{document}
+
+A simple icon: \faHandPointUp
+
+Multiple versions of the file icon:
+
+\faFile
+
+\faFile*
+
+\faFile[regular]
+
+\faFile*[regular]
+
+\end{document}


### PR DESCRIPTION
Changes the status for fontawesome5 to partially-compatible since the symbols are missing ToUnicode/ActualText values.