### PR TITLE
add froufrou compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -3516,13 +3516,13 @@
 
  - name: froufrou
    type: package
-   status: unknown
+   status: partially-compatible
    included-in:
    priority: 9
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   comments: Ornaments should be tagged as Artifacts.
+   updated: 2024-07-31
 
  - name: ftnright
    type: package

--- a/tagging-status/testfiles/froufrou/froufrou-01.tex
+++ b/tagging-status/testfiles/froufrou/froufrou-01.tex
@@ -1,0 +1,22 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+\usepackage{froufrou}
+
+\title{froufrou tagging test}
+
+\begin{document}
+
+Some text
+\froufrou
+More text
+\froufrou[dinkus]
+And more text
+\froufrou[closing]
+
+\end{document}


### PR DESCRIPTION
Lists [froufrou](https://www.ctan.org/pkg/froufrou) as partially-compatible because the symbols are not tagged as Artifacts.