### PR TITLE
add fwlw compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -3546,13 +3546,13 @@
 
  - name: fwlw
    type: package
-   status: unknown
+   status: partially-compatible
    included-in: [tlc3]
    priority: 2
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-14
+   tests: true
+   comments: Words printed in header/footer should be tagged as Artifacts.
+   updated: 2024-07-31
 
 #------------------------ GGG ----------------------------
 

--- a/tagging-status/testfiles/fwlw/fwlw-01.tex
+++ b/tagging-status/testfiles/fwlw/fwlw-01.tex
@@ -1,0 +1,20 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+\usepackage{fwlw}
+\usepackage{kantlipsum}
+
+\title{fwlw tagging test}
+
+\pagestyle{fwlwhead}
+
+\begin{document}
+
+\kant
+
+\end{document}

--- a/tagging-status/testfiles/fwlw/fwlw-02.tex
+++ b/tagging-status/testfiles/fwlw/fwlw-02.tex
@@ -1,0 +1,20 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+\usepackage{fwlw}
+\usepackage{kantlipsum}
+
+\title{fwlw tagging test}
+
+\pagestyle{NextWordFoot}
+
+\begin{document}
+
+\kant
+
+\end{document}


### PR DESCRIPTION
Lists fwlw as partially-compatible because the words printed in header/footer should be tagged as Artifacts.