### PR TITLE
math symbol packages

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -3011,13 +3011,13 @@
 
  - name: fdsymbol
    type: package
-   status: unknown
+   status: compatible
    included-in:
    priority: 9
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   comments: `\\circledR` and `\\circledS` need ToUnicode values.
+   updated: 2024-07-31
 
  - name: fetamont
    type: package
@@ -5260,13 +5260,14 @@
 
  - name: MnSymbol
    type: package
-   status: unknown
+   status: compatible
    included-in: [arxiv01]
-   priority: 6
+   included-in:
+   priority: 9
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   comments: `\\circledR` and `\\circledS` need ToUnicode values.
+   updated: 2024-07-31
 
  - name: magaz
    type: package
@@ -5513,13 +5514,13 @@
 
  - name: mdsymbol
    type: package
-   status: unknown
+   status: compatible
    included-in:
    priority: 9
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   comments: `\\circledR` and `\\circledS` need ToUnicode values.
+   updated: 2024-07-31
 
  - name: media9
    type: package

--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -3014,9 +3014,11 @@
    status: compatible
    included-in:
    priority: 9
+   supported-through: [phase-III,math]
+   comments: "`\\circledR` and `\\circledS` need ToUnicode values.
+              Use of math tagging currently requires support from external tools."
    issues:
    tests: true
-   comments: `\\circledR` and `\\circledS` need ToUnicode values.
    updated: 2024-07-31
 
  - name: fetamont
@@ -5264,9 +5266,11 @@
    included-in: [arxiv01]
    included-in:
    priority: 9
+   supported-through: [phase-III,math]
+   comments: "`\\circledR` and `\\circledS` need ToUnicode values.
+              Use of math tagging currently requires support from external tools."
    issues:
    tests: true
-   comments: `\\circledR` and `\\circledS` need ToUnicode values.
    updated: 2024-07-31
 
  - name: magaz
@@ -5356,13 +5360,15 @@
 
  - name: mathabx
    type: package
-   status: unknown
+   status: partially-compatible
    included-in: [arxiv01]
    priority: 6
+   supported-through: [phase-III,math]
+   comments: "Must be loaded after amsmath. Math symbols are not sensibly mapped to unicode.
+              Use of math tagging currently requires support from external tools."
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   updated: 2024-07-31
 
  - name: mathalpha
    type: package
@@ -5517,9 +5523,11 @@
    status: compatible
    included-in:
    priority: 9
+   supported-through: [phase-III,math]
+   comments: "`\\circledR` and `\\circledS` need ToUnicode values.
+              Use of math tagging currently requires support from external tools."
    issues:
    tests: true
-   comments: `\\circledR` and `\\circledS` need ToUnicode values.
    updated: 2024-07-31
 
  - name: media9

--- a/tagging-status/testfiles/MnSymbol/MnSymbol-01.tex
+++ b/tagging-status/testfiles/MnSymbol/MnSymbol-01.tex
@@ -1,0 +1,39 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+\usepackage{MnSymbol}
+
+\title{MnSymbol tagging test}
+
+\begin{document}
+
+\circledR
+
+\circledS
+
+\yen
+
+\dagger
+
+\ddagger
+
+\mathparagraph
+
+\mathsection
+
+\mathdollar
+
+\mathsterling
+
+$\doublebarwedge$
+
+$\dashedsearrow$
+
+$\int_i^j f(x)$
+
+\end{document}

--- a/tagging-status/testfiles/fdsymbol/fdsymbol-01.tex
+++ b/tagging-status/testfiles/fdsymbol/fdsymbol-01.tex
@@ -1,0 +1,39 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+\usepackage{fdsymbol}
+
+\title{fdsymbol tagging test}
+
+\begin{document}
+
+\circledR
+
+\circledS
+
+\yen
+
+\dagger
+
+\ddagger
+
+\mathparagraph
+
+\mathsection
+
+\mathdollar
+
+\mathsterling
+
+$\doublebarwedge$
+
+$\approxeq$
+
+$\int_i^j f(x)$
+
+\end{document}

--- a/tagging-status/testfiles/mathabx/mathabx-01.tex
+++ b/tagging-status/testfiles/mathabx/mathabx-01.tex
@@ -1,0 +1,26 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+\usepackage{amsmath}
+\usepackage{mathabx}
+\providecommand\mathbfont{\usefont{U}{mathb}{m}{n}} % bug in mathabx
+
+\title{mathabx tagging test}
+
+\begin{document}
+
+$\upupharpoons$
+
+$\doublebarwedge$
+
+$\int_i^j f(x)$
+
+\mayadelimiters([,])
+$\maya{1251}+\maya{2135}=\maya{3386}\neq\mayadigit{0}$
+
+\end{document}

--- a/tagging-status/testfiles/mdsymbol/mdsymbol-01.tex
+++ b/tagging-status/testfiles/mdsymbol/mdsymbol-01.tex
@@ -1,0 +1,39 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+\usepackage{mdsymbol}
+
+\title{mdsymbol tagging test}
+
+\begin{document}
+
+\circledR
+
+\circledS
+
+\yen
+
+\dagger
+
+\ddagger
+
+\mathparagraph
+
+\mathsection
+
+\mathdollar
+
+\mathsterling
+
+$\doublebarwedge$
+
+$\approxeq$
+
+$\int_i^j f(x)$
+
+\end{document}


### PR DESCRIPTION
Lists fdsymbol, mdsymbol, and MnSymbol as compatible, with a comment that the `\circledR` and `\circledS` commands need ToUnicode values.

Lists mathabx as partially-compatible because the math symbols are not sensibly mapped to unicode. It also must be loaded after amsmath.