### PR TITLE
add sillypage info

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -7895,10 +7895,12 @@
    status: compatible
    included-in: [tlc3]
    priority: 2
+   supported-through: [phase-III,package]
+   package-repository: "https://github.com/cereda/sillypage"
    comments:
    issues:
    tests: true
-   updated: 2024-07-24
+   updated: 2024-08-01
 
  - name: simpleicons
    type: package


### PR DESCRIPTION
Adds `supported-through: [phase-III,package]` and the repo link for sillypage.