### PR TITLE
add bibstyles

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -562,13 +562,12 @@
  - name: apalike
    ctan-pkg: bibtex
    type: package
-   status: unknown
+   status: compatible
    included-in: [tlc3]
    priority: 2
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-13
+   updated: 2024-07-31
 
  - name: arabi
    type: package
@@ -664,13 +663,13 @@
 
  - name: astron
    type: package
-   status: unknown
+   status: compatible
    included-in: [tlc3]
    priority: 2
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-13
+   comments: Not distributed with texlive.
+   updated: 2024-07-31
 
  - name: asymptote
    type: package
@@ -1702,13 +1701,12 @@
 
  - name: chicago
    type: package
-   status: unknown
+   status: compatible
    included-in: [tlc3]
    priority: 2
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-14
+   updated: 2024-07-31
 
  - name: cinzel
    type: package
@@ -4463,13 +4461,12 @@
 
  - name: jmb
    type: package
-   status: unknown
+   status: compatible
    included-in: [tlc3]
    priority: 2
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-15
+   updated: 2024-07-31
 
  - name: josefin
    type: package
@@ -5891,13 +5888,13 @@
 
  - name: named
    type: package
-   status: unknown
+   status: compatible
    included-in: [tlc3]
    priority: 2
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-15
+   comments: Not distributed with texlive.
+   updated: 2024-07-31
 
  - name: nameref
    type: package
@@ -5909,13 +5906,12 @@
 
  - name: nar
    type: package
-   status: unknown
+   status: compatible
    included-in: [tlc3]
    priority: 2
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-15
+   updated: 2024-07-31
 
  - name: natbib
    type: package
@@ -5965,12 +5961,12 @@
 
  - name: newapa
    type: package
-   status: unknown
+   status: compatible
    included-in: [tlc3]
    priority: 2
    issues:
    tests: false
-   tasks: needs tests
+   comments: Not distributed with texlive.
    updated: 2024-07-15
 
  - name: newcent
@@ -9177,16 +9173,6 @@
    comments: An old issue has been fixed.
    issues: [5]
    updated: 2024-07-06
-
- - name: urlbst
-   type: package
-   status: unknown
-   included-in: [tlc3]
-   priority: 2
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-15
 
  - name: utopia
    type: package


### PR DESCRIPTION
Several of the packages listed in the yaml file are bibliography styles with accompanying 209 style files (or in the case of [nar](https://ctan.org/pkg/nar), no .sty file). This lists those as compatible without adding test files, though I did a quick check with each that they didn't break tagging. Three of them are not distributed with texlive so a note was added for those.

The listed packages are apalike, [astron](https://ctan.org/pkg/astron), [chicago](https://ctan.org/pkg/chicago), [jmb](https://www.ctan.org/pkg/jmb), [named](https://ctan.org/pkg/named), [nar](https://ctan.org/pkg/nar), and [newapa](https://ctan.org/pkg/newapa).

I also removed [urlbst](https://ctan.org/pkg/urlbst) since it's not a package but a perl script.