### PR TITLE
add several compatible packages

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -654,13 +654,12 @@
 
  - name: askinclude
    type: package
-   status: unknown
+   status: compatible
    included-in: [tlc3]
    priority: 2
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-13
+   tests: true
+   updated: 2024-08-01
 
  - name: astron
    type: package
@@ -1112,13 +1111,12 @@
 
  - name: bitset
    type: package
-   status: unknown
+   status: compatible
    included-in: [arxiv10]
    priority: 3
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   updated: 2024-08-01
 
  - name: bitter
    type: package
@@ -1940,13 +1938,13 @@
 
  - name: continue
    type: package
-   status: unknown
+   status: partially-compatible
    included-in: [tlc3]
    priority: 2
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-14
+   tests: true
+   comments: Continuation marks should be tagged as Artifacts.
+   updated: 2024-08-01
 
  - name: contour
    type: package
@@ -2500,13 +2498,12 @@
 
  - name: ellipsis
    type: package
-   status: unknown
+   status: compatible
    included-in: [tlc3]
    priority: 2
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-14
+   tests: true
+   updated: 2024-08-01
 
  - name: embedall
    type: package
@@ -5033,12 +5030,12 @@
 
  - name: ltxcmds
    type: package
-   status: unknown
+   status: compatible
    included-in: [arxiv10]
    priority: 4
    issues:
    tests: false
-   updated: 2024-07-28
+   updated: 2024-08-01
 
  - name: ltxgrid
    type: package
@@ -6197,13 +6194,12 @@
 
  - name: nolbreaks
    type: package
-   status: unknown
+   status: compatible
    included-in: [tlc3]
    priority: 2
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-15
+   tests: true
+   updated: 2024-08-01
 
  - name: nomencl
    type: package
@@ -6225,13 +6221,12 @@
 
  - name: nopageno
    type: package
-   status: unknown
+   status: compatible
    included-in: [tlc3]
    priority: 2
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-15
+   tests: true
+   updated: 2024-08-01
 
  - name: notes2bib
    type: package
@@ -6438,13 +6433,12 @@
 
  - name: onepagem
    type: package
-   status: unknown
+   status: compatible
    included-in: [tlc3]
    priority: 2
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-15
+   tests: true
+   updated: 2024-08-01
 
  - name: opensans
    type: package
@@ -6855,12 +6849,12 @@
 
  - name: pdftexcmds
    type: package
-   status: unknown
+   status: compatible
    included-in: [arxiv10]
    priority: 3
    issues:
    tests: false
-   updated: 2024-07-28
+   updated: 2024-08-01
 
  - name: pdfx
    type: package
@@ -7334,13 +7328,12 @@
 
  - name: refcount
    type: package
-   status: unknown
+   status: compatible
    included-in: [arxiv10]
    priority: 3
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-17
+   tests: true
+   updated: 2024-08-01
 
  - name: refstyle
    type: package
@@ -7383,13 +7376,12 @@
 
  - name: relsize
    type: package
-   status: unknown
+   status: compatible
    included-in: [tlc3, arxiv1]
    priority: 2
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-15
+   tests: true
+   updated: 2024-08-01
 
  - name: repeatindex
    type: package
@@ -7944,13 +7936,12 @@
 
  - name: snapshot
    type: package
-   status: unknown
+   status: compatible
    included-in: [tlc3]
    priority: 2
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-15
+   tests: true
+   updated: 2024-08-01
 
  - name: snotez
    type: package
@@ -9501,13 +9492,12 @@
 
  - name: xgreek
    type: package
-   status: unknown
+   status: compatible
    included-in: [tlc3]
    priority: 2
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-15
+   tests: true
+   updated: 2024-08-01
 
  - name: xhfill
    type: package

--- a/tagging-status/testfiles/askinclude/askinclude-01-part1.tex
+++ b/tagging-status/testfiles/askinclude/askinclude-01-part1.tex
@@ -1,0 +1,5 @@
+\chapter{blub}
+\begin{tabular}{cc}
+A & B \\
+C & D
+\end{tabular}

--- a/tagging-status/testfiles/askinclude/askinclude-01-part2.tex
+++ b/tagging-status/testfiles/askinclude/askinclude-01-part2.tex
@@ -1,0 +1,5 @@
+\chapter{another blub}
+\begin{figure}
+Some figure
+\caption{some caption}
+\end{figure}

--- a/tagging-status/testfiles/askinclude/askinclude-01.tex
+++ b/tagging-status/testfiles/askinclude/askinclude-01.tex
@@ -1,0 +1,19 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{report}
+\usepackage{askinclude}
+
+\title{askinclude tagging test}
+
+\begin{document}
+
+Some intro text
+\include{askinclude-01-part1}
+\include{askinclude-01-part2}
+
+\end{document}

--- a/tagging-status/testfiles/bitset/bitset-01.tex
+++ b/tagging-status/testfiles/bitset/bitset-01.tex
@@ -1,0 +1,23 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{report}
+\usepackage{bitset}
+
+\title{bitset tagging test}
+
+\begin{document}
+
+\bitsetReset{abc}
+\bitsetSet{abc}{2}
+\bitsetGetBin{abc}{8}
+
+\bitsetSet{abc}{5}
+\bitsetSet{abc}{7}
+\bitsetGetHex{abc}{16}
+
+\end{document}

--- a/tagging-status/testfiles/continue/continue-01.tex
+++ b/tagging-status/testfiles/continue/continue-01.tex
@@ -1,0 +1,35 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass[a5paper,twoside]{article}
+
+\usepackage[margin,word,allpages]{continue}
+\usepackage{kantlipsum}
+
+\renewcommand*{\preflagword}{[}
+
+\title{continue tagging test - 1}
+
+\begin{document}
+
+First\footnote{Foot 1} \kant[1]
+
+Second\footnote{Foot 2} \kant[2]
+
+Third\footnote{Foot 3} \kant[3]
+
+\contstop % stop marking
+
+Fourth\footnote{Foot 4} \kant[4]
+
+Fifth\footnote{Foot 5} \kant[5]
+
+\contgo % start marking
+
+Sixth\footnote{Foot 6} \kant[6]
+
+\end{document}

--- a/tagging-status/testfiles/continue/continue-02.tex
+++ b/tagging-status/testfiles/continue/continue-02.tex
@@ -1,0 +1,35 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass[a5paper,twoside]{article}
+
+\usepackage[margin,allpages]{continue}
+\usepackage{kantlipsum}
+
+\renewcommand{\flagcont}{---$>$}
+
+\title{continue tagging test - 2}
+
+\begin{document}
+
+First\footnote{Foot 1} \kant[1]
+
+Second\footnote{Foot 2} \kant[2]
+
+Third\footnote{Foot 3} \kant[3]
+
+\contstop % stop marking
+
+Fourth\footnote{Foot 4} \kant[4]
+
+Fifth\footnote{Foot 5} \kant[5]
+
+\contgo % start marking
+
+Sixth\footnote{Foot 6} \kant[6]
+
+\end{document}

--- a/tagging-status/testfiles/ellipsis/ellipsis-01.tex
+++ b/tagging-status/testfiles/ellipsis/ellipsis-01.tex
@@ -1,0 +1,26 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+
+\usepackage{ellipsis}
+
+\renewcommand{\ellipsisgap}{0.2em}
+
+\title{ellipsis tagging test}
+
+\begin{document}
+
+Some text\dots more text.
+
+Some text\dots.
+
+Some text\textellipsis more text.
+
+Some text\textellipsis.
+
+\end{document}

--- a/tagging-status/testfiles/nolbreaks/nolbreaks-01.tex
+++ b/tagging-status/testfiles/nolbreaks/nolbreaks-01.tex
@@ -1,0 +1,28 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+
+\usepackage{nolbreaks}
+
+\title{nolbreaks tagging test}
+
+\begin{document}
+
+Some normal text many times Some normal text many times Some normal text many times Some normal text many times Some normal text many times Some normal text many times
+
+\nolbreaks{%
+Some normal text many times Some normal text many times Some normal text many times Some normal text many times Some normal text many times Some normal text many times
+}
+
+Some normal text many times Some normal text many times Some normal text many times Some normal text many times Some normal text many times Some normal text many times
+
+\nolbreaks*{%
+Some normal text many times Some normal text many times Some normal text many times Some normal text many times Some normal text many times Some normal text many times
+}
+
+\end{document}

--- a/tagging-status/testfiles/nopageno/nopageno-01.tex
+++ b/tagging-status/testfiles/nopageno/nopageno-01.tex
@@ -1,0 +1,25 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+\usepackage{nopageno}
+
+\title{nopageno tagging test}
+
+\begin{document}
+
+Some text
+
+\newpage
+
+Another page\footnote{here's a footnote}
+
+\newpage
+
+And another page
+
+\end{document}

--- a/tagging-status/testfiles/onepagem/onepagem-01.tex
+++ b/tagging-status/testfiles/onepagem/onepagem-01.tex
@@ -1,0 +1,21 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+
+\usepackage{onepagem}
+
+\title{onepagem tagging test}
+
+\begin{document}
+
+Only one page!
+
+%\newpage
+%Perhaps not.
+
+\end{document}

--- a/tagging-status/testfiles/refcount/refcount-01.tex
+++ b/tagging-status/testfiles/refcount/refcount-01.tex
@@ -1,0 +1,38 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+
+%\usepackage{refcount} % loaded by hyperref
+\usepackage{hyperref}
+
+\title{refcount tagging test}
+
+\begin{document}
+
+\newcounter{ctrA}
+\newcounter{ctrB}
+\refstepcounter{ctrA}\label{ref:A}
+\setcounterref{ctrB}{ref:A}
+\addtocounterpageref{ctrB}{ref:A}
+
+\thectrA
+
+\thectrB
+
+\section{Some section}
+\label{blub}
+
+\getrefbykeydefault{blub}{}{}
+
+\getrefbykeydefault{blub}{page}{}
+
+\getrefbykeydefault{blub}{name}{}
+
+\getrefbykeydefault{blub}{anchor}{}
+
+\end{document}

--- a/tagging-status/testfiles/relsize/relsize-01.tex
+++ b/tagging-status/testfiles/relsize/relsize-01.tex
@@ -1,0 +1,30 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+
+\usepackage{relsize}
+
+\title{relsize tagging test}
+
+\begin{document}
+
+Some normal text
+
+{\larger Some normal text}
+
+\textlarger[2]{Some normal text}
+
+{\smaller Some normal text}
+
+\textsmaller[2]{Some normal text}
+
+$\int\frac{1}{2}dN - \mathsmaller{\int\frac{1}{2}dN}$
+
+$\int\frac{1}{2}dN - \mathlarger{\int\frac{1}{2}dN}$
+
+\end{document}

--- a/tagging-status/testfiles/snapshot/snapshot-01.tex
+++ b/tagging-status/testfiles/snapshot/snapshot-01.tex
@@ -1,0 +1,32 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\RequirePackage{snapshot}
+\RequireVersions{
+*{application}{TeX} {1990/03/25 v3.x}
+*{format} {LaTeX2e} {1999/06/01 v2.e}
+*{package}{snapshot} {1999/11/03 v1.03}
+*{class} {article} {1999/01/07 v1.4a}
+*{file} {size10.clo} {1999/01/07 v1.4a}
+*{package}{graphicx} {1999/02/16 v1.0f}
+*{package}{keyval} {1999/03/16 v1.13}
+*{package}{graphics} {1999/02/16 v1.0l}
+*{package}{trig} {1999/03/16 v1.09}
+*{file} {graphics.cfg}{0000/00/00 v0.0}
+*{file} {dvips.def} {1999/02/16 v3.0i}
+}
+\documentclass{article}
+
+\usepackage{graphicx}
+
+\title{snapshot tagging test}
+
+\begin{document}
+
+Some text
+
+\end{document}

--- a/tagging-status/testfiles/xgreek/xgreek-01.tex
+++ b/tagging-status/testfiles/xgreek/xgreek-01.tex
@@ -1,0 +1,41 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+
+\usepackage{xgreek}
+\usepackage{fontspec}
+\setmainfont{Libertinus Serif}
+
+\title{xgreek δοκιμή επισήμανσης}
+\author{Κάποιος συγγραφέας}
+
+\begin{document}
+\maketitle
+
+\section{Ορισμένες επικεφαλίδες τμημάτων}
+Κάποιο ελληνικό κείμενο\footnote{Κάποιο κείμενο υποσημειώσεων}
+
+\anwtonos\par
+\katwtonos\par
+\koppa\par
+\sampi\par
+\Digamma\par
+\ddigamma\par
+\anoteleia\par
+\euro\par
+\permill\par
+\stigma\par
+
+\greeknumeral{125}\par
+\Greeknumeral{125}\par
+\atticnum{125}
+
+\grtoday\par
+\Grtoday
+
+\end{document}


### PR DESCRIPTION
This lists several packages as compatible that should be fairly clear. Lists askinclude, bitset, ellipsis, nolbreaks, nopageno, onepagem, refcount, relsize, snapshot, and xgreek as compatible with tests added.

Lists ltxcmds and pdftexcmds as compatible without adding tests.

Lists continue as partially-compatible because the continuation marks should be tagged as Artifacts.

