### PR TITLE
add embrac compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -2527,13 +2527,13 @@
 
  - name: embrac
    type: package
-   status: unknown
+   status: partially-compatible
    included-in: [tlc3]
    priority: 2
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-14
+   tests: true
+   comments: Inserts and removes unnecessary spaces at pdf level.
+   updated: 2024-08-01
 
  - name: emo
    type: package

--- a/tagging-status/testfiles/embrac/embrac-01.tex
+++ b/tagging-status/testfiles/embrac/embrac-01.tex
@@ -1,0 +1,34 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+
+\usepackage{embrac}
+
+\title{embrac tagging test}
+
+\begin{document}
+
+\emph{This is emphasized [sic] text (as you can see).}
+
+\emph*{This is emphasized [sic] text (as you can see).}
+
+\textit{This is emphasized [sic] text (as you can see).}
+
+\textit*{This is emphasized [sic] text (as you can see).}
+
+\textsl{This is emphasized [sic] text (as you can see).}
+
+\textsl*{This is emphasized [sic] text (as you can see).}
+
+{\itshape This is italic \embbracket{sic} text \embparen{as you can see}.}
+
+\ChangeEmph{(}[.1em]{)}[.1em]
+\emph{This is (just) emphasized text.} \par % looks OK, kind of
+\emph{This is emphasized text (as you can see).} % looks bad
+
+\end{document}


### PR DESCRIPTION
Lists embrac as partially-compatible because it inserts and removes spaces improperly at the pdf level. The behavior is different with pdftex and luatex.