### PR TITLE
add enotez compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -2727,13 +2727,14 @@
 
  - name: enotez
    type: package
-   status: unknown
+   status: partially-compatible
    included-in: [tlc3]
    priority: 2
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-14
+   tests: true
+   comments: "`\\pagenote`s are not tagged as `<Note>`s. `\\ref` in `\\endnotemark`
+              produces parent-child warnings."
+   updated: 2024-08-01
 
  - name: enparen
    type: package

--- a/tagging-status/testfiles/enotez/enotez-01.tex
+++ b/tagging-status/testfiles/enotez/enotez-01.tex
@@ -12,7 +12,7 @@
 
 \title{enotez tagging test - 1}
 
-\setenotez{reset,split=section}
+\setenotez{reset,split=section,backref}
 
 \begin{document}
 

--- a/tagging-status/testfiles/enotez/enotez-01.tex
+++ b/tagging-status/testfiles/enotez/enotez-01.tex
@@ -1,0 +1,28 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+
+\usepackage{enotez}
+\usepackage{hyperref}
+
+\title{enotez tagging test - 1}
+
+\setenotez{reset,split=section}
+
+\begin{document}
+
+\section{A first section}
+This is simple text.\endnote{An endnote.}
+Here is a bit more text.\endnote{The
+  second  endnote with two lines.}
+\section{Second section}
+Some\endnote{A third note.} text
+for this section also with a note.
+\newpage \printendnotes[itemize]
+
+\end{document}

--- a/tagging-status/testfiles/enotez/enotez-02.tex
+++ b/tagging-status/testfiles/enotez/enotez-02.tex
@@ -1,0 +1,23 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+
+\usepackage{enotez}
+\usepackage{hyperref}
+
+\title{enotez tagging test - 2}
+
+\begin{document}
+
+% produces parent-child warning
+The next endnote\endnote{This endnote gets a label.}\label{en:test} has
+the number~\ref{en:test}. Let's now test\endnotemark[\ref{en:test}].
+
+\printendnotes
+
+\end{document}


### PR DESCRIPTION
Lists enotez as partially-compatible because the `\endnote`s are not tagged as `<Note>`s and parent-child warnings are produced if `\endnotemark` contains a `\ref` command (see second test).