### PR TITLE
add libertinus-otf compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -5089,13 +5089,13 @@
 
  - name: libertinus-otf
    type: package
-   status: unknown
+   status: partially-compatible
    included-in:
    priority: 9
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   comments: Keyboard font needs ActualText.
+   updated: 2024-08-02
 
  - name: libertinust1math
    type: package

--- a/tagging-status/testfiles/libertinus-otf/libertinus-otf-01.tex
+++ b/tagging-status/testfiles/libertinus-otf/libertinus-otf-01.tex
@@ -1,0 +1,32 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article} 
+
+\usepackage[greek]{libertinus-otf}
+
+\begin{document}
+
+Normal text
+
+$β$
+
+\LKey{a}
+
+\LKeyWin
+
+\LKeyStrg
+
+\LKeyEnter
+
+\LKeyShiftAltGrX{C}
+
+\Lfrac{5/1289}
+
+\textinit{ABC}
+
+\end{document}


### PR DESCRIPTION
Lists [libertinus-otf](https://www.ctan.org/pkg/libertinus-otf) as partially compatible since the keyboard font needs ActualText.