### PR TITLE
add dashrule compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -2266,13 +2266,13 @@
 
  - name: dashrule
    type: package
-   status: unknown
+   status: compatible
    included-in: [tlc3]
    priority: 2
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-14
+   tests: true
+   comments: "`\\hdashrule` commands appear as Path in tags but so does `\\rule`."
+   updated: 2024-08-02
 
  - name: dashundergaps
    type: package

--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -2266,12 +2266,12 @@
 
  - name: dashrule
    type: package
-   status: compatible
+   status: partially-compatible
    included-in: [tlc3]
    priority: 2
    issues:
    tests: true
-   comments: "`\\hdashrule` commands appear as Path in tags but so does `\\rule`."
+   comments: "`\\hdashrule` commands should be tagged as Artifacts."
    updated: 2024-08-02
 
  - name: dashundergaps

--- a/tagging-status/testfiles/dashrule/dashrule-01.tex
+++ b/tagging-status/testfiles/dashrule/dashrule-01.tex
@@ -1,0 +1,46 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,table,title,firstaid}
+  }
+\documentclass{article}
+
+\usepackage{dashrule}
+
+\title{dashrule tagging test}
+
+\begin{document}
+
+\rule{2cm}{1pt} % to compare tagging
+
+\hdashrule{2cm}{1pt}{}
+
+\hdashrule{2cm}{1pt}{1pt}
+
+\hdashrule{4cm}{1pt}{1pt}
+
+\hdashrule[0.5ex]{4cm}{1pt}{1pt}
+
+\hdashrule[0.5ex]{4cm}{1pt}{3mm}
+
+\hdashrule[0.5ex]{4cm}{1mm}{3mm}
+
+\hdashrule[0.5ex]{4cm}{1mm}{3mm 3pt}
+
+\hdashrule[0.5ex]{4cm}{1mm}{3mm 3pt 1mm 2pt}
+
+\hdashrule[0.5ex]{4cm}{1mm}{8mm 2pt}
+
+\hdashrule[0.5ex]{3cm}{1mm}{8mm 2pt}
+
+\hdashrule[0.5ex][c]{4cm}{1mm}{8mm 2pt}
+
+\hdashrule[0.5ex][c]{3cm}{1mm}{8mm 2pt}
+
+\hdashrule[0.5ex][x]{4cm}{1mm}{8mm 2pt}
+
+\hdashrule[0.5ex][x]{3cm}{1mm}{8mm 2pt}
+
+\end{document}


### PR DESCRIPTION
Lists [dashrule](https://ctan.org/pkg/dashrule) as compatible and adds a test. I'm not sure about this one because the rule commands appear as "Path" or worse "PathPathPath..." in tags, however this is also the behavior of `\rule`. Maybe these should be Artifacts? But then the same should be true for `\rule`.