### PR TITLE
add todonotes, luatodonotes, and changes compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -1696,13 +1696,13 @@
 
  - name: changes
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in: [tlc3, arxiv01]
    priority: 2
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-14
+   tests: true
+   comments: See todonotes and ulem.
+   updated: 2024-08-02
 
  - name: chappg
    type: package
@@ -5448,13 +5448,12 @@
 
  - name: luatodonotes
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in:
    priority: 9
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   issues: [425]
+   tests: true
+   updated: 2024-08-02
 
  - name: luavlna
    type: package
@@ -9305,13 +9304,12 @@
 
  - name: todonotes
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in: [tlc3, arxiv1]
    priority: 2
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-15
+   issues: [424]
+   tests: true
+   updated: 2024-08-02
 
  - name: topcapt
    type: package

--- a/tagging-status/testfiles/changes/changes-01.tex
+++ b/tagging-status/testfiles/changes/changes-01.tex
@@ -1,0 +1,21 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+\usepackage{changes}
+
+\title{changes tagging test - 1}
+
+\begin{document}
+
+Sample text, something \added{added},
+a \replaced{word}{blob} replaced and
+\deleted{some} stuff\comment{Fix!}
+removed. \highlight{Whoa!}
+\listofchanges
+
+\end{document}

--- a/tagging-status/testfiles/changes/changes-02.tex
+++ b/tagging-status/testfiles/changes/changes-02.tex
@@ -1,0 +1,19 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+\usepackage[final]{changes}
+
+\title{changes tagging test - 2}
+
+\begin{document}
+
+Sample text, something \added{added}, a \replaced{word}{blob}
+replaced and \deleted{some} stuff\comment{Fix!} removed.
+\highlight{Whoa!}    \listofchanges
+
+\end{document}

--- a/tagging-status/testfiles/changes/changes-03.tex
+++ b/tagging-status/testfiles/changes/changes-03.tex
@@ -1,0 +1,24 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+\usepackage{changes}
+\definechangesauthor[color=red,name=Frank]{FMi}
+
+\title{changes tagging test - 3}
+
+\begin{document}
+% parent-child warnings
+Sample text, something \added{added},
+a \replaced[id=FMi,comment=really?]
+        {word}{blob} replaced
+and \deleted[id=FMi]{some} stuff
+removed.\comment{Fix it everywhere
+in the document!}
+\listofchanges
+
+\end{document}

--- a/tagging-status/testfiles/changes/changes-04.tex
+++ b/tagging-status/testfiles/changes/changes-04.tex
@@ -1,0 +1,29 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+\usepackage[commentmarkup=footnote]
+           {changes}
+\definechangesauthor[color=red,
+            name=Frank M.]{FMi}
+\setsummarytowidth{Commented\qquad}
+
+\title{changes tagging test - 4}
+
+\begin{document}
+
+Sample text, something \added{added},
+a \replaced[id=FMi,comment=really?]
+           {word}{blob}
+replaced and \deleted[id=FMi]{some}
+\highlight{stuff}
+removed.\comment[id=FMi]{Mumble!}
+
+\listofchanges[title=Summary of
+             changes,style=summary]
+
+\end{document}

--- a/tagging-status/testfiles/luatodonotes/luatodonotes-01.tex
+++ b/tagging-status/testfiles/luatodonotes/luatodonotes-01.tex
@@ -1,0 +1,17 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+\usepackage{luatodonotes}
+
+\title{luatodonotes tagging test}
+
+\begin{document}
+
+text\todo{blub}
+
+\end{document}

--- a/tagging-status/testfiles/todonotes/todonotes-01.tex
+++ b/tagging-status/testfiles/todonotes/todonotes-01.tex
@@ -1,0 +1,17 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+\usepackage{todonotes}
+
+\title{todonotes tagging test}
+
+\begin{document}
+
+text\todo{blub}
+
+\end{document}


### PR DESCRIPTION
Lists todonotes, luatodonotes, and changes as currently-incompatible. The first two are discussed in #424 and #425. The third relies on todonotes and ulem, which are incompatible.