### PR TITLE
remove luapstricks

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -5417,16 +5417,6 @@
    tests: true
    updated: 2024-07-29
 
- - name: luapstricks
-   type: package
-   status: unknown
-   included-in: [tlc3]
-   priority: 2
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-15
-
  - name: luatexja
    type: package
    status: currently-incompatible


### PR DESCRIPTION
Removes [luapstricks](https://www.ctan.org/pkg/luapstricks) from the yaml file because it is not a .sty file loaded with `\usepackage` but the default support for pstricks with luatex.