### PR TITLE
add magaz compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -5545,13 +5545,13 @@
 
  - name: magaz
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in: [tlc3]
    priority: 2
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-15
+   tests: true
+   comments: "Inserts empty `<Formula>`s."
+   updated: 2024-08-02
 
  - name: magicnum
    type: package

--- a/tagging-status/testfiles/magaz/magaz-01.tex
+++ b/tagging-status/testfiles/magaz/magaz-01.tex
@@ -1,0 +1,32 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+
+\usepackage{magaz}
+\renewcommand\FirstLineFont{\bfseries}
+\setlength\textwidth{159.0pt}
+
+\title{magaz tagging test}
+
+\begin{document}
+
+\FirstLine{The first line of this paragraph is
+           typeset in boldface. And more text to display the behavior.}
+The remainder is set in the normal body font.
+
+\FirstLine{\noindent Less material} in the argument
+will be fully typeset in the special font. Note the
+placement and result of the \verb=\noindent= command.
+
+% produces parent-child warnings, but is a mistake as mentioned in the text
+%\noindent\FirstLine{If placed in front it will get
+%lost} as you can see here.
+
+\FirstLine{There is no just \emph{ground}, therefore, $a+b=c$ for the charge $x\in\{0,1,2\}$ brought against me by certain ignoramuses.}
+
+\end{document}


### PR DESCRIPTION
Lists [magaz](https://www.ctan.org/pkg/magaz) as currently-incompatible because it inserts empty formulas and other empty tags. It also errors if preceded with `\noindent` but this is user error as mentioned in the tlc3 example.