### PR TITLE
add overpic compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -6813,13 +6813,14 @@
 
  - name: overpic
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in: [tlc3, arxiv01]
    priority: 2
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-15
+   tests: true
+   comments: "No way to tag as Artifact or with Alt text. Argument of `Overpic`
+              cannot contain arbitrary content like tabular."
+   updated: 2024-08-02
 
 #------------------------ PPP ----------------------------
 

--- a/tagging-status/testfiles/overpic/overpic-01.tex
+++ b/tagging-status/testfiles/overpic/overpic-01.tex
@@ -1,0 +1,38 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+
+\usepackage{overpic}
+\usepackage{xcolor}
+\usepackage{pict2e}
+
+\title{overpic tagging test - 1}
+
+\begin{document}
+
+\begin{overpic}[abs,unit=1mm,scale=.5,grid,alt=alt text]{example-image}
+\put(3,27){\color{blue}\huge\LaTeX}
+\end{overpic}
+
+\vspace{1cm}
+
+\begin{overpic}[scale=.5,percent ,grid,alt=alt text]{example-image}
+\put(5,45){\color{blue}\huge\LaTeX}
+\put(55,10){\color{red}%
+\frame{\includegraphics[scale=.2,alt=alt text]{example-image}}}
+\end{overpic}
+
+\vspace{1cm}
+
+\begin{Overpic}[grid,rel=50,tics=10]
+               {$ \displaystyle \sum_{i=1}^n x_i = A + B $}
+  \color{blue} \Vector(40,5)(32,9)
+  \put(42,3){\footnotesize\itshape some explanation}
+\end{Overpic}
+
+\end{document}

--- a/tagging-status/testfiles/overpic/overpic-02.tex
+++ b/tagging-status/testfiles/overpic/overpic-02.tex
@@ -1,0 +1,34 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+
+\usepackage{overpic}
+\usepackage{xcolor}
+\usepackage{pict2e}
+
+\title{overpic tagging test - 2}
+
+\begin{document}
+
+\begin{Overpic}[abs,unit=1mm,grid=true,tics=5]{%
+\bfseries\sffamily
+\begin{tabular}{*{8}{p{8mm}}}
+H & - & - & - & - & - & - & He\\
+Li & Be & B & C & N & O & F & Ne\\
+Na & Mg & Al & Si & P & S & Cl & Ar\\
+K & Ca & Ga & Ge & As & Se & Br & Kr\\
+Rb & Sr & In & Sn & Sb & Te & I & Xe\\
+Cs & Ba & Tl & Pb & Bi & Po & At & Rn\\
+Fr & Ra & 112& - & 114& - & - & - \\
+\end{tabular}}%
+\put(0,0){\color{blue}\linethickness{0.5mm}
+\polygon(0,30)(10,30)(10,21.5)(45,21.5)(45,13)(22,13)%
+(22,4.5)(0,4.5)}
+\end{Overpic}
+
+\end{document}


### PR DESCRIPTION
Lists [overpic](https://ctan.org/pkg/overpic) as currently-incompatible because there is no way to tag the picture as an Artifact or give alt text. Also, the argument of `Overpic` cannot contain arbitrary content like a tabular without producing parent-child warnings (second test).