### PR TITLE
add pgf extras

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -7230,42 +7230,41 @@
 
  - name: pgfcalendar
    type: package
-   status: unknown
+   status: compatible
    included-in: [arxiv001]
    priority: 7
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-08-01
+   tests: true
+   updated: 2024-08-02
 
  - name: pgffor
    ctan-pkg: pgf
    type: package
-   status: unknown
+   status: compatible
    included-in: [arxiv10]
    priority: 3
    issues:
    tests: false
-   updated: 2024-07-28
+   updated: 2024-08-02
 
  - name: pgfkeys
    type: package
-   status: unknown
+   status: compatible
    included-in: [arxiv10]
    priority: 3
    issues:
    tests: false
-   updated: 2024-07-28
+   updated: 2024-08-02
 
  - name: pgfmath
    ctan-pkg: pgf
    type: package
-   status: unknown
+   status: compatible
    included-in: [arxiv10]
    priority: 3
    issues:
    tests: false
-   updated: 2024-07-28
+   updated: 2024-08-02
 
  - name: pgfmorepages
    type: package
@@ -7279,13 +7278,12 @@
 
  - name: pgfopts
    type: package
-   status: unknown
+   status: compatible
    included-in: [arxiv001]
    priority: 7
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-28
+   updated: 2024-08-02
 
  - name: pgfpages
    ctan-pkg: pgf
@@ -10103,13 +10101,12 @@
  - name: xxcolor
    ctan-pkg: pgf
    type: package
-   status: unknown
+   status: compatible
    included-in:
    priority: 9
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-08-01
+   tests: true
+   updated: 2024-08-02
 
  - name: xy
    ctan-pkg: xypic

--- a/tagging-status/testfiles/pgfcalendar/pgfcalendar-01.tex
+++ b/tagging-status/testfiles/pgfcalendar/pgfcalendar-01.tex
@@ -1,0 +1,34 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+
+\usepackage{pgfcalendar}
+
+\title{pgfcalendar tagging test}
+
+\begin{document}
+
+\pgfcalendar{cal}{2007-01-20}{2007-02-10}{\pgfcalendarcurrentday\ }
+
+\bigskip
+
+\pgfcalendar{cal}{2007-01-20}{2007-02-10}
+{
+\pgfcalendarcurrentday\
+\ifdate{Sunday}{\par}{}
+}
+
+\bigskip
+
+\pgfcalendar{cal}{2007-01-20}{2007-02-10}
+{%
+\leavevmode%
+\hbox to0pt{\hskip\pgfcalendarcurrentweekday cm\pgfcalendarcurrentday\hss}%
+\ifdate{Sunday}{\par}{}%
+}
+\end{document}

--- a/tagging-status/testfiles/xxcolor/xxcolor-01.tex
+++ b/tagging-status/testfiles/xxcolor/xxcolor-01.tex
@@ -1,0 +1,43 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+\usepackage{pgf} % xxcolor needs pgf utils
+\usepackage{xxcolor}
+\usepackage{calc}
+
+\begin{document}
+
+\begin{minipage}{3.5cm}\raggedright
+\color{red}Red text,
+\begin{colormixin}{25!white}
+washed-out red text,
+\color{blue} washed-out blue text,
+\begin{colormixin}{25!black}
+dark washed-out blue text,
+\color{green} dark washed-out green text,%
+\end{colormixin}
+back to washed-out blue text,%
+\end{colormixin}
+and back to red.
+\end{minipage}%
+
+\bigskip
+
+\begin{minipage}{\linewidth-6pt}\raggedright
+\begin{colormixin}{75!white}
+\colorcurrentmixin\ should be ``!75!white''\par
+\begin{colormixin}{75!black}
+\colorcurrentmixin\ should be ``!75!black!75!white''\par
+\begin{colormixin}{50!white}
+\colorcurrentmixin\ should be ``!50!white!75!black!75!white''\par
+\end{colormixin}
+\end{colormixin}
+\end{colormixin}
+\end{minipage}
+
+\end{document}


### PR DESCRIPTION
Lists pgfcalendar and xxcolor as compatible with tests.

Lists pgffor, pgfkeys, pgfmath, and pgfopts as compatible without tests.