### PR TITLE
add showtags compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -8232,13 +8232,12 @@
 
  - name: showtags
    type: package
-   status: unknown
+   status: compatible
    included-in: [tlc3]
    priority: 2
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-15
+   tests: true
+   updated: 2024-08-02
 
  - name: sidecap
    type: package

--- a/tagging-status/testfiles/showtags/showtags-01.tex
+++ b/tagging-status/testfiles/showtags/showtags-01.tex
@@ -1,0 +1,21 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+\usepackage{showtags}
+
+\begin{document}
+
+text
+
+\begin{thebibliography}{9}
+\bibitem{dihe:newdir}
+W.~Diffie and E.~Hellman, \emph{New directions in cryptography}, IEEE
+Transactions on Information Theory \textbf{22} (1976), no.~5, 644--654.
+\end{thebibliography}
+
+\end{document}


### PR DESCRIPTION
Lists [showtags](https://ctan.org/pkg/showtags) as compatible and adds a test. The citation key is tagged as an artifact, which is correct. The package redefines `\@bibitem` and `\@lbibitem` though which seems questionable.