### PR TITLE
add tabto compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -8735,13 +8735,13 @@
 
  - name: tabto
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in: [tlc3, arxiv01]
    priority: 2
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-15
+   tests: true
+   comments: Inserts empty `equation*` tags.
+   updated: 2024-08-02
 
  - name: tabu
    type: package

--- a/tagging-status/testfiles/tabto/tabto-01.tex
+++ b/tagging-status/testfiles/tabto/tabto-01.tex
@@ -1,0 +1,24 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+\usepackage{tabto}
+\usepackage{kantlipsum}
+
+\begin{document}
+
+\kant[1][1] \tabto{3cm}T1 \tabto{4cm}T2
+\tabto{3cm}T3 \kant[1][2] \tabto{4cm}T4
+\tabto*{2cm}T5
+
+\NumTabs{4}
+Start\tab T1\tab T2\tab T3\tab T0b \tab\tab T3b
+
+\TabPositions{.25\linewidth,.5\linewidth}
+Start\tab T1\tab T2 (last one in line)\tab T0b
+(get past T1b)\tab T2b \tabto*{.42\linewidth}T?
+\end{document}


### PR DESCRIPTION
Lists tabto as currently-incompatible because it inserts empty `equation*` tags.