### PR TITLE
add multicolrule compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -6106,13 +6106,12 @@
 
  - name: multicolrule
    type: package
-   status: unknown
+   status: compatible
    included-in: [tlc3]
    priority: 2
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-15
+   tests: true
+   updated: 2024-08-04
 
  - name: multido
    type: package

--- a/tagging-status/testfiles/multicolrule/multicolrule-01.tex
+++ b/tagging-status/testfiles/multicolrule/multicolrule-01.tex
@@ -1,0 +1,20 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,table,title,firstaid}
+  }
+\documentclass{article}
+\usepackage{multicol}
+\usepackage{multicolrule}
+\usepackage{xcolor}
+\usepackage{kantlipsum}
+
+\SetMCRule{width=thin,color=red,line-style=dots}
+
+\begin{document}
+\begin{multicols}{3}
+\kant[1-6]
+\end{multicols}
+\end{document}

--- a/tagging-status/testfiles/multicolrule/multicolrule-02.tex
+++ b/tagging-status/testfiles/multicolrule/multicolrule-02.tex
@@ -1,0 +1,19 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,table,title,firstaid}
+  }
+\documentclass[twocolumn]{article}
+\usepackage{multicolrule}
+\usepackage{xcolor}
+\usepackage{kantlipsum}
+
+\SetMCRule{width=thin,color=red,line-style=dots}
+
+\begin{document}
+
+\kant[1-6]
+
+\end{document}

--- a/tagging-status/testfiles/multicolrule/multicolrule-03.tex
+++ b/tagging-status/testfiles/multicolrule/multicolrule-03.tex
@@ -1,0 +1,24 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,table,title,firstaid}
+  }
+\documentclass{article}
+\usepackage[tikz]{multicolrule}
+\usepackage{pgfornament}
+\usepackage{kantlipsum}
+
+\SetMCRule{color=blue,width=1pt,
+  custom-line={\path (TOP) to
+    [ornament=83] (BOT);},
+  extend-top=-12pt,
+  extend-bot=-6pt}
+\setlength{\columnsep}{30pt}
+
+\begin{document}
+\begin{multicols}{3}
+\kant[1-6]
+\end{multicols}
+\end{document}


### PR DESCRIPTION
Lists [multicolrule](https://www.ctan.org/pkg/multicolrule) as compatible and adds some tests. The rules seem to be correctly tagged as Artifacts.