### PR TITLE
remove nature entry

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -6240,16 +6240,6 @@
    priority: 2
    updated: 2024-07-06
 
- - name: nature
-   type: package
-   status: unknown
-   included-in: [tlc3, arxiv01]
-   priority: 2
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-15
-
  - name: navigator
    type: package
    status: unknown


### PR DESCRIPTION
The current entry for nature in the yaml file links to https://www.ctan.org/pkg/nature which does not contain the nature.sty and nature.bst mentioned in the 1994 latex companion. These files are on CTAN [here](https://www.ctan.org/tex-archive/obsolete/biblio/bibtex/contrib/#nature.bst) under `obsolete/biblio/bibtex/contrib` and not distributed with texlive.

This PR removes the nature entry, but if it should remain with a more appropriate link that's of course fine too. Looking at nature.sty though, it would certainly error with current latex regardless of tagging.