### PR TITLE
add stfloats compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -8480,13 +8480,12 @@
 
  - name: stfloats
    type: package
-   status: unknown
+   status: compatible
    included-in: [tlc3, arxiv1]
    priority: 2
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-15
+   tests: true
+   updated: 2024-08-04
 
  - name: stickstootext
    ctan-pkg: stickstoo

--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -8480,7 +8480,7 @@
 
  - name: stfloats
    type: package
-   status: compatible
+   status: currently-incompatible
    included-in: [tlc3, arxiv1]
    priority: 2
    issues:

--- a/tagging-status/testfiles/stfloats/stfloats-01.tex
+++ b/tagging-status/testfiles/stfloats/stfloats-01.tex
@@ -1,0 +1,25 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,table,title,firstaid}
+  }
+\documentclass[twocolumn]{article}
+\usepackage{stfloats}
+\usepackage{graphicx}
+\usepackage{kantlipsum}
+
+\title{stfloats tagging test - 1}
+
+\begin{document}
+
+\kant[1-2]
+\begin{figure*}[b]
+\centering
+\includegraphics[alt=alt text,scale=0.5]{example-image}
+\caption{Some caption}
+\end{figure*}
+\kant[3-4]
+
+\end{document}

--- a/tagging-status/testfiles/stfloats/stfloats-02.tex
+++ b/tagging-status/testfiles/stfloats/stfloats-02.tex
@@ -1,0 +1,29 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,table,title,firstaid}
+  }
+\documentclass{article}
+\usepackage{stfloats}
+\usepackage{graphicx}
+\usepackage{kantlipsum}
+\usepackage{hyperref}
+
+\title{stfloats tagging test - 2}
+
+\fnbelowfloat
+
+\begin{document}
+
+\kant[1]\footnote{A footnote}
+\begin{figure}[b]
+\centering
+\includegraphics[alt=alt text,scale=0.5]{example-image}
+\caption{Some caption}
+\end{figure}
+\kant[2]\footnote{another footnote}
+\kant[3-4]
+
+\end{document}


### PR DESCRIPTION
Lists [stfloats](https://ctan.org/pkg/stfloats) as currently-incompatible and adds tests. 

As with the [fnpos PR](https://github.com/latex3/tagging-project/pull/388#issue-2440810480) this package redefines internal commands, in particular `\@addtodblcol`, `\@addtocurcol`, `\@addtotoporbot`, `\@addtobot`, `\@doclearpage`, `\@combinedblfloats`, and `\@makecol`. I think it has the same problem with the missing EMC with pdflatex.

Otherwise, however, the tagging looks okay to me.