### PR TITLE
add incompatible packages

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -6308,13 +6308,12 @@
 
  - name: newfloat
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in: [tlc3, arxiv01]
    priority: 2
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-15
+   issues: [450]
+   tests: true
+   updated: 2024-08-04
 
  - name: newpax
    type: package
@@ -7842,13 +7841,13 @@
 
  - name: rotfloat
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in: [tlc3, arxiv001]
    priority: 2
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-15
+   tests: true
+   comments: See rotating and float.
+   updated: 2024-08-04
 
  - name: rotpages
    type: package
@@ -9089,13 +9088,13 @@
 
  - name: threeparttablex
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in: [tlc3, arxiv01]
    priority: 2
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-15
+   tests: true
+   comments: See threeparttable.
+   updated: 2024-08-04
 
  - name: thumbpdf
    type: package
@@ -9681,13 +9680,13 @@
 
  - name: vertbars
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in: [tlc3]
    priority: 2
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-15
+   tests: true
+   comments: See lineno.
+   updated: 2024-08-04
 
  - name: vwcol
    type: package

--- a/tagging-status/testfiles/newfloat/newfloat-01.tex
+++ b/tagging-status/testfiles/newfloat/newfloat-01.tex
@@ -1,0 +1,25 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,table,title,firstaid}
+  }
+\documentclass{article}
+\usepackage{newfloat}
+\usepackage{graphicx}
+
+\title{newfloat tagging test}
+
+\DeclareFloatingEnvironment{diagram}
+
+\begin{document}
+
+text
+\begin{diagram}
+\centering
+\includegraphics[alt=alt text]{example-image}
+\caption{Some caption}
+\end{diagram}
+
+\end{document}

--- a/tagging-status/testfiles/rotfloat/rotfloat-01.tex
+++ b/tagging-status/testfiles/rotfloat/rotfloat-01.tex
@@ -1,0 +1,30 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article} 
+
+\usepackage{rotfloat}
+
+\floatname{program}{Program}
+\newfloat{program}{tbp}{lop}[section]
+
+\begin{document}
+
+text
+\begin{program}
+\centering
+\includegraphics[alt=alt text]{example-image}
+\caption{Some caption}
+\end{program}
+
+\begin{sidewaysprogram}
+\centering
+\includegraphics[alt=alt text]{example-image}
+\caption{Another caption}
+\end{sidewaysprogram}
+
+\end{document}

--- a/tagging-status/testfiles/threeparttablex/threeparttablex-01.tex
+++ b/tagging-status/testfiles/threeparttablex/threeparttablex-01.tex
@@ -1,0 +1,39 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article} 
+
+\usepackage{threeparttablex}
+\usepackage{longtable,booktabs}
+
+\title{threeparttablex tagging test}
+
+\begin{document}
+
+\begin{ThreePartTable}
+\begin{TableNotes}
+\item[a] A note
+\item[b] Another note
+\end{TableNotes}
+\begin{longtable}{l l}
+\toprule
+Column 1 & Column 2 \\
+\midrule
+\endhead
+\cmidrule{2-2}
+\multicolumn{2}{r}{\textit{continued}}
+\endfoot
+\bottomrule
+\insertTableNotes
+\endlastfoot
+% the contents of the table
+A & B\tnote{a} \\
+C\tnote{b} & D \\
+\end{longtable}
+\end{ThreePartTable}
+
+\end{document}

--- a/tagging-status/testfiles/vertbars/vertbars-01.tex
+++ b/tagging-status/testfiles/vertbars/vertbars-01.tex
@@ -1,0 +1,20 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article} 
+
+\usepackage{vertbars}
+
+\begin{document}
+
+Some normal text
+\begin{vertbar}
+Some text with bars
+\end{vertbar}
+More normal text
+
+\end{document}


### PR DESCRIPTION
Lists newfloat, rotfloat, threeparttablex, and vertbars as incompatible and adds tests. The first has a linked issue, the rest are built on top of incompatible packages.