### PR TITLE
add undolabl compat

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -9492,6 +9492,15 @@
    tests: true
    updated: 2024-07-26
 
+ - name: undolabl
+   type: package
+   status: compatible
+   included-in:
+   priority: 9
+   issues:
+   tests: true
+   updated: 2024-08-04
+
  - name: unicode-math
    type: package
    status: compatible

--- a/tagging-status/testfiles/undolabl/undolabl-01.tex
+++ b/tagging-status/testfiles/undolabl/undolabl-01.tex
@@ -1,0 +1,53 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+\usepackage{undolabl}
+\usepackage{hyperref}
+
+\title{undolabl tagging test}
+
+\begin{document}
+
+\section*{Example for undolabl}
+This example demonstrates the use of package\newline
+\textsf{undolabl}, v1.0m as of 2023-02-14 (HMM).\newline
+For details please see the documentation!
+
+\bigskip
+
+\section{Test}
+text \label{testlabel}\\
+page-reference: \pageref{testlabel}\\%%  -> page 4
+sectional-reference: \ref{testlabel}\\%% -> section 4
+name-reference: \nameref{testlabel}%%    -> Still another test
+
+\newpage
+
+\section{Another test}
+text \overridelabel{testlabel}\\
+page-reference: \pageref{testlabel}\\%%  -> page 4
+sectional-reference: \ref{testlabel}\\%% -> section 4
+name-reference: \nameref{testlabel}%%    -> Still another test
+
+\newpage
+
+\section{Yet another test}
+text \overridelabel{testlabel}\\
+page-reference: \pageref{testlabel}\\%%  -> page 4
+sectional-reference: \ref{testlabel}\\%% -> section 4
+name-reference: \nameref{testlabel}%%    -> Still another test
+
+\newpage
+
+\section{Still another test}
+text \overridelabel{testlabel}\\
+page-reference: \pageref{testlabel}\\%%  -> page 4
+sectional-reference: \ref{testlabel}\\%% -> section 4
+name-reference: \nameref{testlabel}%%    -> Still another test
+
+\end{document}


### PR DESCRIPTION
Lists [undolbl](https://www.ctan.org/pkg/undolabl) as compatible and adds a test.

This is a dependency of [pageslts](https://www.ctan.org/pkg/pageslts) which is in tlc3 but based on some recent TeX-SX posts I think this package is broken with current latex.