### PR TITLE
add xcomment compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -9838,13 +9838,13 @@
 
  - name: xcomment
    type: package
-   status: unknown
+   status: partially-compatible
    included-in: [tlc3]
    priority: 2
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-15
+   tests: true
+   comments: `\\nofloat` produces parent-child warnings.
+   updated: 2024-08-04
 
  - name: xecjk
    type: package

--- a/tagging-status/testfiles/xcomment/xcomment-01.tex
+++ b/tagging-status/testfiles/xcomment/xcomment-01.tex
@@ -1,0 +1,38 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+\usepackage{xcomment}
+
+%\nofloat{figure} % parent-child warnings
+
+\begin{document}
+
+text
+
+\newxcomment{mycomment}
+\begin{xcomment}{figure,mycomment}
+This is stuff that is not included.
+\begin{figure}
+This figure is included.
+\caption{Included!}
+\end{figure}
+More stuff that is not included.
+\begin{mycomment}
+Out and back into comment mode
+\begin{figure}
+Ignored by mycomment envir.
+This figure is NOT included.
+\caption{Not included}
+\end{figure}
+Also ignored by mycomment envir.
+\end{mycomment}
+In and back out of comment mode.
+More stuff that is not included.
+\end{xcomment}
+
+\end{document}


### PR DESCRIPTION
Lists [xcomment](https://ctan.org/pkg/xcomment) as partially compatible because its main feature works fine but the `\nofloat` command produces parent-child warnings.