### PR TITLE
add harvard and har2nat

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -4197,23 +4197,22 @@
 
  - name: har2nat
    type: package
-   status: unknown
+   status: compatible
    included-in: [tlc3, arxiv001]
    priority: 2
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-14
+   tests: true
+   updated: 2024-08-05
 
  - name: harvard
    type: package
-   status: unknown
+   status: partially-compatible
    included-in: [tlc3, arxiv001]
    priority: 2
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-14
+   tests: true
+   comments: "No links with hyperref."
+   updated: 2024-08-05
 
  - name: helvet
    type: package

--- a/tagging-status/testfiles/har2nat/har2nat-01.tex
+++ b/tagging-status/testfiles/har2nat/har2nat-01.tex
@@ -1,0 +1,59 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+%    testphase={phase-III,math,title,table,firstaid},
+  }
+\begin{filecontents}[overwrite]{sample.bib}
+@article{einstein,
+  author =       "Albert Einstein",
+  title =        "{Zur Elektrodynamik bewegter K{\"o}rper}. ({German})
+                 [{On} the electrodynamics of moving bodies]",
+  journal =      "Annalen der Physik",
+  volume =       "322",
+  number =       "10",
+  pages =        "891--921",
+  year =         "1905",
+  DOI =          "http://dx.doi.org/10.1002/andp.19053221004"
+}
+
+@book{latexcompanion,
+    author    = "Michel Goossens and Frank Mittelbach and Alexander Samarin",
+    title     = "The \LaTeX\ Companion",
+    year      = "1993",
+    publisher = "Addison-Wesley",
+    address   = "Reading, Massachusetts"
+}
+ 
+@misc{knuthwebsite,
+    author    = "Donald Knuth",
+    title     = "Knuth: Computers and Typesetting",
+    url       = "http://www-cs-faculty.stanford.edu/\~{}uno/abcde.html"
+}
+\end{filecontents}
+
+\documentclass{article}
+\usepackage{natbib}
+\usepackage{har2nat}
+\usepackage{hyperref}
+
+\begin{document}
+
+text \cite{einstein}
+
+As \citeasnoun{einstein} and \citeasnoun[Annex~B]{latexcompanion} describe \ldots
+
+manuals \citeaffixed{knuthwebsite,latexcompanion}{e.g.} describe \ldots
+
+\citeyear{latexcompanion}
+
+\citename{einstein}
+
+\medskip
+
+\bibliographystyle{plainnat}
+\bibliography{sample}
+
+\end{document}
+

--- a/tagging-status/testfiles/harvard/harvard-01.tex
+++ b/tagging-status/testfiles/harvard/harvard-01.tex
@@ -1,0 +1,29 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+\usepackage{harvard}
+\usepackage{hyperref}
+
+\begin{document}
+
+text \cite[postfix]{inbook-full}
+
+As \citeasnoun{article-full} and \citeasnoun[Annex~B]{whole-journal} describe \ldots
+
+\possessivecite{book-full} description of this feature is \ldots
+
+manuals \citeaffixed{manual-full,masterthesis-minimal}{e.g.} describe \ldots
+
+\citeyear{inbook-full}
+
+\citename{inbook-full}
+
+\bibliographystyle{agsm}
+\bibliography{xampl}
+
+\end{document}


### PR DESCRIPTION
Lists harvard as partially-compatible because with hyperref, there are no links.

Lists har2nat as compatible.