### PR TITLE
add math font packages

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -6413,7 +6413,7 @@
  - name: newpxmath
    ctan-pkg: newpx
    type: package
-   status: unknown
+   status: compatible
    included-in: [tlc3, arxiv001]
    priority: 2
    issues:

--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -870,6 +870,56 @@
    tests: false
    updated: 2024-07-13
 
+ - name: BOONDOX-cal
+   ctan-pkg: boondox
+   type: package
+   status: compatible
+   included-in:
+   priority: 9
+   issues:
+   tests: false
+   updated: 2024-08-05
+
+ - name: BOONDOX-calo
+   ctan-pkg: boondox
+   type: package
+   status: compatible
+   included-in:
+   priority: 9
+   issues:
+   tests: false
+   updated: 2024-08-05
+
+ - name: BOONDOX-ds
+   ctan-pkg: boondox
+   type: package
+   status: compatible
+   included-in:
+   priority: 9
+   issues:
+   tests: false
+   updated: 2024-08-05
+
+ - name: BOONDOX-frak
+   ctan-pkg: boondox
+   type: package
+   status: compatible
+   included-in:
+   priority: 9
+   issues:
+   tests: false
+   updated: 2024-08-05
+
+ - name: BOONDOX-uprscr
+   ctan-pkg: boondox
+   type: package
+   status: compatible
+   included-in:
+   priority: 9
+   issues:
+   tests: false
+   updated: 2024-08-05
+
  - name: babel
    type: package
    status: unknown
@@ -2529,6 +2579,14 @@
    tests: false
    updated: 2024-07-14
 
+ - name: dutchcal
+   type: package
+   status: compatible
+   included-in:
+   priority: 9
+   issues:
+   tests: false
+   updated: 2024-08-05
 
 #------------------------ EEE ----------------------------
 
@@ -2903,6 +2961,33 @@
    tests: false
    tasks: needs tests
    updated: 2024-07-17
+
+ - name: esstixbb
+   type: package
+   status: compatible
+   included-in:
+   priority: 9
+   issues:
+   tests: false
+   updated: 2024-08-05
+
+ - name: esstixcal
+   type: package
+   status: compatible
+   included-in:
+   priority: 9
+   issues:
+   tests: false
+   updated: 2024-08-05
+
+ - name: esstixfrak
+   type: package
+   status: compatible
+   included-in:
+   priority: 9
+   issues:
+   tests: false
+   updated: 2024-08-05
 
  - name: esvect
    type: package
@@ -3854,13 +3939,12 @@
 
  - name: gelasiomath
    type: package
-   status: unknown
+   status: compatible
    included-in:
    priority: 9
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   updated: 2024-08-05
 
  - name: gensymb
    type: package
@@ -6603,13 +6687,12 @@
 
  - name: notomath
    type: package
-   status: unknown
+   status: compatible
    included-in: [tlc3]
    priority: 2
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-15
+   tests: true
+   updated: 2024-08-05
 
  - name: nth
    type: package
@@ -7546,6 +7629,16 @@
    tests: true
    updated: 2024-07-12
 
+ - name: px-ds
+   ctan-pkg: pxtxalfa
+   type: package
+   status: compatible
+   included-in:
+   priority: 9
+   issues:
+   tests: false
+   updated: 2024-08-05
+
  - name: pxpic
    type: package
    status: unknown
@@ -7555,6 +7648,26 @@
    tests: false
    tasks: needs tests
    updated: 2024-07-18
+
+ - name: pxtx-cal
+   ctan-pkg: pxtxalfa
+   type: package
+   status: compatible
+   included-in:
+   priority: 9
+   issues:
+   tests: false
+   updated: 2024-08-05
+
+ - name: pxtx-frak
+   ctan-pkg: pxtxalfa
+   type: package
+   status: compatible
+   included-in:
+   priority: 9
+   issues:
+   tests: false
+   updated: 2024-08-05
 
  - name: pyluatex
    type: package
@@ -9431,6 +9544,35 @@
    issues:
    tests: false
    updated: 2024-07-15
+
+ - name: tx-ds
+   ctan-pkg: pxtxalfa
+   type: package
+   status: compatible
+   included-in:
+   priority: 9
+   issues:
+   tests: false
+   updated: 2024-08-05
+
+ - name: tx-of
+   ctan-pkg: pxtxalfa
+   type: package
+   status: compatible
+   included-in:
+   priority: 9
+   issues:
+   tests: false
+   updated: 2024-08-05
+
+ - name: txuprcal
+   type: package
+   status: compatible
+   included-in:
+   priority: 9
+   issues:
+   tests: false
+   updated: 2024-08-05
 
  - name: typearea
    type: package

--- a/tagging-status/testfiles/gelasiomath/gelasiomath-01.tex
+++ b/tagging-status/testfiles/gelasiomath/gelasiomath-01.tex
@@ -1,0 +1,37 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+
+\usepackage{gelasiomath}
+\usepackage{kantlipsum}
+
+\title{gelasiomath tagging test}
+
+\begin{document}
+
+\kant[1-2]
+
+\textSC{abcdef12345}
+
+\textfrac[2]{3}{16}
+
+\checkmark
+
+\circledR
+
+\maltese
+
+\textsquare
+
+$\bigcupplus$
+
+$\circlearrowleft$
+
+$\varmathbb{ABC}$
+
+\end{document}

--- a/tagging-status/testfiles/notomath/notomath-01.tex
+++ b/tagging-status/testfiles/notomath/notomath-01.tex
@@ -1,0 +1,35 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+
+\usepackage[useBImacros]{notomath}
+\usepackage{kantlipsum}
+
+\title{notomath tagging test}
+
+\begin{document}
+
+\kant[1-2]
+
+\checkmark
+
+\circledR
+
+\maltese
+
+\textsquare
+
+$\bigcupplus$
+
+$\circlearrowleft$
+
+$\varmathbb{ABC}$
+
+$\BIF$
+
+\end{document}


### PR DESCRIPTION
Lists [gelasiomath](https://www.ctan.org/pkg/gelasiomath) and [notomath](https://www.ctan.org/pkg/notomath) (both newtx-derived) as compatible with tests.

Lists the [boondox](https://www.ctan.org/pkg/boondox), [dutchcal](https://www.ctan.org/pkg/dutchcal), [esstix](https://www.ctan.org/pkg/esstix), and [pxtxalfa](https://www.ctan.org/pkg/pxtxalfa) math font collections as compatible without tests.

Also fixes the status for newpxmath