### PR TITLE
add savetrees compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -7895,13 +7895,13 @@
 
  - name: savetrees
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in: [tlc3, arxiv01]
    priority: 2
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-15
+   tests: true
+   tasks: "Redefines `\\maketitle` and uses titlesec to redefine section commands."
+   updated: 2024-08-05
 
  - name: scalefnt
    type: package

--- a/tagging-status/testfiles/savetrees/savetrees-01.tex
+++ b/tagging-status/testfiles/savetrees/savetrees-01.tex
@@ -1,0 +1,36 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+
+\usepackage[extreme]{savetrees}
+\usepackage{kantlipsum}
+
+\title{savetrees tagging test}
+\author{Some author}
+
+\begin{document}
+\maketitle
+
+\section{A section heading}
+\kant[1-3]
+\begin{enumerate}
+\item blub
+\item blub blub
+\end{enumerate}
+\begin{figure}
+Some figure
+\caption{Some caption}
+\end{figure}
+
+\begin{thebibliography}{9}
+\bibitem{dihe:newdir}
+W.~Diffie and E.~Hellman, \emph{New directions in cryptography}, IEEE
+Transactions on Information Theory \textbf{22} (1976), no.~5, 644--654.
+\end{thebibliography}
+
+\end{document}


### PR DESCRIPTION
Lists savetrees as currently-incompatible because it redefines `\maketitle` and uses titlesec to redefine section commands.