### PR TITLE
add bibtopic compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -1102,12 +1102,13 @@
 
  - name: bibtopic
    type: package
-   status: unknown
+   status: partially-compatible
    included-in: [tlc3]
    priority: 2
    issues:
-   tests: false
-   tasks: needs tests
+   tests: true
+   tasks: "Errors with hyperref option `backref`. No links are created by hyperref
+           if `btUnit` is used."
    updated: 2024-07-14
 
  - name: bibunits

--- a/tagging-status/testfiles/bibtopic/bibtopic-01.tex
+++ b/tagging-status/testfiles/bibtopic/bibtopic-01.tex
@@ -1,0 +1,69 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\begin{filecontents}{articles.bib}
+@incollection{RouxSmart:95,
+    author    = "M. Roux and J. Smart",
+    title     = "A Model of Medical Knowledge Representation, Application
+                 to the Reports Analysis of Descriptive Pathology",
+    booktitle = "Methods of Information in Medecine",
+    note      = {\`A para\^{\i}tre},
+    publisher = "Schattauer",
+    address   = "Holland",
+    year      = 1995
+}
+
+@article{Schwind:96,
+    author    = {Camilla B. Schwind},
+    title     = {Knowledge Based Language Tutoring},
+    journal   = {Computer Assisted Language Learning},
+    publisher = {Svets},
+    year      = 1996,
+    note      = {\`A para\^{\i}tre}
+}
+\end{filecontents}
+\begin{filecontents}{books.bib}
+@book{ColBenh:93,
+   editor = "Fr\'ed\'eric Benhamou and Alain Colmerauer" ,
+   title = "Constraint Logic programming, Selected Research",
+   publisher = "MIT Press",
+   year = 1993
+}
+
+@book{Munt:93,
+   author =    {Tra{\"\i}an Muntean},
+   title =     {Puces tr\`es performantes},
+   publisher = {Hatier},
+   address =   {Paris},
+   series = {Terres du futur, Les Editions UNESCO},
+   year =      1993,
+}
+\end{filecontents}
+
+\documentclass[10pt]{article}
+\usepackage{bibtopic}
+\usepackage{hyperref}
+\begin{document}
+\bibliographystyle{alpha}
+
+\section{Testing}
+Let's cite all the books: \cite{ColBenh:93} and
+\cite{Munt:93}; and an article: \cite{RouxSmart:95}.
+
+\begin{btSect}{books}
+\section{References from books}
+\btPrintCited
+\end{btSect}
+
+\begin{btSect}[plain]{articles}
+\section{References from articles}
+\btPrintCited
+
+\section{Articles not cited}
+\btPrintNotCited
+\end{btSect}
+\end{document}

--- a/tagging-status/testfiles/bibtopic/bibtopic-02.tex
+++ b/tagging-status/testfiles/bibtopic/bibtopic-02.tex
@@ -1,0 +1,75 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\begin{filecontents}[overwrite]{articles.bib}
+@incollection{RouxSmart:95,
+    author    = "M. Roux and J. Smart",
+    title     = "A Model of Medical Knowledge Representation, Application
+                 to the Reports Analysis of Descriptive Pathology",
+    booktitle = "Methods of Information in Medecine",
+    note      = {\`A para\^{\i}tre},
+    publisher = "Schattauer",
+    address   = "Holland",
+    year      = 1995
+}
+
+@article{Schwind:96,
+    author    = {Camilla B. Schwind},
+    title     = {Knowledge Based Language Tutoring},
+    journal   = {Computer Assisted Language Learning},
+    publisher = {Svets},
+    year      = 1996,
+    note      = {\`A para\^{\i}tre}
+}
+\end{filecontents}
+\begin{filecontents}[overwrite]{books.bib}
+@book{ColBenh:93,
+   editor = "Fr\'ed\'eric Benhamou and Alain Colmerauer" ,
+   title = "Constraint Logic programming, Selected Research",
+   publisher = "MIT Press",
+   year = 1993
+}
+
+@book{Munt:93,
+   author =    {Tra{\"\i}an Muntean},
+   title =     {Puces tr\`es performantes},
+   publisher = {Hatier},
+   address =   {Paris},
+   series = {Terres du futur, Les Editions UNESCO},
+   year =      1993,
+}
+\end{filecontents}
+
+\documentclass[10pt]{article}
+\usepackage{bibtopic}
+\usepackage{hyperref}
+\begin{document}
+\bibliographystyle{alpha}
+\begin{btUnit} %%% begin first btUnit
+Let’s cite all the books: \cite{ColBenh:93} and
+\cite{Munt:93}; and an article: \cite{RouxSmart:95}.
+\begin{btSect}{books}
+\section{References from books}
+\btPrintCited
+\end{btSect}
+\begin{btSect}[plain]{articles}
+\section{References from articles}
+\btPrintCited
+\section{Articles not cited}
+\btPrintNotCited
+\end{btSect}
+\end{btUnit} %%% end first btUnit
+\begin{btUnit} %%% begin second btUnit
+We may cite \cite{RouxSmart:95} another time without causing a
+‘multiple defined citations’ warning from \LaTeX, since this
+citation is located in another ‘btUnit’.
+\begin{btSect}{articles}
+\section{All articles}
+\btPrintAll
+\end{btSect}
+\end{btUnit} %%% end second btUnit
+\end{document}


### PR DESCRIPTION
Lists [bibtopic](https://ctan.org/pkg/bibtopic) as partially-compatible because it errors with hyperref's `backref` option and no links are created by hyperref if `btUnit` is used (second test).