### PR TITLE
add incompatible packages

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -2443,13 +2443,12 @@
 
  - name: diagbox
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in: [tlc3, arxiv1]
    priority: 2
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-14
+   issues: [453]
+   tests: true
+   updated: 2024-08-05
 
  - name: diffcoeff
    type: package
@@ -2884,13 +2883,12 @@
 
  - name: epigraph
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in: [tlc3, arxiv01]
    priority: 2
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-14
+   issues: [455]
+   tests: true
+   updated: 2024-08-05
 
  - name: epsf
    type: package
@@ -3216,13 +3214,12 @@
 
  - name: fancypar
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in: [tlc3]
    priority: 2
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-14
+   issues: [467]
+   tests: true
+   updated: 2024-08-05
 
  - name: fancyref
    type: package
@@ -4903,13 +4900,13 @@
 
  - name: keyvaltable
    type: package
-   status: unknown
+   status: partially-compatible
    included-in: [tlc3]
    priority: 2
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-15
+   issues: [464]
+   tests: true
+   comments: "`align=X` errors."
+   updated: 2024-08-05
 
  - name: kotex
    ctan-pkg: cjk-ko
@@ -6656,13 +6653,12 @@
 
  - name: notoccite
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in: [tlc3, arxiv001]
    priority: 2
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-15
+   issues: [458]
+   tests: true
+   updated: 2024-08-05
 
  - name: notocondensed
    type: package
@@ -7161,13 +7157,12 @@
 
  - name: pdfcomment
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in: [tlc3, arxiv01]
    priority: 2
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   issues: [465]
+   tests: true
+   updated: 2024-08-05
 
  - name: pdfescape
    type: package
@@ -7837,13 +7832,12 @@
 
  - name: repeatindex
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in: [tlc3]
    priority: 2
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-15
+   issues: [461]
+   tests: true
+   updated: 2024-08-05
 
  - name: repltext
    type: package

--- a/tagging-status/testfiles/diagbox/diagbox-01.tex
+++ b/tagging-status/testfiles/diagbox/diagbox-01.tex
@@ -1,0 +1,32 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article} 
+
+\usepackage{diagbox}
+
+\begin{document}
+
+\begin{tabular}{|l|ccc|}
+\hline
+\diagbox{Time}{Day} & Mon & Tue & \diagbox[dir=NE]{Wed}{Thur} \\
+\hline
+Morning & used & used & \\
+Afternoon & & used & used \\
+\hline
+\end{tabular}
+
+\begin{tabular}{|l|ccc|}
+\hline
+\diagbox{Time}{Room}{Day} & Mon & Tue & Wed \\
+\hline
+Morning & used & used & \\
+Afternoon & & used & used \\
+\hline
+\end{tabular}
+
+\end{document}

--- a/tagging-status/testfiles/epigraph/epigraph-01.tex
+++ b/tagging-status/testfiles/epigraph/epigraph-01.tex
@@ -1,0 +1,17 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article} 
+
+\usepackage{epigraph}
+
+\title{epigraph tagging test}
+
+\begin{document}
+\epigraph{I had to deny knowledge in order to make room for faith.}{Kant}
+text
+\end{document}

--- a/tagging-status/testfiles/fancypar/fancypar-01.tex
+++ b/tagging-status/testfiles/fancypar/fancypar-01.tex
@@ -1,0 +1,24 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+\usepackage{fancypar}
+\usepackage{kantlipsum}
+
+\begin{document}
+
+\textit{The notebook style:}
+\NotebookPar{\kant[2]}
+%\textit{The zebra style:}
+%\ZebraPar{\kant[2]}
+%\textit{The marked style:}
+%\MarkedPar{\kant[2]}
+%\textit{The dashed style:}
+%\DashedPar{\kant[2]}
+%\textit{The underlined style:}
+%\UnderlinedPar{\kant[2]}
+\end{document}

--- a/tagging-status/testfiles/keyvaltable/keyvaltable-01.tex
+++ b/tagging-status/testfiles/keyvaltable/keyvaltable-01.tex
@@ -1,0 +1,26 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+\usepackage{keyvaltable}
+
+\NewKeyValTable{Recipe}{
+amount: align=r;
+ingredient: align=l;
+step: align=X;
+}
+
+\begin{document}
+
+\begin{KeyValTable}{Recipe}
+\Row{amount=150g, ingredient=ice cream,
+step=put into bowl}
+\Row{amount= 50g, ingredient=cherries,
+step=heat up and add to bowl}
+\end{KeyValTable}
+
+\end{document}

--- a/tagging-status/testfiles/keyvaltable/keyvaltable-02.tex
+++ b/tagging-status/testfiles/keyvaltable/keyvaltable-02.tex
@@ -1,0 +1,97 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\begin{filecontents}[overwrite]{cities.kvt}
+ \Row{city=Mainz, country=Germany, people=0.2 mil, visited=\emph{home town}}
+ \Row{city=London,   country=UK,   people=8.9 mil, visited=yes}
+ \Row[style=H]{city=New York, country=USA,  people=8.4 mil, visited=planned}
+ \Row[style=H]{city=Paris, country=France, people=2.1 mil}
+\end{filecontents}
+\documentclass{article}
+\usepackage{keyvaltable}
+
+\NewKeyValTable[backend=tabular,norules,norowbg,
+                headformat=\bfseries]
+   {cities}{name; country; visited; note: hidden}
+   
+\kvtNewRowStyle{H}{}
+\NewKeyValTable{overview}{city: ; country: ; people: ; visited: hidden}
+\NewKeyValTable{visits}{country: ; city: ; people: hidden; visited: align=c}
+
+\NewKeyValTable[norowbg]{ToDo}{ prio: default=high;
+                                text: head=comment }
+\NewCollectedTable{notes}{ToDo}
+\newcommand\note[2][]{\CollectRow[#1]{notes}{text=#2}}
+
+\NewKeyValTable{autonum}{ text: head=\textbf{Text};
+                          line: head=\ , default=\S\thekvtRow }
+\kvtSet{ColGroup/format=\itshape,ColGroup/align=r}
+\NewKeyValTable{spantest}{ colA: align=l|; colB: align=l||;
+                          colC: align=l|; colD:}
+     [ colgroups={ all: span=colA+colB+colC+colD, format=\textbf;
+                 AuBuC: span=colA+colB+colC, align=c|;
+                   AuB: span=colA+colB, align=l||;  CuD: span=colC+colD } ]
+\NewKeyValTable[headformat=\sffamily]{MultiCol}
+   { penny: align=c|, format=\bfseries; euro: align=l|; cent: }
+\NewKeyValTable[headformat=\bfseries, norowbg]{complexheader}
+  { precolumn: align=c, format=\textbf ; colA: ; colB: ; colC: ;colD: }
+  [ headers={ colA+colB+colC+colD : head=\textsf{From A to D} \\
+              colA+colB : head= A \& B;
+                       colC+colD : align=r, head=$\to$ C \& D \\ :: }
+   ,colgroups={BtoE: span=colA+colB+colC+colD, format=\textit}        ]                         
+\begin{document}
+
+\begin{KeyValTable}{cities}
+  \Row[above=5pt]{country=Germany, name=Mainz, note=...}
+  \MidRule[2pt]
+  \Row{country=USA, name=New York, visited=yes}
+\end{KeyValTable}
+
+\ShowKeyValTableFile[shape=onepage,valign=t]{overview}{cities.kvt} \quad
+\kvtRenewRowStyle{H}{hidden}     % hide the H rows in next table
+\ShowKeyValTableFile[shape=onepage,nobg,valign=t]{visits}{cities.kvt}
+
+\note{{A note, with comma}}
+\note{one more with prio change, prio=low}
+My notes: \ShowCollectedTable{notes} And more text.
+\note[bg=blue!10]{and some afterthought}
+    
+\begin{KeyValTable}{autonum}
+  \Row{text=First row} \Row{text=Second row, line=\thekvtRow*}
+  \Row[uncounted]{text=Interlude, line=--} \Row{text=Last row}
+\end{KeyValTable}
+
+\begin{KeyValTable}{spantest}
+ \Row{all=The Start}  \Row{colA=1, colB=2, colC=3, colD=4}
+ \Row{all=--- right aligned text ---}
+ \Row{AuB=1 \& 2,       colC=3,  colD=4}
+ \Row{colA=1, colB=2,   colC=3,  colD=4}
+ \Row{colA=1, colB=2,    CuD=3 \& 4}
+ \Row{AuBuC=--- 3 out of 4 ---,    colD=4}
+ \Row{AuB=1 \& 2, CuD=3 \& 4} \Row{all=The End}
+\end{KeyValTable}
+
+\begin{KeyValTable}{MultiCol}
+  \Row{euro=\multicolumn{1}{r|}{2}, cent=3, penny=1}
+  \Row[format!=\sffamily]{penny=1, cent=3, euro=2}
+  \Row{penny=1, euro=\multicolumn{2}{c}{\color{blue}2+3}}
+  \Row{cent=3, penny=\multicolumn{2}{c|}{1+2}}
+  \Row[format=\itshape]{penny=\multicolumn{3}{c}{1+2+3}}
+  \Row{cent=3, euro=2, penny=1}
+\end{KeyValTable}
+
+\begin{KeyValTable}{complexheader}
+  \Row{ precolumn=1, colA=1.a, colB=1.b,
+                           colC=---, colD=1.d }
+  \Row{ precolumn=2, colA=2.a, colB=2.b,
+                           colC=2.c, colD=2.d }
+\Row[around=3pt]{BtoE=Centered subtitle}
+  \Row{ precolumn=3, colA=3.a, colB=---,
+                           colC=3.c, colD=3.d }
+\end{KeyValTable}
+
+\end{document}

--- a/tagging-status/testfiles/notoccite/notoccite-01.tex
+++ b/tagging-status/testfiles/notoccite/notoccite-01.tex
@@ -1,0 +1,35 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+\usepackage{notoccite}
+
+\title{notoccite tagging test}
+
+\begin{document}
+
+\tableofcontents
+
+\listoffigures
+
+\bigskip
+
+text \cite{misc-full}
+
+\section{Let's cite: \cite{inproceedings-full}}
+
+more text \cite{inbook-full}
+\begin{figure}
+\centering
+Some figure
+\caption{Cite again: \cite{phdthesis-minimal}}
+\end{figure}
+
+\bibliographystyle{unsrt}
+\bibliography{xampl}
+
+\end{document}

--- a/tagging-status/testfiles/pdfcomment/pdfcomment-01.tex
+++ b/tagging-status/testfiles/pdfcomment/pdfcomment-01.tex
@@ -1,0 +1,15 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+\usepackage{pdfcomment}
+
+\begin{document}
+
+text\pdfcomment{some annotation} 
+
+\end{document}

--- a/tagging-status/testfiles/repeatindex/repeatindex-01.tex
+++ b/tagging-status/testfiles/repeatindex/repeatindex-01.tex
@@ -1,0 +1,69 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+
+\usepackage{repeatindex}
+
+\makeindex
+
+\textheight6cm%
+
+\begin{document}
+
+Hallo
+\index{P01}%
+\index{P01!U01}%
+\index{P01!U02}%
+\index{P01!U03}%
+\index{P01!U04}%
+\index{P01!U05}%
+\index{P01!U06}%
+\index{P01!U07}%
+\index{P01!U08}%
+\index{P01!U09}%
+\index{P01a}%
+\index{P01a!U10}%
+\index{P01b}%
+\index{P01b!U11}%
+\index{P01b!U12}%
+\index{P01b!U13}%
+\index{P01b!U14}%
+\index{P01b!U15}%
+\index{P01b!U16}%
+\index{P01b!U17}%
+\index{P01b!U18}%
+\index{P01b!U19}%
+\index{P01b!U20}%
+\index{P01b!U21}%
+\index{P01b!U22}%
+\index{P01b!U23}%
+\index{P01b!U24}%
+\index{P01b!U25}%
+\index{P01b!U26}%
+\index{P01b!U27}%
+\index{P01b!U28}%
+\index{P01b!U29}%
+\index{P02}%
+\index{P02!U01}%
+\index{P02!U02}%
+\index{P02!U03}%
+\index{P02!U04}%
+\index{P02!U05}%
+\index{P02!U06}%
+\index{P02!U07}%
+\index{P02!U08}%
+\index{P02!U09}%
+\index{P02!U10}%
+\index{P02!U11}%
+\index{P02!U12}%
+\index{P02!U13}%
+\index{P02!U14}%
+\index{P02!U15}%
+
+\printindex
+\end{document}


### PR DESCRIPTION
Lists diagbox, epigraph, fancypar, notoccite, pdfcomment, and repeatindex as currently-incompatible, links to the corresponding issue, and adds tests.

Lists keyvaltable as partially-compatible, links to the issue, and adds tests.