### PR TITLE
add flushend compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -3508,13 +3508,13 @@
 
  - name: flushend
    type: package
-   status: unknown
+   status: partially-compatible
    included-in: [arxiv01]
    priority: 6
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   comments: "`\\atColsEnd` errors."
+   updated: 2024-08-06
 
  - name: fmtcount
    type: package

--- a/tagging-status/testfiles/flushend/flushend-01.tex
+++ b/tagging-status/testfiles/flushend/flushend-01.tex
@@ -1,0 +1,17 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass[twocolumn]{article}
+
+\usepackage{flushend}
+\usepackage{kantlipsum}
+
+\begin{document}
+
+\kant[1-6]
+
+\end{document}

--- a/tagging-status/testfiles/flushend/flushend-02.tex
+++ b/tagging-status/testfiles/flushend/flushend-02.tex
@@ -1,0 +1,19 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass[twocolumn]{article}
+
+\usepackage{flushend}
+\usepackage{kantlipsum}
+
+\atColsEnd{BLUB}
+
+\begin{document}
+
+\kant[1-6]
+
+\end{document}


### PR DESCRIPTION
Lists [flushend](https://www.ctan.org/pkg/flushend) as partially-compatible and adds tests. Partial since it errors if any content is added with `\atColsEnd`.