### PR TITLE
add youngtab compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -10275,13 +10275,16 @@
 
  - name: youngtab
    type: package
-   status: unknown
+   status: partially-compatible
    included-in: [arxiv01]
    priority: 6
+   supported-through: [phase-III,math]
+   comments: "Use of math tagging currently requires support from external tools."
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-08-01
+   tests: true
+   comments: "Diagrams in text mode need Alt text and for rules to be tagged as
+              Artifacts."
+   updated: 2024-08-06
 
  - name: ytableau
    type: package

--- a/tagging-status/testfiles/youngtab/youngtab-01.tex
+++ b/tagging-status/testfiles/youngtab/youngtab-01.tex
@@ -1,0 +1,26 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,title,math,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{youngtab}
+
+\title{youngtab tagging test}
+
+\begin{document}
+
+\yng(2,1)
+
+\Yvcentermath1 $\yng(1,1)\oplus\yng(1)=$
+\yng(2,1)$\oplus$ \dots
+
+\begin{equation}
+\Yvcentermath1
+\yng(1,1)\oplus\yng(1)= \Yboxdim{12pt}
+\yng(2,1)\oplus\dots
+\end{equation}
+
+\end{document}


### PR DESCRIPTION
Lists [youngtab](https://www.ctan.org/pkg/youngtab) as partially-compatible because in text mode the diagrams need Alt text and the rules need to be tagged as Artifacts.