### PR TITLE
add several packages

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -1646,13 +1646,12 @@
 
  - name: catchfile
    type: package
-   status: unknown
+   status: compatible
    included-in: [arxiv01]
    priority: 6
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   updated: 2024-08-06
 
  - name: ccaption
    type: package
@@ -2221,13 +2220,21 @@
 
  - name: currfile
    type: package
-   status: unknown
+   status: compatible
    included-in: [arxiv001]
    priority: 7
    issues:
+   tests: true
+   updated: 2024-08-06
+
+ - name: currfile-abspath
+   type: package
+   status: compatible
+   included-in:
+   priority: 9
+   issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   updated: 2024-08-06
 
  - name: curve2e
    type: package
@@ -3218,13 +3225,12 @@
 
  - name: fancyref
    type: package
-   status: unknown
+   status: compatible
    included-in: [arxiv001]
    priority: 7
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-08-01
+   tests: true
+   updated: 2024-08-06
 
  - name: fancyvrb
    type: package
@@ -3469,13 +3475,12 @@
 
  - name: floatflt
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in: [arxiv01]
    priority: 6
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   issues: [496]
+   tests: true
+   updated: 2024-08-06
 
  - name: floatrow
    type: package
@@ -4481,13 +4486,12 @@
 
  - name: hyphsubst
    type: package
-   status: unknown
+   status: compatible
    included-in: [arxiv001]
    priority: 7
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   updated: 2024-08-06
 
 #------------------------ III ----------------------------
 
@@ -6112,13 +6116,12 @@
 
  - name: morefloats
    type: package
-   status: unknown
+   status: compatible
    included-in: [arxiv01]
    priority: 6
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-08-01
+   tests: true
+   updated: 2024-08-06
 
  - name: moreverb
    type: package
@@ -6186,13 +6189,12 @@
 
  - name: multido
    type: package
-   status: unknown
+   status: compatible
    included-in: [arxiv01]
    priority: 6
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   updated: 2024-08-06
 
  - name: multiexpand
    type: package
@@ -6283,6 +6285,15 @@
    tests: false
    comments: Not distributed with texlive.
    updated: 2024-07-31
+
+ - name: namedef
+   type: package
+   status: compatible
+   included-in:
+   priority: 9
+   issues:
+   tests: false
+   updated: 2024-08-06
 
  - name: nameref
    type: package
@@ -6833,13 +6844,13 @@
 
  - name: orcidlink
    type: package
-   status: unknown
+   status: partially-compatible
    included-in: [arxiv01]
    priority: 6
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   comments: "ORCiD logo needs Alt/ActualText."
+   updated: 2024-08-06
 
  - name: oscola
    type: package
@@ -7542,13 +7553,12 @@
 
  - name: prettyref
    type: package
-   status: unknown
+   status: compatible
    included-in: [arxiv01]
    priority: 6
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-08-01
+   tests: true
+   updated: 2024-08-06
 
  - name: preview
    type: package
@@ -8662,19 +8672,17 @@
    priority: 9
    issues:
    comments: "Incompatible with amsmath which is loaded by `testphase=math`."
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-29
+   tests: true
+   updated: 2024-08-06
 
  - name: subeqnarray
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in: [arxiv01]
    priority: 6
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-08-01
+   issues: [503]
+   tests: true
+   updated: 2024-08-06
 
  - name: subfig
    type: package
@@ -9043,13 +9051,12 @@
 
  - name: textpos
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in: [arxiv01]
    priority: 6
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-17
+   issues: [501]
+   tests: true
+   updated: 2024-08-06
 
  - name: tgadventor
    ctan-pkg: tex-gyre-adventor
@@ -9272,10 +9279,20 @@
    tasks: needs tests
    updated: 2024-07-15
 
+ - name: titlecaps
+   type: package
+   status: compatible
+   included-in: [arxiv001]
+   priority: 7
+   issues:
+   tests: true
+   updated: 2024-08-06
+
  - name: titleps
    type: package
    status: compatible
    included-in:
+   priority: 2
    issues:
    tests: true
    updated: 2024-07-12
@@ -9423,13 +9440,12 @@
 
  - name: tracklang
    type: package
-   status: unknown
+   status: compatible
    included-in: [arxiv01]
    priority: 6
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   updated: 2024-08-06
 
  - name: translations
    type: package
@@ -9581,6 +9597,16 @@
    issues: [174]
    tests: true
    updated: 2024-07-17
+
+ - name: typicons
+   type: package
+   status: partially-compatible
+   included-in:
+   priority: 9
+   issues:
+   tests: true
+   comments: "Symbols need Alt/ActualText."
+   updated: 2024-08-06
 
 #------------------------ UUU ----------------------------
 
@@ -10285,13 +10311,12 @@
 
  - name: ytableau
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in: [arxiv01]
    priority: 6
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-08-01
+   issues: [499]
+   tests: true
+   updated: 2024-08-06
 
  - name: ysabeau
    type: package

--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -2228,6 +2228,7 @@
    updated: 2024-08-06
 
  - name: currfile-abspath
+   ctan-pkg: currfile
    type: package
    status: compatible
    included-in:

--- a/tagging-status/testfiles/currfile/currfile-01.tex
+++ b/tagging-status/testfiles/currfile/currfile-01.tex
@@ -1,0 +1,28 @@
+% compile with --recorder option
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,title,math,table,firstaid}
+  }
+\documentclass{article}
+\usepackage[abspath]{currfile}
+
+\begin{document}
+
+\currfiledir
+
+\currfilebase
+
+\currfileext
+
+\currfilename
+
+\currfilepath
+
+\currfileabsdir
+
+\currfileabspath
+
+\end{document}

--- a/tagging-status/testfiles/fancyref/fancyref-01.tex
+++ b/tagging-status/testfiles/fancyref/fancyref-01.tex
@@ -1,0 +1,194 @@
+% this is just freftest.tex
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,title,math,table,firstaid}
+  }
+\documentclass{article}
+
+\usepackage{fancyref}
+\usepackage{shortvrb}
+\usepackage{hyperref}
+
+\MakeShortVerb{\|}
+
+\fancyrefaddcaptions{english}{%
+  \newcommand*{\Frefthmname}{Theorem}%
+  \newcommand*{\frefthmname}{\MakeLowercase{\Frefthmname}}%
+}%
+\newcommand*{\booktitle}[1]{``#1''}
+\newcommand*{\format}[1]{\texttt{#1}}
+\newcommand*{\labelname}[1]{\texttt{#1}}
+\newcommand*{\option}[1]{\texttt{#1}}
+\newcommand*{\package}[1]{\texttt{#1}}
+\newcommand*{\person}[1]{\textsc{#1}}
+\newcommand*{\prefix}[1]{\texttt{#1}}
+\newcommand*{\stringdef}[1]{``#1''}
+\newtheorem{theorem}{Theorem}
+
+\title{fancyref tagging test}
+
+\begin{document}
+
+Let us start with a famous equation:
+\begin{equation}
+  \label{eq:pythagoras}
+  a^2 + b^2 = c^2
+\end{equation}
+\Fref{eq:pythagoras} has been proven by \person{Pythagoras}.  And this
+cross-reference was made with |\Fref{eq:pythagoras}|.  Note that I
+really wrote:
+\begin{verbatim}
+   \Fref{eq:pythagoras} has ...
+\end{verbatim}
+I did not use:
+\begin{verbatim}
+   Equation~(\Fref{eq:pythagoras}) has ...
+\end{verbatim}
+
+See the next page for further features of the \package{fancyref}
+package, I need this page break for demonstration purposes.
+
+\clearpage
+The cross-reference works also in the middle of a sentence:
+\person{Pythagoras} has proven \fref{eq:pythagoras}.  And this
+cross-reference was made with |\fref{eq:pythagoras}|.  You can see the
+fancy output from the \package{varioref} package.
+
+Oh, you do not like this package and want normal |\ref| output
+instead?  No problem, just redefine the default format:
+\renewcommand*{\fancyrefdefaultformat}{plain}
+\begin{verbatim}
+   \renewcommand*{\fancyrefdefaultformat}{plain}
+\end{verbatim}
+Now the cross-reference looks like this:  \Fref{eq:pythagoras}.  There
+is also a package option called \option{plain} for this purpose.
+
+Oh, you do not like \stringdef{Equation} and want \stringdef{Eq.}
+instead?  No problem, just redefine the string:
+\renewcommand*{\Frefeqname}{Eq.}
+\begin{verbatim}
+   \renewcommand*{\Frefeqname}{Eq.}
+\end{verbatim}
+\Fref{eq:pythagoras} and \fref{eq:pythagoras} will be the result,
+respectively.  Note that there is no need to redefine
+|\frefeqname| to \stringdef{eq.}.  The \package{fancyref} package
+will do this automatically for you.  But of course you can use
+\stringdef{eqn.} instead, if you really want to.
+
+Oh, you are not using the colon as a delimitor but rather the dash?  No
+problem, just redefine the character:
+\renewcommand*{\fancyrefargdelim}{-}
+\begin{verbatim}
+   \renewcommand*{\fancyrefargdelim}{-}
+\end{verbatim}
+The new test equation with label \labelname{eq-trivial} will be:
+\begin{equation}
+  \label{eq-trivial}
+  a = a
+\end{equation}
+The cross-reference |\fref{eq-trivial}| will give \fref{eq-trivial} as
+output, as expected.
+
+All that stuff may be nice, but you are using \prefix{eqn} instead of
+\prefix{eq}?  No problem, just redefine the prefix:
+\fancyrefchangeprefix{\fancyrefeqlabelprefix}{eqn}
+\begin{verbatim}
+   \fancyrefchangeprefix{\fancyrefeqlabelprefix}{eqn}
+\end{verbatim}
+We need a new, fantastic test equation with label
+\labelname{eqn-fantastic}:
+\begin{equation}
+  \label{eqn-fantastic}
+  b = b
+\end{equation}
+The cross-reference |\fref{eqn-fantastic}| will give
+\fref{eqn-fantastic} as output, as expected.
+
+Maybe the spacing between \stringdef{eq.} and ``3'' is too generous,
+let us tighten things a bit, with
+\renewcommand*{\fancyrefdefaultspacing}{\fancyreftightspacing}
+\begin{verbatim}
+   \renewcommand*{\fancyrefdefaultspacing}{%
+     \fancyreftightspacing
+   }
+\end{verbatim}
+the spacing looks like \fref{eqn-fantastic}.  If you think this is
+better, just use the \option{tight} option of this package.
+\fancyrefchangeprefix{\fancyrefeqlabelprefix}{eq}
+
+Perhaps you want parentheses around the cross-reference?  No problem,
+just redefine the appropriate hook:
+\renewcommand*{\fancyrefhook}[1]{(#1)}
+\begin{verbatim}
+   \renewcommand*{\fancyrefhook}[1]{(#1)}
+\end{verbatim}
+The result from |\fref{eq-trivial}| is \fref{eq-trivial}.  In fact
+this could have been obtained easier, as I provided an package option
+just for this purpose:
+\begin{verbatim}
+   \usepackage[paren]{fancyref}
+\end{verbatim}
+
+Now let us try something really cool.  What about introducing a new
+type of objects, e.\,g.\ theorems, with \prefix{thm} prefixed, new
+strings like \stringdef{Theorem} added and the cross-reference in huge
+italics?  Also, as you have read in that bargain textbook on
+typography (\booktitle{cAN U rEaD It} by \person{John Badmountain}),
+cross-references to theorems should be typeset as footnotes.  No
+problem:  First, we need a new prefix:
+\newcommand*{\fancyrefthmlabelprefix}{thm}
+\begin{verbatim}
+   \newcommand*{\fancyrefthmlabelprefix}{thm}
+\end{verbatim}
+Then we declare a new \package{fancyref} format called \format{foot}:
+\frefformat{foot}{\fancyrefthmlabelprefix}{%
+  \unskip\footnote{%
+    \huge\itshape\Frefthmname\fancyrefdefaultspacing#1#3%
+  }%
+}
+\Frefformat{foot}{\fancyrefthmlabelprefix}{%
+  \unskip\footnote{%
+    \huge\itshape\Frefthmname\fancyrefdefaultspacing#1#3%
+  }%
+}
+\begin{verbatim}
+   \frefformat{foot}{\fancyrefthmlabelprefix}{%
+     \unskip\footnote{%
+       \huge\itshape\Frefthmname\fancyrefdefaultspacing#1#3%
+     }%
+   }
+   \Frefformat{foot}{\fancyrefthmlabelprefix}{%
+     \unskip\footnote{%
+       \huge\itshape\Frefthmname\fancyrefdefaultspacing#1#3%
+     }%
+   }
+\end{verbatim}
+The strings have to be setup in the preamble of the document, I did
+this already, because I knew it would be necessary.  The code I used
+was:
+\begin{verbatim}
+   \fancyrefaddcaptions{english}{%
+     \newcommand*{\Frefthmname}{Theorem}%
+     \newcommand*{\frefthmname}{%
+       \MakeLowercase{\Frefthmname}%
+     }%
+   }%
+\end{verbatim}
+And finally this is the test theorem:
+\begin{theorem}[Murphy]
+  \label{thm-murphy}
+  If something \emph{can} go wrong, it \emph{will} go wrong.
+\end{theorem}
+Now let us try it.  |\Fref[foot]{thm-murphy}| comes out
+as \Fref[foot]{thm-murphy}.  Oops, the hook is still at work, I will
+just reset it to its default value:
+\renewcommand*{\fancyrefhook}[1]{#1}%
+\begin{verbatim}
+   \renewcommand*{\fancyrefhook}[1]{#1}
+\end{verbatim}
+And now?  \Fref[foot]{thm-murphy} Gotcha!
+
+\end{document}

--- a/tagging-status/testfiles/floatflt/floatflt-01.tex
+++ b/tagging-status/testfiles/floatflt/floatflt-01.tex
@@ -1,0 +1,23 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+
+\usepackage{floatflt}
+\usepackage{kantlipsum}
+\usepackage{graphicx}
+
+\begin{document}
+
+\kant[1-2]
+\begin{floatingfigure}{0.4\textwidth}
+\includegraphics[width=0.35\textwidth,alt=alt text]{example-image}
+\caption{Some caption}
+\end{floatingfigure}
+\kant[3-4]
+
+\end{document}

--- a/tagging-status/testfiles/morefloats/morefloats-01.tex
+++ b/tagging-status/testfiles/morefloats/morefloats-01.tex
@@ -1,0 +1,32 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,title,math,table,firstaid}
+  }
+\documentclass{article}
+\usepackage[maxfloats=53]{morefloats}
+
+\maxdeadcycles=200 % necessary
+
+\newcommand{\floattest}{%
+  \begin{table}[t]\centering%
+    \begin{tabular}{|l|}%
+      \hline%
+      A table, which will keep floating.\\%
+      \hline
+    \end{tabular}%
+    \caption{A floating Table.}%
+  \end{table}%
+  }
+
+\begin{document}
+
+text
+
+\ExplSyntaxOn
+\prg_replicate:nn { 53 } { \floattest } % errors at 53
+\ExplSyntaxOff
+
+\end{document}

--- a/tagging-status/testfiles/orcidlink/orcidlink-01.tex
+++ b/tagging-status/testfiles/orcidlink/orcidlink-01.tex
@@ -1,0 +1,25 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,title,math,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{orcidlink}
+
+\title{orcidlink tagging test}
+\author{Emmy Noether\,\orcidlink{0000-0000-0000-0000}}
+
+\begin{document}
+\maketitle
+
+\orcidlogo
+
+\orcidlinkf{0000-0001-7559-9597}
+
+\orcidlinkc{0000-0001-7559-9597}
+
+\orcidlinki{Leo C. Stein}{0000-0001-7559-9597}
+
+\end{document}

--- a/tagging-status/testfiles/prettyref/prettyref-01.tex
+++ b/tagging-status/testfiles/prettyref/prettyref-01.tex
@@ -1,0 +1,30 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,title,math,table,firstaid}
+  }
+\documentclass{article}
+
+\usepackage{prettyref}
+\usepackage{hyperref}
+
+\title{prettyref tagging test}
+
+\begin{document}
+
+\section{Some section}
+\label{sec:some}
+
+\begin{figure}
+Figure content
+\caption{Some figure}
+\label{fig:some}
+\end{figure}
+
+\prettyref{sec:some}
+
+\prettyref{fig:some}
+
+\end{document}

--- a/tagging-status/testfiles/subeqn/subeqn-01.tex
+++ b/tagging-status/testfiles/subeqn/subeqn-01.tex
@@ -1,0 +1,21 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,title,math,table,firstaid}
+  }
+\documentclass{article}
+
+\usepackage{subeqn}
+
+\title{subeqn tagging test}
+
+\begin{document}
+
+\begin{subeqnarray}
+A & B \\
+C & D
+\end{subeqnarray}
+
+\end{document}

--- a/tagging-status/testfiles/subeqnarray/subeqnarray-01.tex
+++ b/tagging-status/testfiles/subeqnarray/subeqnarray-01.tex
@@ -1,0 +1,19 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,title,math,table,firstaid}
+  }
+\documentclass{article}
+
+\usepackage{subeqn}
+
+\begin{document}
+
+\begin{subeqnarray}
+A & B \\
+C & D
+\end{subeqnarray}
+
+\end{document}

--- a/tagging-status/testfiles/textpos/textpos-01.tex
+++ b/tagging-status/testfiles/textpos/textpos-01.tex
@@ -1,0 +1,18 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,title,math,table,firstaid}
+  }
+\documentclass{article}
+
+\usepackage{textpos}
+
+\begin{document}
+
+\begin{textblock}{2}(5,5)
+Here is some text
+\end{textblock}
+
+\end{document}

--- a/tagging-status/testfiles/titlecaps/titlecaps-01.tex
+++ b/tagging-status/testfiles/titlecaps/titlecaps-01.tex
@@ -1,0 +1,20 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,title,math,table,firstaid}
+  }
+\documentclass{article}
+
+\usepackage{titlecaps}
+
+\Addlcwords{a of to}
+
+\begin{document}
+
+\titlecap{a bunch of TeXt to test titlecaps}
+
+\titlecap{\huge a bunch of TeXt \bfseries \{\textnc{to}\} test \texttt{titlecaps}}
+
+\end{document}

--- a/tagging-status/testfiles/typicons/typicons-01.tex
+++ b/tagging-status/testfiles/typicons/typicons-01.tex
@@ -1,0 +1,20 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,title,math,table,firstaid}
+  }
+\documentclass{article}
+
+\usepackage{typicons}
+
+\begin{document}
+
+\tiAdjustBrightness
+
+\tiChevronLeftOutline
+
+\tiFlag
+
+\end{document}

--- a/tagging-status/testfiles/ytableau/ytableau-01.tex
+++ b/tagging-status/testfiles/ytableau/ytableau-01.tex
@@ -1,0 +1,21 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,title,math,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{ytableau}
+
+\title{ytableau tagging test}
+
+\begin{document}
+
+\begin{ytableau}
+a & d & f \\
+b & e & g \\
+c
+\end{ytableau}
+
+\end{document}


### PR DESCRIPTION
This adds several packages whose status should be simple to evaluate.

Lists currfile, fancyref, morefloats, prettyref, and titlecaps as compatible with tests.

Lists catchfile, currfile-abspath, hyphsubst, multido, namedef, and tracklang as compatible without tests.

Lists orcidlink and typicons as partially-compatible because the symbols need Alt/ActualText.

Lists floatflt, subeqnarray, textpos, and ytableau as currently-incompatible with tests and links to issues.

Adds a test for subeqn.

Adds `priority: 2` for titleps.