### PR TITLE
add pagecolor compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -6973,13 +6973,13 @@
 
  - name: pagecolor
    type: package
-   status: unknown
+   status: compatible
    included-in: [arxiv001]
    priority: 7
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   comments: "Interaction with crop package not supported until crop is made compatible."
+   updated: 2024-08-06
 
  - name: pagegrid
    type: package

--- a/tagging-status/testfiles/pagecolor/pagecolor-01.tex
+++ b/tagging-status/testfiles/pagecolor/pagecolor-01.tex
@@ -1,0 +1,33 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,title,math,table,firstaid}
+  }
+\documentclass{article}
+
+\usepackage{xcolor}
+\usepackage[pagecolor=blue!10]{pagecolor}
+\usepackage{kantlipsum}
+
+\title{pagecolor tagging test}
+
+\begin{document}
+
+\thepagecolor
+
+\kant[1-5]
+
+\pagecolor{rgb:-green!40!yellow,3;green!40!yellow,2;red,1}
+\thepagecolor
+
+\newpage
+\newpagecolor{red!10}
+\kant[6]
+
+\newpage
+\restorepagecolor
+\kant[7]
+
+\end{document}


### PR DESCRIPTION
Lists [pagecolor](https://www.ctan.org/pkg/pagecolor) as compatible and adds a test. A note is added that its interaction with the crop package is not supported until crop is made compatible.