### PR TITLE
add algorithm and algorithmic compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -294,37 +294,28 @@
  - name: algorithm
    ctan-pkg: algorithms
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in: [arxiv5]
    priority: 4
    issues:
-   tests: false
-   updated: 2024-07-28
+   tests: true
+   comments: "`algorithm` environments not tagged as floats. See float package."
+   updated: 2024-08-06
 
  - name: algorithmic
    ctan-pkg: algorithms
    type: package
-   status: unknown
+   status: compatible
    included-in: [arxiv5]
    priority: 4
    issues:
-   tests: false
-   updated: 2024-07-28
+   tests: true
+   updated: 2024-08-06
 
  - name: algorithmicx
    type: package
    status: unknown
    included-in: [tlc3, arxiv5]
-   priority: 2
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-14
-
- - name: algorithms
-   type: package
-   status: unknown
-   included-in: [tlc3]
    priority: 2
    issues:
    tests: false

--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -295,7 +295,7 @@
    ctan-pkg: algorithms
    type: package
    status: currently-incompatible
-   included-in: [arxiv5]
+   included-in: [tlc3,arxiv5]
    priority: 4
    issues:
    tests: true

--- a/tagging-status/testfiles/algorithm/algorithm-01.tex
+++ b/tagging-status/testfiles/algorithm/algorithm-01.tex
@@ -1,0 +1,43 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+\usepackage{algorithm,algorithmic}
+
+\title{algorithm tagging test}
+
+\begin{document}
+
+\listofalgorithms
+
+\begin{algorithm}
+\caption{Calculate $y = x^n$}
+\label{alg1}
+\begin{algorithmic}
+\REQUIRE $n \geq 0 \vee x \neq 0$
+\ENSURE $y = x^n$
+\STATE $y \leftarrow 1$
+\IF{$n < 0$}
+\STATE $X \leftarrow 1 / x$
+\STATE $N \leftarrow -n$
+\ELSE
+\STATE $X \leftarrow x$
+\STATE $N \leftarrow n$
+\ENDIF
+\WHILE{$N \neq 0$}
+\IF{$N$ is even}
+\STATE $X \leftarrow X \times X$
+\STATE $N \leftarrow N / 2$
+\ELSE[$N$ is odd]
+\STATE $y \leftarrow y \times X$
+\STATE $N \leftarrow N - 1$
+\ENDIF
+\ENDWHILE
+\end{algorithmic}
+\end{algorithm}
+
+\end{document}

--- a/tagging-status/testfiles/algorithmic/algorithmic-01.tex
+++ b/tagging-status/testfiles/algorithmic/algorithmic-01.tex
@@ -1,0 +1,40 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+\usepackage{algorithmic}
+
+\title{algorithmic tagging test}
+
+\begin{document}
+
+\begin{algorithmic}[1]
+\REQUIRE $n \geq 0 \vee x \neq 0$
+\ENSURE $y = x^n$
+\STATE $y \leftarrow 1$
+\IF{$n < 0$}
+\STATE $X \leftarrow 1 / x$
+\STATE $N \leftarrow -n$
+\ELSE
+\STATE $X \leftarrow x$
+\STATE $N \leftarrow n$
+\ENDIF
+\WHILE{$N \neq 0$}
+\IF{$N$ is even}\label{alg:n-is-even}
+\STATE $X \leftarrow X \times X$
+\STATE $N \leftarrow N / 2$
+\ELSE[$N$ is odd] \label{alg:n-is-odd}
+\STATE $y \leftarrow y \times X$
+\STATE $N \leftarrow N - 1$
+\ENDIF
+\ENDWHILE
+\end{algorithmic}
+
+\ref{alg:n-is-even}
+
+\ref{alg:n-is-odd}
+\end{document}


### PR DESCRIPTION
Lists algorithm as currently-incompatible because it defines the `algorithm` environment with the float package so is not tagged as a float.

Lists algorithmic as compatible and adds a test. The `algorithmic` environment is implemented as a list which I guess is okay for tagging algorithms.

Removes the "algorithms" entry since that's just the CTAN name for these two packages.