### PR TITLE
add algorithmicx and algpseudocode compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -313,13 +313,12 @@
 
  - name: algorithmicx
    type: package
-   status: unknown
+   status: compatible
    included-in: [tlc3, arxiv5]
    priority: 2
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-14
+   updated: 2024-08-06
 
  - name: algorithms
    type: package
@@ -334,13 +333,12 @@
  - name: algpseudocode
    ctan-pkg: algorithmicx
    type: package
-   status: unknown
+   status: compatible
    included-in: [tlc3, arxiv1]
    priority: 2
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-14
+   tests: true
+   updated: 2024-08-06
 
  - name: aliascnt
    type: package

--- a/tagging-status/testfiles/algpseudocode/algpseudocode-01.tex
+++ b/tagging-status/testfiles/algpseudocode/algpseudocode-01.tex
@@ -1,0 +1,50 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,table,title,firstaid}
+  }
+\documentclass{article}
+\usepackage{algpseudocode}
+
+\title{algpseudocode tagging test - 1}
+
+\begin{document}
+
+\begin{algorithmic}[1]
+\Procedure {BellmanKalaba}{$G$, $u$, $l$, $p$}
+\ForAll {$v \in V(G)$}
+\State $l(v) \leftarrow \infty$
+\EndFor
+\State $l(u) \leftarrow 0$
+\Repeat
+\For {$i \leftarrow 1, n$}
+\State $min \leftarrow l(v_i)$
+\For {$j \leftarrow 1, n$}
+\If {$min > e(v_i, v_j) + l(v_j)$}
+\State $min \leftarrow e(v_i, v_j) + l(v_j)$
+\State $p(i) \leftarrow v_j$
+\EndIf
+\EndFor
+\State $l'(i) \leftarrow min$
+\EndFor
+\State $changed \leftarrow l \not= l'$
+\State $l \leftarrow l'$
+\Until{$\neg changed$}
+\EndProcedure
+\Statex
+\Procedure {FindPathBK}{$v$, $u$, $p$}
+\If {$v = u$}
+\State \textbf{Write} $v$
+\Else
+\State $w \leftarrow v$
+\While {$w \not= u$}
+\State \textbf{Write} $w$
+\State $w \leftarrow p(w)$
+\EndWhile
+\EndIf
+\EndProcedure
+\end{algorithmic}
+
+\end{document}

--- a/tagging-status/testfiles/algpseudocode/algpseudocode-02.tex
+++ b/tagging-status/testfiles/algpseudocode/algpseudocode-02.tex
@@ -1,0 +1,46 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,table,title,firstaid}
+  }
+\documentclass{article}
+\usepackage{algpseudocode}
+
+\title{algpseudocode tagging test - 2}
+
+\begin{document}
+
+\begin{algorithmic}[1]
+\Procedure {BellmanKalaba}{$G$, $u$, $l$, $p$}
+\ForAll {$v \in V(G)$}
+\State $l(v) \leftarrow \infty$
+\EndFor
+\State $l(u) \leftarrow 0$
+\Repeat
+\For {$i \leftarrow 1, n$}
+\State $min \leftarrow l(v_i)$
+\For {$j \leftarrow 1, n$}
+\If {$min > e(v_i, v_j) + l(v_j)$}
+\State $min \leftarrow e(v_i, v_j) + l(v_j)$
+\State \Comment For some reason we need to break here!
+\algstore{bkbreak}
+\end{algorithmic}
+
+Some intermediate text
+
+\begin{algorithmic}[1]
+\algrestore{bkbreak}
+\State $p(i) \leftarrow v_j$
+\EndIf
+\EndFor
+\State $l'(i) \leftarrow min$
+\EndFor
+\State $changed \leftarrow l \not= l'$
+\State $l \leftarrow l'$
+\Until{$\neg changed$}
+\EndProcedure
+\end{algorithmic}
+
+\end{document}


### PR DESCRIPTION
Same comments as in #509 apply here.

Lists algpseudocode as compatible with tests. Lists algorithmicx as compatible without tests because it's the package underlying the "styles" algpseudocode, algc, and algpascal.