### PR TITLE
add blowup compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -1288,13 +1288,12 @@
 
  - name: blowup
    type: package
-   status: unknown
+   status: compatible
    included-in:
    priority: 9
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-28
+   tests: true
+   updated: 2024-08-06
 
  - name: bm
    type: package

--- a/tagging-status/testfiles/blowup/blowup-01.tex
+++ b/tagging-status/testfiles/blowup/blowup-01.tex
@@ -1,0 +1,56 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,title,math,table,firstaid}
+  }
+\documentclass[letterpaper,twoside]{article}
+\usepackage{array,xcolor}
+
+% Just to show the page size of the source.
+\usepackage{xcolor}
+\AddToHook{shipout/background}{%
+  \put(0,0){\textcolor{green!30}{\rule[-\paperheight]{\paperwidth}{\paperheight}}}%
+}
+
+\renewcommand\familydefault{\sfdefault}
+\setlength\parindent{0pt}
+\pagestyle{empty}
+
+\usepackage{blowup}
+\blowUp{target=a4,pos=c}% vert. and horiz. centered (default)
+
+\title{blowup tagging test - 1}
+
+\begin{document}
+
+\null\vfill
+
+\huge\centering
+
+Letter-size document on A4-size paper
+
+\vfill
+
+\setlength\extrarowheight{.5ex}
+\begin{tabular}{|>{\bfseries}l<{:}r<{\,mm}!{$\times$}r<{\,mm}|} \hline
+  letter    & 216 &  279 \\
+  legal     & 216 &  356 \\
+  executive & 184 &  267 \\
+  A8        &  52 &   74 \\
+  A7        &  74 &  105 \\
+  A6        & 105 &  148 \\
+  A5        & 148 &  210 \\
+  A4        & 210 &  297 \\
+  A3        & 297 &  420 \\
+  A2        & 420 &  594 \\
+  A1        & 594 &  841 \\
+  A0        & 841 & 1189 \\ \hline
+\end{tabular}
+
+\vfill
+
+\newpage\null 2nd page\dots
+
+\end{document}

--- a/tagging-status/testfiles/blowup/blowup-02.tex
+++ b/tagging-status/testfiles/blowup/blowup-02.tex
@@ -1,0 +1,56 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,title,math,table,firstaid}
+  }
+\documentclass[a4paper,twoside]{article}
+\usepackage{array,xcolor}
+
+% Just to show the page size of the source.
+\usepackage{xcolor}
+\AddToHook{shipout/background}{%
+  \put(0,0){\textcolor{green!30}{\rule[-\paperheight]{\paperwidth}{\paperheight}}}%
+}
+
+\renewcommand\familydefault{\sfdefault}
+\setlength\parindent{0pt}
+\pagestyle{empty}
+
+\usepackage{blowup}
+\blowUp{h-mirroring,v-mirroring}% vertical and horizontal mirrored
+
+\title{blowup tagging test - 2}
+
+\begin{document}
+
+\null\vfill
+
+\huge\centering
+
+A4-sized document not resized, mirrored vertically and horizontally
+
+\vfill
+
+\setlength\extrarowheight{.5ex}
+\begin{tabular}{|>{\bfseries}l<{:}r<{\,mm}!{$\times$}r<{\,mm}|} \hline
+  letter    & 216 &  279 \\
+  legal     & 216 &  356 \\
+  executive & 184 &  267 \\
+  A8        &  52 &   74 \\
+  A7        &  74 &  105 \\
+  A6        & 105 &  148 \\
+  A5        & 148 &  210 \\
+  A4        & 210 &  297 \\
+  A3        & 297 &  420 \\
+  A2        & 420 &  594 \\
+  A1        & 594 &  841 \\
+  A0        & 841 & 1189 \\ \hline
+\end{tabular}
+
+\vfill
+
+\newpage\null 2nd page\dots
+
+\end{document}


### PR DESCRIPTION
Lists [blowup](https://www.ctan.org/pkg/blowup) as compatible and adds a test. Even when the content is mirrored the logical order seems correct.