### PR TITLE
fix references

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -3458,7 +3458,7 @@
    included-in: [tlc3, arxiv10]
    priority: 2
    comments: "[H] floats are not yet automatically tagged."
-   references: [2]
+   references: [1]
    tasks: needs tests
    updated: 2024-07-06
 
@@ -9216,7 +9216,7 @@
    status: currently-incompatible
    included-in: [tlc3, arxiv10]
    priority: 2
-   references: [2]
+   references: [1]
    updated: 2024-07-06
 
  - name: tikz-cd


### PR DESCRIPTION
Fixes the references for tikz and float. Closes #447.