### PR TITLE
add amsproc

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -10411,6 +10411,7 @@
    priority: 2
    supported-through: [phase-III,firstaid,title]
    comments: "theorem environments not compatible, see amsthm. Used by project example arxiv3"
+   tests: false
    tasks: needs further tests
    updated: 2024-07-07
 
@@ -10421,6 +10422,7 @@
    priority: 2
    supported-through: [phase-III,firstaid,title]
    comments: "theorem environments not compatible, see amsthm."
+   tests: false
    tasks: needs further tests
    updated: 2024-07-07
 
@@ -10431,8 +10433,20 @@
    included-in:
    priority: 2
    comments: "See some needed adjustments in project example `amsldoc`"
+   tests: false
    tasks: needs further tests
    updated: 2024-07-07
+
+ - name: amsproc
+   type: class
+   status: partially-compatible
+   included-in: [arxiv01]
+   priority: 6
+   supported-through: [phase-III,firstaid,title]
+   comments: "theorem environments not compatible, see amsthm."
+   tests: false
+   tasks: needs further tests
+   updated: 2024-08-06
 
  - name: article
    type: class


### PR DESCRIPTION
Adds an entry for [amsproc](https://www.ctan.org/pkg/amsproc). I kept `supported-through: [phase-III,firstaid,title]` from amsart and amsbook but it would need its own
```tex
\AddToHook{class/amsproc/after}
 {\def\@author{\authors}}
```
in latex-lab-firstaid. (I'm not sure what this does; with amsart/amsbook the metadata fields for title and author are empty. Also `\maketitle` is broken with the ams classes (#443) so listing `supported-through: [title]` might be a little misleading.)