### PR TITLE
add changebar compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -1727,7 +1727,7 @@
    priority: 2
    issues:
    tests: true
-   tasks: "Broken with lualatex."
+   tasks: "Needs luatex85 loaded with lualatex."
    updated: 2024-08-06
 
  - name: changepage

--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -1722,13 +1722,13 @@
 
  - name: changebar
    type: package
-   status: unknown
+   status: partially-compatible
    included-in: [tlc3, arxiv01]
    priority: 2
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-14
+   tests: true
+   tasks: "Broken with lualatex."
+   updated: 2024-08-06
 
  - name: changepage
    type: package

--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -1727,8 +1727,9 @@
    priority: 2
    issues:
    tests: true
-   tasks: "Needs luatex85 loaded with lualatex."
-   updated: 2024-08-06
+   tasks: "Determine how to tag changed parts."
+   comments: "Needs luatex85 loaded with lualatex."
+   updated: 2024-08-07
 
  - name: changepage
    type: package

--- a/tagging-status/testfiles/changebar/changebar-01.tex
+++ b/tagging-status/testfiles/changebar/changebar-01.tex
@@ -1,0 +1,35 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,title,math,table,firstaid}
+  }
+\documentclass{article}
+
+\usepackage{changebar}
+\usepackage{kantlipsum}
+
+\title{changebar tagging test}
+
+\begin{document}
+
+\cbstart
+text
+\cbend
+
+\cbdelete
+Here is some text that. Here is some text that. Here is some text that.
+
+\begin{changebar}[5pt]
+Here is some text that. Here is some text that. Here is some text that.
+Here is some text that. Here is some text that. Here is some text that.
+Here is some text that. Here is some text that. Here is some text that.
+
+Here is some text that.\cbdelete[10pt] Here is some text that. Here is some text that.
+Here is some text that. Here is some text that. Here is some text that.
+\end{changebar}
+
+Here is some text that. Here is some text that. Here is some text that.
+
+\end{document}

--- a/tagging-status/testfiles/changebar/changebar-01.tex
+++ b/tagging-status/testfiles/changebar/changebar-01.tex
@@ -7,6 +7,7 @@
   }
 \documentclass{article}
 
+%\usepackage{luatex85} % needed with lualatex
 \usepackage{changebar}
 \usepackage{kantlipsum}
 


### PR DESCRIPTION
Lists [changebar](https://ctan.org/pkg/changebar) as partially-compatible and adds a test. The bars are not tagged as Artifacts but instead in the main stream of content.

<img width="386" alt="changebar_content" src="https://github.com/user-attachments/assets/30637ac8-911d-48cb-8db6-c4c07d79b09c">

This didn't adversely affect the result when uploaded to ngpdf, but may still be incorrect.

Also, it needs luatex85 with luatex. With luatex it errors with
```
! Undefined control sequence.
\cb@defpoint ...ount }}\let \the =\z@ \pdfsavepos 
                                                  \edef \cb@temp {\write \@a...
```
so it's assuming luatex defines the same pdftex primitives.
