### PR TITLE
add bussproofs compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -1408,13 +1408,13 @@
 
  - name: bussproofs
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in: [arxiv01]
    priority: 6
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   comments: "Tagged as normal text instead of figure with Alt text."
+   updated: 2024-08-06
 
  - name: bxeepic
    type: package

--- a/tagging-status/testfiles/bussproofs/bussproofs-01.tex
+++ b/tagging-status/testfiles/bussproofs/bussproofs-01.tex
@@ -1,0 +1,34 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,title,math,table,firstaid}
+  }
+\documentclass{article}
+
+\usepackage{bussproofs}
+
+\title{bussproofs tagging test}
+
+\begin{document}
+
+\begin{prooftree}
+\AxiomC{A}
+\AxiomC{B}
+\AxiomC{C}
+\TrinaryInfC{D}
+\end{prooftree}
+
+\begin{prooftree}
+\Axiom$A, B, C, D,\fCenter\ E, F$
+\UnaryInf$A, B,\fCenter\ C, D, E, F$
+\end{prooftree}
+
+\begin{prooftree}
+\AxiomC{$\Gamma, A \vdash B$}
+\LeftLabel{Conditional Proof:}
+\UnaryInfC{$\Gamma \vdash A \rightarrow B$}
+\end{prooftree}
+
+\end{document}


### PR DESCRIPTION
Lists [bussproofs](https://ctan.org/pkg/bussproofs) as currently-incompatible because the proofs are tagged as normal text with rules and formulas mixed in. They should probably be Figures with the option to add Alt text.