### PR TITLE
add more packages

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -744,15 +744,23 @@
    tests: false
    updated: 2024-07-21
 
+ - name: attachfile
+   type: package
+   status: currently-incompatible
+   included-in: [arxiv001]
+   priority: 7
+   issues: [511]
+   tests: true
+   updated: 2024-08-06
+
  - name: attachfile2
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in:
    priority: 9
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-17
+   issues: [511]
+   tests: true
+   updated: 2024-08-06
 
  - name: atveryend
    type: package
@@ -1802,13 +1810,12 @@
 
  - name: chemformula
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in: [arxiv01]
    priority: 6
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   issues: [521]
+   tests: true
+   updated: 2024-08-06
 
  - name: chemgreek
    type: package
@@ -1946,13 +1953,12 @@
 
  - name: classlist
    type: package
-   status: unknown
+   status: compatible
    included-in:
    priority: 9
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   updated: 2024-08-06
 
  - name: cleveref
    type: package
@@ -2815,13 +2821,12 @@
 
  - name: enparen
    type: package
-   status: unknown
+   status: compatible
    included-in:
    priority: 9
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   updated: 2024-08-06
 
  - name: enumerate
    type: package
@@ -3153,13 +3158,12 @@
  - name: extramarks
    ctan-pkg: fancyhdr
    type: package
-   status: unknown
+   status: compatible
    included-in: [arxiv001]
    priority: 7
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   updated: 2024-08-06
 
 #------------------------ FFF ----------------------------
 
@@ -3559,13 +3563,13 @@
 
  - name: fnlineno
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in:
    priority: 9
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   comments: "See lineno."
+   updated: 2024-08-06
 
  - name: fnpct
    type: package
@@ -4220,13 +4224,12 @@
 
  - name: grfext
    type: package
-   status: unknown
+   status: compatible
    included-in:
    priority: 9
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   updated: 2024-08-06
 
  - name: gridset
    type: package
@@ -5455,13 +5458,12 @@
 
  - name: luacode
    type: package
-   status: unknown
+   status: compatible
    included-in:
    priority: 9
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   updated: 2024-08-06
 
  - name: lualatex-math
    type: package
@@ -6018,13 +6020,12 @@
 
  - name: midpage
    type: package
-   status: unknown
+   status: compatible
    included-in:
    priority: 9
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   updated: 2024-08-06
 
  - name: minibox
    type: package
@@ -7397,13 +7398,12 @@
 
  - name: phonenumbers
    type: package
-   status: unknown
+   status: compatible
    included-in:
    priority: 9
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   updated: 2024-08-06
 
  - name: piano
    type: package
@@ -7716,6 +7716,15 @@
    tests: true
    updated: 2024-07-28
 
+ - name: quoting
+   type: package
+   status: currently-incompatible
+   included-in: [arxiv001]
+   priority: 7
+   issues: [507]
+   tests: true
+   updated: 2024-08-06
+
 #------------------------ RRR ----------------------------
 
  - name: Rosario
@@ -7856,13 +7865,12 @@
 
  - name: rerunfilecheck
    type: package
-   status: unknown
+   status: compatible
    included-in:
    priority: 9
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   updated: 2024-08-06
 
  - name: resizegather
    type: package
@@ -8148,13 +8156,12 @@
 
  - name: selectp
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in: [arxiv001]
    priority: 7
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   issues: [506]
+   tests: true
+   updated: 2024-08-06
 
  - name: selinput
    type: package
@@ -8285,13 +8292,12 @@
 
  - name: showframe
    type: package
-   status: unknown
+   status: compatible
    included-in:
    priority: 9
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   updated: 2024-08-06
 
  - name: showhyphenation
    type: package
@@ -8539,13 +8545,12 @@
 
  - name: stampinclude
    type: package
-   status: unknown
+   status: compatible
    included-in:
    priority: 9
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   updated: 2024-08-06
 
  - name: standardsectioning
    type: package
@@ -9409,13 +9414,12 @@
 
  - name: totalcount
    type: package
-   status: unknown
+   status: compatible
    included-in:
    priority: 9
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   updated: 2024-08-06
 
  - name: trace
    type: package

--- a/tagging-status/testfiles/attachfile/attachfile-01.tex
+++ b/tagging-status/testfiles/attachfile/attachfile-01.tex
@@ -1,0 +1,24 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,title,math,table,firstaid}
+  }
+\documentclass{article}
+
+\usepackage{attachfile}
+
+\title{attachfile tagging test}
+
+\begin{document}
+
+\attachfile{example-image.pdf} % compare with below
+% text\attachfile{example-image.pdf}
+\noattachfile
+
+\textattachfile{example-image-a.pdf}{This text links to a file}
+
+\notextattachfile{This text does not link to a file}
+
+\end{document}

--- a/tagging-status/testfiles/attachfile2/attachfile2-01.tex
+++ b/tagging-status/testfiles/attachfile2/attachfile2-01.tex
@@ -1,0 +1,27 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,title,math,table,firstaid}
+  }
+\documentclass{article}
+
+\usepackage{attachfile2}
+\usepackage{xcolor}
+
+\title{attachfile2 tagging test}
+
+\attachfilesetup{color=blue}
+
+\begin{document}
+
+\attachfile{example-image.pdf} % compare with below
+% text\attachfile{example-image.pdf}
+\noattachfile
+
+\textattachfile{example-image-a.pdf}{This text links to a file}
+
+\notextattachfile{This text does not link to a file}
+
+\end{document}

--- a/tagging-status/testfiles/chemformula/chemformula-01.tex
+++ b/tagging-status/testfiles/chemformula/chemformula-01.tex
@@ -1,0 +1,18 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,title,math,table,firstaid}
+  }
+\documentclass{article}
+
+\usepackage{chemformula}
+
+\title{chemformula tagging test}
+
+\begin{document}
+
+\ch{H2O}
+
+\end{document}

--- a/tagging-status/testfiles/classlist/classlist-01.tex
+++ b/tagging-status/testfiles/classlist/classlist-01.tex
@@ -1,0 +1,18 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,title,math,table,firstaid}
+  }
+\RequirePackage{classlist}
+\documentclass[12pt,a4paper]{exam}
+
+\title{classlist tagging test}
+
+\begin{document}
+
+\MainClassName
+
+\PrintClassList
+\end{document}

--- a/tagging-status/testfiles/enparen/enparen-01.tex
+++ b/tagging-status/testfiles/enparen/enparen-01.tex
@@ -1,0 +1,27 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,title,math,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{enparen}
+
+\title{enparen tagging test}
+
+\begin{document}
+
+\enparen{a \enparen{b} \enparen{c \enparen{d}} \enparen{e}}
+
+\enparenLeft text before table ...
+\begin{table}
+\caption{Table caption \enparen{foobar}}
+\enparenBeginContext{table}
+Other text \enparen{foobar}.
+\enparenEndContext{table}
+\end{table}
+text after table ...\footnote{text \enparen{foobar}}
+\enparenRight
+
+\end{document}

--- a/tagging-status/testfiles/extramarks/extramarks-01.tex
+++ b/tagging-status/testfiles/extramarks/extramarks-01.tex
@@ -1,0 +1,39 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,title,math,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{fancyhdr}
+\usepackage{extramarks}
+\usepackage{kantlipsum}
+
+\pagestyle{fancy}
+\fancyhead[L]{\firstxmark}
+\fancyfoot[R]{\lastxmark}
+\fancypagestyle{plain}{\fancyhead{}\renewcommand{\headrule}{}}
+
+\title{extramarks tagging test}
+
+\begin{document}
+
+\extramarks{}{}% 1
+\kant[1]
+
+\newpage
+
+\extramarks{Continued\ldots}{Continued on next page\ldots}% 2
+\kant[2-6]
+
+\newpage
+
+\extramarks{Continued\ldots}{}% 3
+\kant[7]
+
+\newpage
+\extramarks{}{}% 4
+\kant[8]
+
+\end{document}

--- a/tagging-status/testfiles/fnlineno/fnlineno-01.tex
+++ b/tagging-status/testfiles/fnlineno/fnlineno-01.tex
@@ -1,0 +1,19 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,title,math,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{lineno,fnlineno}
+
+\title{fnlineno tagging test}
+
+\begin{document}
+
+\begin{linenumbers}
+bla bla
+\end{linenumbers}
+
+\end{document}

--- a/tagging-status/testfiles/midpage/midpage-01.tex
+++ b/tagging-status/testfiles/midpage/midpage-01.tex
@@ -1,0 +1,24 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,title,math,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{midpage}
+\usepackage{kantlipsum}
+
+\title{midpage tagging test}
+
+\begin{document}
+
+\kant[1-2]
+\clearpage
+\begin{midpage}
+\kant[3-4]
+\end{midpage}
+\clearpage
+\kant[5-6]
+
+\end{document}

--- a/tagging-status/testfiles/phonenumbers/phonenumbers-01.tex
+++ b/tagging-status/testfiles/phonenumbers/phonenumbers-01.tex
@@ -1,0 +1,30 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,title,math,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{phonenumbers}
+
+\title{phonenumbers tagging test}
+
+\begin{document}
+
+\phonenumber{0441343396}[83]
+
+\phonenumber[area-code-sep=brackets]{020432632194}
+
+\phonenumber[country=AT,area-code-sep=brackets]{0225854321}
+
+\phonenumber[country=AT,area-code=place,area-code-sep=space]{0662654321}
+
+\setphonenumbers{foreign,foreign-area-code-sep=brackets}
+\phonenumber[country=DE]{0441343396}
+
+\phonenumber[country=UK]{01514960123}
+
+\phonenumber[country=US]{2125550123}
+
+\end{document}

--- a/tagging-status/testfiles/quoting/quoting-01.tex
+++ b/tagging-status/testfiles/quoting/quoting-01.tex
@@ -1,0 +1,25 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,title,math,table,firstaid}
+  }
+\documentclass{article}
+
+\usepackage{quoting}
+\usepackage{kantlipsum}
+
+\title{quoting tagging test}
+
+\begin{document}
+
+outer text
+\begin{quoting}
+\kant[1-2]
+\end{quoting}
+
+% ^ error goes away if this line removed
+outer text
+
+\end{document}

--- a/tagging-status/testfiles/selectp/selectp-01.tex
+++ b/tagging-status/testfiles/selectp/selectp-01.tex
@@ -1,0 +1,36 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,title,math,table,firstaid}
+  }
+\documentclass{article}
+
+\usepackage{selectp}
+\usepackage[math,toc]{blindtext}
+\usepackage{kantlipsum}
+\usepackage{longtable}
+
+\outputonly{2,20}
+\title{selectp tagging test}
+
+\begin{document}
+\kant[1-3]
+\Blinddocument
+\begin{longtable}{c}
+a=b \\
+a=b \\
+a=b \\
+a=b \\
+a=b \\
+a=b \\
+a=b \\
+a=b \\
+a=b \\
+a=b \\
+a=b \\
+a=b \\
+\end{longtable}
+
+\end{document}

--- a/tagging-status/testfiles/showframe/showframe-01.tex
+++ b/tagging-status/testfiles/showframe/showframe-01.tex
@@ -1,0 +1,17 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,title,math,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{showframe}
+
+\title{showframe tagging test}
+
+\begin{document}
+
+Some text
+
+\end{document}


### PR DESCRIPTION
Lists classlist, enparen, extramarks, midpage, phonenumbers, and showframe as compatible with tests.

Lists grfext, luacode, rerunfilecheck, stampinclude, and totalcount as compatible without tests.

Lists attachfile, attachfile2, chemformula, fnlineno, quoting, and selectp as currently-incompatible with links to issues and tests.