### PR TITLE
add standalone compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -10674,10 +10674,11 @@
 
  - name: standalone
    type: class
-   status: unknown
+   status: currently-incompatible
    included-in: [arxiv01]
    priority: 6
    issues:
-   tasks: needs tests
-   updated: 2024-07-17
+   tests: true
+   comments: "Content is lost at pdf level due to being boxed."
+   updated: 2024-08-07
 

--- a/tagging-status/testfiles/standalone/standalone-01.tex
+++ b/tagging-status/testfiles/standalone/standalone-01.tex
@@ -1,0 +1,11 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,title,math,table,firstaid}
+  }
+\documentclass{standalone}
+\begin{document}
+text
+\end{document}

--- a/tagging-status/testfiles/standalone/standalone-02.tex
+++ b/tagging-status/testfiles/standalone/standalone-02.tex
@@ -1,0 +1,11 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,title,math,table,firstaid}
+  }
+\documentclass[preview=true]{standalone}
+\begin{document}
+text
+\end{document}

--- a/tagging-status/testfiles/standalone/standalone-03.tex
+++ b/tagging-status/testfiles/standalone/standalone-03.tex
@@ -1,0 +1,11 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,title,math,table,firstaid}
+  }
+\documentclass[crop=false]{standalone}
+\begin{document}
+text
+\end{document}


### PR DESCRIPTION
Lists the [standalone](https://ctan.org/pkg/standalone) class as currently-incompatible because with the crop (default) or preview options, the material is boxed and lost at the pdf level.