### PR TITLE
add several packages

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -616,13 +616,12 @@
 
  - name: arabicfront
    type: package
-   status: unknown
+   status: compatible
    included-in: [tlc3]
    priority: 2
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-13
+   tests: true
+   updated: 2024-08-07
 
  - name: arabluatex
    type: package
@@ -1792,13 +1791,13 @@
 
  - name: chemfig
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in: [arxiv001]
    priority: 7
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   comments: "Figures are tagged as a sequence of many formulas."
+   updated: 2024-08-07
 
  - name: chemformula
    type: package
@@ -1964,13 +1963,12 @@
 
  - name: clrstrip
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in:
    priority: 9
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   issues: [528]
+   tests: true
+   updated: 2024-08-07
 
  - name: cmbright
    type: package
@@ -2392,13 +2390,13 @@
 
  - name: decorule
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in:
    priority: 9
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   tasks: "`\\decorule` should be tagged as an Artifact."
+   updated: 2024-08-07
 
  - name: dejavu
    type: package
@@ -2607,13 +2605,12 @@
 
  - name: easylist
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in: [arxiv001]
    priority: 7
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   issues: [536]
+   tests: true
+   updated: 2024-08-07
 
  - name: ebgaramond
    type: package
@@ -3335,13 +3332,12 @@
 
  - name: filecontentsdef
    type: package
-   status: unknown
+   status: compatible
    included-in:
    priority: 9
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   updated: 2024-08-07
 
  - name: filemod
    type: package
@@ -3585,13 +3581,13 @@
 
  - name: fnumprint
    type: package
-   status: unknown
+   status: partially-compatible
    included-in:
    priority: 9
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   comments: See numprint.
+   updated: 2024-08-07
 
  - name: fontawesome5
    type: package
@@ -3679,13 +3675,13 @@
 
  - name: footnotehyper
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in: [arxiv001]
    priority: 7
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   tasks: "Similar issues as footnote package." 
+   updated: 2024-08-07
 
  - name: footnoterange
    type: package
@@ -3971,13 +3967,12 @@
 
  - name: gettitlestring
    type: package
-   status: unknown
+   status: compatible
    included-in: [arxiv10]
    priority: 3
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   updated: 2024-08-07
 
  - name: gfsartemisia
    type: package
@@ -4257,13 +4252,12 @@
 
  - name: hanging
    type: package
-   status: unknown
-   included-in:
-   priority: 9
+   status: compatible
+   included-in: [arxiv001]
+   priority: 7
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   updated: 2024-08-07
 
  - name: har2nat
    type: package
@@ -5528,13 +5522,12 @@
 
  - name: luavlna
    type: package
-   status: unknown
+   status: compatible
    included-in:
    priority: 9
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   updated: 2024-08-07
 
  - name: lucida-otf
    type: package
@@ -5963,9 +5956,17 @@
    tests: true
    updated: 2024-07-30
 
- - name: mflogo
+ - name: mfb-oldstyle
    type: package
    status: compatible
+   included-in:
+   priority: 9
+   issues:
+   tests: false
+   updated: 2024-08-07
+
+ - name: mflogo
+   type: package
    included-in:
    priority: 9
    issues:
@@ -6736,15 +6737,24 @@
    tasks: needs tests
    updated: 2024-07-18
 
+ - name: numprint
+   type: package
+   status: partially-compatible
+   included-in: [arxiv01]
+   priority: 6
+   issues:
+   tests: true
+   comments: "In text mode, printed numbers are a mix of text and math."
+   updated: 2024-08-07
+
  - name: numspell
    type: package
-   status: unknown
+   status: compatible
    included-in:
    priority: 9
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   updated: 2024-08-07
 
  - name: nunito
    type: package
@@ -7630,13 +7640,13 @@
 
  - name: pxpic
    type: package
-   status: unknown
+   status: partially-compatible
    included-in:
    priority: 9
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   comments: "pixpic's should be tagged as figures with Alt text."
+   updated: 2024-08-07
 
  - name: pxtx-cal
    ctan-pkg: pxtxalfa
@@ -7669,13 +7679,13 @@
 
  - name: pythontex
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in:
    priority: 9
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   comments: Verbatim environments error. See fvextra.
+   updated: 2024-08-07
 
 #------------------------ QQQ ----------------------------
 
@@ -7948,13 +7958,12 @@
 
  - name: rotpages
    type: package
-   status: unknown
+   status: compatible
    included-in:
    priority: 9
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   updated: 2024-08-07
 
 #------------------------ SSS ----------------------------
 
@@ -8164,13 +8173,12 @@
 
  - name: selnolig
    type: package
-   status: unknown
+   status: compatible
    included-in:
    priority: 9
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   updated: 2024-08-07
 
  - name: sepfootnotes
    type: package
@@ -8466,13 +8474,13 @@
 
  - name: spark-otf
    type: package
-   status: unknown
+   status: partially-compatible
    included-in:
    priority: 9
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   comments: "Spark charts need to be tagged as figure with Alt text."
+   updated: 2024-08-07
 
  - name: spectral
    type: package
@@ -9492,13 +9500,13 @@
 
  - name: trivfloat
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in:
    priority: 9
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-28
+   tests: true
+   comments: "Environments defined with `\\trivfloat` not tagged as floats. See float package."
+   updated: 2024-08-07
 
  - name: truncate
    type: package
@@ -10011,13 +10019,12 @@
 
  - name: xevlna
    type: package
-   status: unknown
+   status: compatible
    included-in:
    priority: 9
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   updated: 2024-08-07
 
  - name: xfakebold
    type: package
@@ -10322,13 +10329,12 @@
 
  - name: zhnumber
    type: package
-   status: unknown
+   status: compatible
    included-in:
    priority: 9
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   updated: 2024-08-07
 
  - name: zlmtt
    type: package

--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -5967,6 +5967,7 @@
 
  - name: mflogo
    type: package
+   status: compatible
    included-in:
    priority: 9
    issues:

--- a/tagging-status/testfiles/arabicfront/arabicfront-01.tex
+++ b/tagging-status/testfiles/arabicfront/arabicfront-01.tex
@@ -1,0 +1,28 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{book}
+
+\usepackage{arabicfront}
+
+\title{arabicfront tagging test}
+\author{Some author}
+
+\begin{document}
+
+\frontmatter
+\maketitle
+\tableofcontents
+
+\mainmatter
+\chapter{Some chapter}
+text
+
+\backmatter
+\chapter{Some end chapter}
+
+\end{document}

--- a/tagging-status/testfiles/chemfig/chemfig-01.tex
+++ b/tagging-status/testfiles/chemfig/chemfig-01.tex
@@ -1,0 +1,19 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+
+\usepackage{chemfig}
+
+\title{chemfig tagging test}
+
+\begin{document}
+
+\chemfig{A1BC2-[:30]DxEyFGz-H3I}
+\chemmove{\draw[blue](n1-3)to[out=75,in=90](n2-4);}
+
+\end{document}

--- a/tagging-status/testfiles/clrstrip/clrstrip-01.tex
+++ b/tagging-status/testfiles/clrstrip/clrstrip-01.tex
@@ -1,0 +1,21 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,title,math,table,firstaid}
+  }
+\documentclass{article}
+
+\usepackage{xcolor}
+\usepackage{clrstrip}
+
+\begin{document}
+
+outer text
+\begin{colorstrip}{red!5}
+inner text
+\end{colorstrip}
+outer text
+
+\end{document}

--- a/tagging-status/testfiles/decorule/decorule-01.tex
+++ b/tagging-status/testfiles/decorule/decorule-01.tex
@@ -1,0 +1,23 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{decorule}
+
+\title{decorule tagging test}
+
+\begin{document}
+
+text\decorule text
+
+text
+
+\decorule
+
+text
+
+\end{document}

--- a/tagging-status/testfiles/easylist/easylist-01.tex
+++ b/tagging-status/testfiles/easylist/easylist-01.tex
@@ -1,0 +1,25 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{easylist}
+
+\title{easylist tagging test}
+
+\begin{document}
+
+\begin{easylist}
+§ First proposition.
+§§ Interesting comment.
+§§§ A note on the comment.
+§§§ Another note.
+§§§§ By the way...
+§§§§§ This is a subsub...-proposition.
+§ Let’s start something new...
+\end{easylist}
+
+\end{document}

--- a/tagging-status/testfiles/filecontentsdef/filecontentsdef-01.tex
+++ b/tagging-status/testfiles/filecontentsdef/filecontentsdef-01.tex
@@ -1,0 +1,60 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{filecontentsdef}
+
+\title{filecontentsdef tagging test}
+
+\newtheorem{theorem}{Theorem}
+
+\begin{filecontentsdefmacro}{\testverb}
+^&*^%^^ ____+
+
+#@%$$&%*(
+\end{filecontentsdefmacro}
+
+\newcounter{pablo}
+\newenvironment{defexercise}
+{\stepcounter{pablo}%
+\begingroup
+\filecontentsgdefstarred
+{\jobname-ex\the\value{pablo}}{exercise-\the\value{pablo}}}%
+{\endfilecontentsgdefstarred\endgroup}
+\newcommand{\printexercise}[1]{\filecontentsexec{exercise-\the\numexpr#1\relax}}
+
+\begin{document}
+
+\filecontentsprint\testverb
+
+\begin{filecontentshere}{mytest.txt}
+\begin{theorem}
+Some theorem text
+\end{theorem}
+\end{filecontentshere}
+\filecontentsexec\filecontentsheremacro
+
+\begin{defexercise}
+Prove that \[x^n+y^n=z^n\] is not solvable in positive integers if $n$ is at
+most $-3$.\par
+\end{defexercise}
+\begin{defexercise}
+Refute the existence of black holes in less than 140 characters.\par
+\end{defexercise}
+\begin{defexercise}
+\def\NSA{NSA}%
+Prove that factorization is easily done via probabilistic algorithms and
+advance evidence from knowledge of the names of its employees in the
+seventies that the \NSA\ has known that for 40 years.\par
+\end{defexercise}
+\begin{itemize}
+\item \printexercise{3}
+\item \printexercise{2}
+\item \printexercise{1}
+\end{itemize}
+
+\end{document}

--- a/tagging-status/testfiles/fnumprint/fnumprint-01.tex
+++ b/tagging-status/testfiles/fnumprint/fnumprint-01.tex
@@ -1,0 +1,35 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage[german]{fnumprint}
+
+\title{fnumprint tagging test}
+
+\begin{document}
+
+\fnumprint{-1}
+
+\fnumprint{0}
+
+\fnumprint{1}
+
+\fnumprint{3.14}
+
+\fnumprint{10}
+
+\fnumprint{12}
+
+\fnumprint{13}
+
+\fnumprint{\the\month}
+
+\fnumprint{\the\day}
+
+\fnumprintc{page}
+
+\end{document}

--- a/tagging-status/testfiles/footnotehyper/footnotehyper-01.tex
+++ b/tagging-status/testfiles/footnotehyper/footnotehyper-01.tex
@@ -1,0 +1,22 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{footnotehyper}
+
+\title{footnotehyper tagging test - tabular}
+
+\begin{document}
+
+\begin{savenotes}
+\begin{tabular}{cc}
+text\footnote{first} & more\footnote{second} text\footnote{third} \\
+even more text\footnote{fourth} & blub
+\end{tabular}
+\end{savenotes}
+
+\end{document}

--- a/tagging-status/testfiles/gettitlestring/gettitlestring-01.tex
+++ b/tagging-status/testfiles/gettitlestring/gettitlestring-01.tex
@@ -1,0 +1,31 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,title,math,table,firstaid}
+  }
+\documentclass{article}
+
+\PassOptionsToPackage{expand}{gettitlestring}
+\usepackage{hyperref}
+
+\title{gettitlestring tagging test}
+
+\begin{document}
+
+\def\foo{Foo}
+\section{\foo}
+\label{lab}
+
+\paragraph{1}
+\nameref{lab}
+
+\def\foo{Bar}
+\paragraph{2}
+\nameref{lab}
+
+\paragraph{3}
+\nameref{lab}
+
+\end{document}

--- a/tagging-status/testfiles/hanging/hanging-01.tex
+++ b/tagging-status/testfiles/hanging/hanging-01.tex
@@ -1,0 +1,29 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,title,math,table,firstaid}
+  }
+\documentclass{article}
+
+\usepackage{hanging}
+\usepackage{kantlipsum}
+
+\title{hanging tagging test}
+
+\begin{document}
+
+\hangpara{2cm}{1}\kant[1-2]
+\hangpara{2cm}{4}\kant[3-4]
+\begin{hangparas}{2cm}{3}
+\kant[5-6]
+\end{hangparas}
+
+\noindent\begin{minipage}{10em}
+\begin{hangpunct}
+`abc def ghi abc def ghi abc def ghi abc def ghi' abc
+\end{hangpunct}
+\end{minipage}
+
+\end{document}

--- a/tagging-status/testfiles/luavlna/luavlna-01.tex
+++ b/tagging-status/testfiles/luavlna/luavlna-01.tex
@@ -1,0 +1,42 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,title,math,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{fontspec}
+\setmainfont{Libertinus Serif}
+\usepackage[
+%  debug
+  ]{luavlna}
+
+\title{luavlna tagging test}
+
+\setlength{\textwidth}{3in}
+
+\begin{document}
+
+Příliš žluťoučký kůň úpěl ďábelské ódy.
+Text s krátkými souhláskami a samohláskami i dalšími jevy
+z nabídky možností (v textu možnými).
+
+I začátek odstavce je třeba řešit, i když výskyt zalomení
+není pravděpodobný.
+
+Co třeba í znaky š diakritikou?
+
+Různé možnosti [v závorkách <i jiných znacích
+
+Podpora iniciál a titulů: M. J. Hegel, Ing. Běháková, Ph.D., Ž. Zíbrt,
+Ch. Borner.
+
+Podpora jednotek: 100,5 MN\textperiodcentered s, 100.5 kJ, 200 μA, $-1$ dag,
+12 MiB.
+1http://tex.stackexchange.com/a/28128/2891
+2
+Uvnitř matematiky by mělo být zpracování vypnuté: $k \in N$.
+Pokračujeme v příkladu.
+
+\end{document}

--- a/tagging-status/testfiles/numprint/numprint-01.tex
+++ b/tagging-status/testfiles/numprint/numprint-01.tex
@@ -1,0 +1,54 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage[boldmath]{numprint}
+\usepackage{booktabs,xcolor}
+
+\title{numprint tagging test}
+
+\begin{document}
+
+\numprint{-123456}
+
+\numprint{\pm 123456}
+
+\numprint{+-3,1415927e-3.1}
+
+\numprint[N/mm^2]{-123456}
+
+\cntprint{page}
+
+\lenprint{\textwidth}
+
+\begin{tabular}{|n{5}{3}|n[3]{5}{3}|n[3][1]{5}{3}|N{5}{3}|}
+\hline
+123.45e12& 123.45e12& 123.45e12 & 123.45e12 \\
+12345.678e123& 12345.678e123& 12345.678e123& 12345.678e123 \\
+123.45e12.3& 123.45e12.3& 123.45e12.3& 123.45e12.3 \\
+12345.678e123.3& 12345.678e123.3& 12345.678e123.3& 12345.678e123.3 \\
+\hline
+\end{tabular}
+
+\begin{tabular}{lN{12}{3}n{12}{3}}
+\toprule
+normal:&
+123456123456.123e12&
+123456123456.123e12
+\\
+bold:&
+{\fontseries{b}\selectfont} 123456123456.123e12&
+{\npboldmath} 123456123456.123e12
+\\
+bold extended:&
+{\bfseries} 123456123456.123e12&
+{\boldmath} 123456123456.123e12
+\\
+\bottomrule
+\end{tabular}
+
+\end{document}

--- a/tagging-status/testfiles/numspell/numspell-01.tex
+++ b/tagging-status/testfiles/numspell/numspell-01.tex
@@ -1,0 +1,34 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,title,math,table,firstaid}
+  }
+\documentclass{article}
+
+\usepackage[magyar,main=english]{babel}
+\usepackage{numspell}
+
+\title{numspell tagging test}
+
+\begin{document}
+
+\numspell{12000}
+
+\numspell[6]{12}
+
+\numspell{1};
+\numspellsave{MyNum}
+\numspell{2};
+\thenumspell;
+\thenumspellMyNum
+
+\begin{otherlanguage}{magyar}
+\numspell{6512312354762547162546254756}
+
+\numspelldashspace{10pt}
+\numspell{6512312354762547162546254756}
+\end{otherlanguage}
+
+\end{document}

--- a/tagging-status/testfiles/pxpic/pxpic-01.tex
+++ b/tagging-status/testfiles/pxpic/pxpic-01.tex
@@ -1,0 +1,79 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,title,math,table,firstaid}
+  }
+\begin{filecontents*}[overwrite]{\jobname-parrot.csv}
+.,.,.,.,.,.,k,k,k,k,.,.,.,.,.,.
+.,.,.,.,k,k,r,r,r,r,k,k,.,.,.,.
+.,.,.,k,r,r,r,r,r,r,r,r,k,.,.,.
+.,.,k,r,r,r,r,r,r,r,r,r,r,k,.,.
+.,.,k,r,r,r,r,r,r,r,r,r,r,k,.,.
+.,k,r,.,.,r,r,r,r,r,r,.,.,r,k,.
+.,k,.,.,.,.,k,k,k,k,.,.,.,.,k,.
+.,k,.,k,.,.,k,k,k,k,.,k,.,.,k,.
+.,k,r,.,.,.,k,k,k,k,.,.,.,r,k,.
+.,.,k,r,r,.,k,k,k,k,.,r,r,k,.,.
+.,.,k,r,r,r,k,k,k,k,r,r,r,k,.,.
+.,.,.,k,r,r,r,k,k,r,r,r,k,.,.,.
+.,.,k,3,r,r,r,r,r,r,r,r,3,k,.,.
+.,k,b,3,r,r,r,r,r,r,r,r,3,b,k,.
+.,k,b,b,r,r,r,r,r,r,r,r,b,b,k,.
+.,k,b,b,r,r,r,r,r,r,r,r,b,b,k,.
+.,k,b,k,r,r,r,k,k,r,r,r,k,b,k,.
+2,2,k,2,k,k,k,2,2,k,k,k,2,k,2,2
+2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2
+2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2
+.,.,.,.,.,k,r,r,r,r,k,.,.,.,.,.
+.,.,.,.,.,.,k,r,r,k,.,.,.,.,.,.
+.,.,.,.,.,.,.,k,k,.,.,.,.,.,.,.
+\end{filecontents*}
+
+\documentclass{article}
+\usepackage{pxpic}
+
+\title{pxpic tagging test}
+
+\pxpicsetup
+  {
+    mode = px
+    ,colours = {k=black, r=[HTML]{9F393D}, g=green!75!black, b=[rgb]{0,0,1}}
+    ,skip = .
+    ,size = 10pt
+  }
+
+\begin{document}
+
+text
+\pxpic
+  {
+    {.k}
+    {kkk}
+    {.k}
+  }
+
+\pxpic[lines=space]
+  {
+    ..rr.rr
+    .rrrrrrr
+    rrrrrrrrr
+    rrrrrrrrr
+    rrrrrrrrr
+    .rrrrrrr
+    ..rrrrr
+    ...rrr
+    ....r
+  }
+
+\pxpic
+  [
+    lines=csv,
+    colours={2=brown,3=yellow},
+    file,
+    size=3pt
+  ]
+  {\jobname-parrot.csv}
+
+\end{document}

--- a/tagging-status/testfiles/pythontex/pythontex-01.tex
+++ b/tagging-status/testfiles/pythontex/pythontex-01.tex
@@ -1,0 +1,35 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,title,math,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{pythontex}
+
+\title{pythontex tagging test}
+
+\begin{document}
+
+\py{'ABC'.lower()}
+
+\pyc{var = 2} \py{var}
+
+\pyb{var = 2}
+
+\pys{\verb|var = !{var}|}
+
+\begin{pycode}
+print(r'\begin{center}')
+print(r'\textit{A message from Python!}')
+print(r'\end{center}')
+\end{pycode}
+
+% this errors
+\begin{pyconsole}
+var = 1 + 1
+var
+\end{pyconsole}
+
+\end{document}

--- a/tagging-status/testfiles/rotpages/rotpages-01.tex
+++ b/tagging-status/testfiles/rotpages/rotpages-01.tex
@@ -1,0 +1,320 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,title,math,table,firstaid}
+  }
+\documentclass[12pt,twoside]{article}
+\usepackage[a4paper,headheight=4ex]{geometry}
+\usepackage{rotpages}
+\usepackage{fancyhdr}
+
+\title{\texttt{rotpages.sty} --- Multiple page rotation in \LaTeX\\
+  Example file}
+\author{Sergio Callegari}
+\date{January 1st, 2003}
+
+\fancyhead[LE]{\emph{rotpages.sty}}
+\fancyhead[RO]{Multiple page rotation in \LaTeX}
+\fancyfoot{}
+\fancyfoot[L]{{\footnotesize Example file for a single column document.}}
+\fancyfoot[R]{\thepage}
+
+
+\begin{document}
+\sloppy
+\pagestyle{fancy}
+\maketitle
+\thispagestyle{fancy}
+
+This is the first page of the document. In this document we take
+advantage only of the simplest features of the \texttt{rotpages.sty}
+package, i.e.\@ we only use the basic \verb|\rotboxpages| and
+\verb|\endrotboxpages| commands.
+
+
+The first pages are typeset normally.  To fill them a little, we include
+the first part of \emph{Pinocchio} by Carlo Collodi.
+
+\bigskip
+{\slshape%
+  \textbf{CHAPTER 1}
+  
+  \emph{How it happened that Mastro Cherry, carpenter,
+  found a piece of wood that wept and laughed like a child}
+  \medskip
+ 
+  Centuries ago there lived ---
+  
+  "A king!" my little readers will say immediately.
+  
+  No, children, you are mistaken.  Once upon a time
+  there was a piece of wood.  It was not an expensive piece
+  of wood.  Far from it.  Just a common block of firewood,
+  one of those thick, solid logs that are put on the fire in
+  winter to make cold rooms cozy and warm.
+  
+  I do not know how this really happened, yet the fact
+  remains that one fine day this piece of wood found itself
+  in the shop of an old carpenter.  His real name was
+  Mastro Antonio, but everyone called him Mastro Cherry,
+  for the tip of his nose was so round and red and shiny
+  that it looked like a ripe cherry.
+  
+  As soon as he saw that piece of wood, Mastro Cherry
+  was filled with joy.  Rubbing his hands together happily,
+  he mumbled half to himself:
+  
+  "This has come in the nick of time.  I shall use it to
+  make the leg of a table."
+  
+  He grasped the hatchet quickly to peel off the bark and
+  shape the wood.  But as he was about to give it the first
+  blow, he stood still with arm uplifted, for he had heard a
+  wee, little voice say in a beseeching tone:  "Please be careful!
+  Do not hit me so hard!"
+  
+  What a look of surprise shone on Mastro Cherry's
+  face!  His funny face became still funnier.
+  
+  He turned frightened eyes about the room to find out
+  where that wee, little voice had come from and he saw
+  no one! He looked under the bench--no one! He peeped
+  inside the closet--no one! He searched among the shavings--
+  no one! He opened the door to look up and down
+  the street--and still no one!
+
+  "Oh, I see!" he then said, laughing and scratching his Wig.
+  "It can easily be seen that I only thought I heard the tiny
+  voice say the words! Well, well--to work once more."
+  
+  He struck a most solemn blow upon the piece of wood.
+  
+  "Oh, oh!  You hurt!" cried the same far-away little voice.
+  
+  Mastro Cherry grew dumb, his eyes popped out of his
+  head, his mouth opened wide, and his tongue hung down
+  on his chin.
+  
+  As soon as he regained the use of his senses, he said,
+  trembling and stuttering from fright:
+  
+  "Where did that voice come from, when there is no
+  one around?  Might it be that this piece of wood has
+  learned to weep and cry like a child?  I can hardly
+  believe it.  Here it is--a piece of common firewood, good
+  only to burn in the stove, the same as any other.  Yet--
+  might someone be hidden in it?  If so, the worse for him.
+  I'll fix him!"
+  
+  With these words, he grabbed the log with both hands
+  and started to knock it about unmercifully.  He threw it
+  to the floor, against the walls of the room, and even up
+  to the ceiling.
+  
+  He listened for the tiny voice to moan and cry.
+  He waited two minutes--nothing; five minutes--nothing;
+  ten minutes--nothing.
+  
+  "Oh, I see," he said, trying bravely to laugh and
+  ruffling up his wig with his hand.  "It can easily be seen
+  I only imagined I heard the tiny voice!  Well, well--to
+  work once more!"
+
+  The poor fellow was scared half to death, so he tried
+  to sing a gay song in order to gain courage.
+  
+  He set aside the hatchet and picked up the plane to
+  make the wood smooth and even, but as he drew it to
+  and fro, he heard the same tiny voice.  This time it giggled
+  as it spoke:
+  
+  "Stop it!  Oh, stop it!  Ha, ha, ha! You tickle my stomach."
+  
+  This time poor Mastro Cherry fell as if shot.  When
+  he opened his eyes, he found himself sitting on the floor.
+  
+  His face had changed; fright had turned even the tip of
+  his nose from red to deepest purple.
+
+}
+\bigskip
+Note that the next pages are upside down.
+
+\rotboxpages%
+Here come the rotated pages. Note that while formatting the
+document, this page is \emph{deferred}, until all the block of rotated
+pages is processed. In this way, this page is printed as the last one
+of the block. However, if the printed work is read upside down, this
+page correctly appears as the first of the block.
+
+Obviously, also this page contains the continuation of the novel:
+
+\bigskip
+{\slshape%
+
+  \textbf{CHAPTER 2}
+
+  \emph{Mastro Cherry gives the piece of wood to his friend Geppetto,
+    who takes it to make himself a Marionette that will dance,
+    fence, and turn somersaults}
+  \medskip
+  
+  In that very instant, a loud knock sounded on the door.
+  "Come in," said the carpenter, not having an atom of
+  strength left with which to stand up.
+  
+  At the words, the door opened and a dapper little old man came in.
+  His name was Geppetto, but to the boys of the neighborhood he was
+  Polendina\footnote{Corneal mush}, on account of the wig he always
+  wore which was just the color of yellow corn.
+  
+}
+
+\bigbreak
+
+Here we make a small break in the story. Please, take a second to
+observe how the page content is rotated, while the page headers and
+footers, comprising the page number, are printed with the standard
+orientation. Take also a quick look at the footnote and observe that
+it is in the right place.
+
+Note also that in order to introduce a frame, the rotated pages are
+slightly smaller (i.e.\@ they contain a little less text than the
+normal ones.)  
+
+After this informative bit, it is time for some more Pinocchio:
+
+\bigskip
+{\slshape%
+  Geppetto had a very bad temper.  Woe to the one who
+  called him Polendina!  He became as wild as a beast and
+  no one could soothe him.
+  
+  "Good day, Mastro Antonio," said Geppetto.  "What
+  are you doing on the floor?"
+  
+  "I am teaching the ants their A B C's."
+  
+  "Good luck to you!"
+  
+  "What brought you here, friend Geppetto?"
+  
+  "My legs.  And it may flatter you to know, Mastro
+  Antonio, that I have come to you to beg for a favor."
+  
+  "Here I am, at your service," answered the carpenter,
+  raising himself on to his knees.
+  
+  "This morning a fine idea came to me."
+  
+  "Let's hear it."
+  
+  "I thought of making myself a beautiful wooden
+  Marionette.  It must be wonderful, one that will be able to
+  dance, fence, and turn somersaults.  With it I intend to go
+  around the world, to earn my crust of bread and cup of
+  wine.  What do you think of it?"
+  
+  "Bravo, Polendina!" cried the same tiny voice which
+  came from no one knew where.
+  
+  On hearing himself called Polendina, Mastro Geppetto
+  turned the color of a red pepper and, facing the carpenter,
+  said to him angrily:
+  
+  "Why do you insult me?"
+  
+  "Who is insulting you?"
+  
+  "You called me Polendina."
+  
+  "I did not."
+  
+  "I suppose you think \_I\_ did!  Yet I KNOW it was you."
+  
+  "No!"
+  
+  "Yes!"
+  
+  "No!"
+  
+  "Yes!"
+  
+  And growing angrier each moment, they went from
+  words to blows, and finally began to scratch and bite and
+  slap each other.
+  
+  When the fight was over, Mastro Antonio had Geppetto's
+  yellow wig in his hands and Geppetto found the carpenter's
+  curly wig in his mouth.
+  
+  "Give me back my wig!" shouted Mastro Antonio in a surly voice.
+  
+  "You return mine and we'll be friends."
+  
+  The two little old men, each with his own wig back on
+  his own head, shook hands and swore to be good friends
+  for the rest of their lives.
+  
+  "Well then, Mastro Geppetto," said the carpenter, to
+  show he bore him no ill will, "what is it you want?"
+  
+  "I want a piece of wood to make a Marionette.  Will you give it to
+  me?"
+    
+  Mastro Antonio, very glad indeed, went immediately
+  to his bench to get the piece of wood which had frightened
+  him so much.  But as he was about to give it to his friend,
+  with a violent jerk it slipped out of his hands and hit
+  against poor Geppetto's thin legs.
+  
+  "Ah!  Is this the gentle way, Mastro Antonio, in which
+  you make your gifts?  You have made me almost lame!"
+  
+  "I swear to you I did not do it!"
+  
+  "It was \_I\_, of course!"
+  
+  "It's the fault of this piece of wood."
+  
+  "You're right; but remember you were the one to throw it at my legs."
+  
+  "I did not throw it!"
+  
+  "Liar!"
+  
+  "Geppetto, do not insult me or I shall call you Polendina."
+  
+  "Idiot."
+  
+  "Polendina!"
+  
+  "Donkey!"
+  
+  "Polendina!"
+  
+  "Ugly monkey!"
+  
+  "Polendina!"
+  
+  On hearing himself called Polendina for the third time,
+  Geppetto lost his head with rage and threw himself upon
+  the carpenter.  Then and there they gave each other a
+  sound thrashing.
+  
+  After this fight, Mastro Antonio had two more scratches
+  on his nose, and Geppetto had two buttons missing from
+  his coat.  Thus having settled their accounts, they shook
+  hands and swore to be good friends for the rest of their lives.
+  
+  Then Geppetto took the fine piece of wood,
+  thanked Mastro Antonio, and limped away toward home.
+}
+\endrotboxpages 
+
+And the normal behaviur of \LaTeX is back!
+Exiting isn't it? So don't forget to tell your friends about this new
+package!
+\end{document}

--- a/tagging-status/testfiles/rotpages/rotpages-02.tex
+++ b/tagging-status/testfiles/rotpages/rotpages-02.tex
@@ -1,0 +1,320 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,title,math,table,firstaid}
+  }
+\documentclass[12pt,twoside,twocolumn]{article}
+\usepackage[a4paper,headheight=4ex]{geometry}
+\usepackage{rotpages}
+\usepackage{fancyhdr}
+
+\title{\texttt{rotpages.sty} --- Multiple page rotation in \LaTeX\\
+  Example file}
+\author{Sergio Callegari}
+\date{January 1st, 2003}
+
+\fancyhead[LE]{\emph{rotpages.sty}}
+\fancyhead[RO]{Multiple page rotation in \LaTeX}
+\fancyfoot{}
+\fancyfoot[L]{{\footnotesize Example file for a two column document.}}
+\fancyfoot[R]{\thepage}
+
+
+\begin{document}
+\sloppy
+\pagestyle{fancy}
+\maketitle
+\thispagestyle{fancy}
+
+This is the first column of the document. In this document we take
+advantage only of the simplest features of the \texttt{rotpages.sty}
+package, i.e.\@ we only use the basic \verb|\rotboxpages| and
+\verb|\endrotboxpages| commands.
+
+
+The first columns are typeset normally.  To fill them a little, we include
+the first part of \emph{Pinocchio} by Carlo Collodi.
+
+\bigskip
+{\slshape%
+  \textbf{CHAPTER 1}
+  
+  \emph{How it happened that Mastro Cherry, carpenter,
+  found a piece of wood that wept and laughed like a child}
+  \medskip
+ 
+  Centuries ago there lived ---
+  
+  "A king!" my little readers will say immediately.
+  
+  No, children, you are mistaken.  Once upon a time
+  there was a piece of wood.  It was not an expensive piece
+  of wood.  Far from it.  Just a common block of firewood,
+  one of those thick, solid logs that are put on the fire in
+  winter to make cold rooms cozy and warm.
+  
+  I do not know how this really happened, yet the fact
+  remains that one fine day this piece of wood found itself
+  in the shop of an old carpenter.  His real name was
+  Mastro Antonio, but everyone called him Mastro Cherry,
+  for the tip of his nose was so round and red and shiny
+  that it looked like a ripe cherry.
+  
+  As soon as he saw that piece of wood, Mastro Cherry
+  was filled with joy.  Rubbing his hands together happily,
+  he mumbled half to himself:
+  
+  "This has come in the nick of time.  I shall use it to
+  make the leg of a table."
+  
+  He grasped the hatchet quickly to peel off the bark and
+  shape the wood.  But as he was about to give it the first
+  blow, he stood still with arm uplifted, for he had heard a
+  wee, little voice say in a beseeching tone:  "Please be careful!
+  Do not hit me so hard!"
+  
+  What a look of surprise shone on Mastro Cherry's
+  face!  His funny face became still funnier.
+  
+  He turned frightened eyes about the room to find out
+  where that wee, little voice had come from and he saw
+  no one! He looked under the bench--no one! He peeped
+  inside the closet--no one! He searched among the shavings--
+  no one! He opened the door to look up and down
+  the street--and still no one!
+
+  "Oh, I see!" he then said, laughing and scratching his Wig.
+  "It can easily be seen that I only thought I heard the tiny
+  voice say the words! Well, well--to work once more."
+  
+  He struck a most solemn blow upon the piece of wood.
+  
+  "Oh, oh!  You hurt!" cried the same far-away little voice.
+  
+  Mastro Cherry grew dumb, his eyes popped out of his
+  head, his mouth opened wide, and his tongue hung down
+  on his chin.
+  
+  As soon as he regained the use of his senses, he said,
+  trembling and stuttering from fright:
+  
+  "Where did that voice come from, when there is no
+  one around?  Might it be that this piece of wood has
+  learned to weep and cry like a child?  I can hardly
+  believe it.  Here it is--a piece of common firewood, good
+  only to burn in the stove, the same as any other.  Yet--
+  might someone be hidden in it?  If so, the worse for him.
+  I'll fix him!"
+  
+  With these words, he grabbed the log with both hands
+  and started to knock it about unmercifully.  He threw it
+  to the floor, against the walls of the room, and even up
+  to the ceiling.
+  
+  He listened for the tiny voice to moan and cry.
+  He waited two minutes--nothing; five minutes--nothing;
+  ten minutes--nothing.
+  
+  "Oh, I see," he said, trying bravely to laugh and
+  ruffling up his wig with his hand.  "It can easily be seen
+  I only imagined I heard the tiny voice!  Well, well--to
+  work once more!"
+
+  The poor fellow was scared half to death, so he tried
+  to sing a gay song in order to gain courage.
+  
+  He set aside the hatchet and picked up the plane to
+  make the wood smooth and even, but as he drew it to
+  and fro, he heard the same tiny voice.  This time it giggled
+  as it spoke:
+  
+  "Stop it!  Oh, stop it!  Ha, ha, ha! You tickle my stomach."
+  
+  This time poor Mastro Cherry fell as if shot.  When
+  he opened his eyes, he found himself sitting on the floor.
+  
+  His face had changed; fright had turned even the tip of
+  his nose from red to deepest purple.
+
+}
+\bigskip
+Note that the next columns are upside down.
+
+\rotboxpages%
+Here come the rotated columns. Note that while formatting the
+document, this column is \emph{deferred}, until all the block of rotated
+columns is processed. In this way, this column is printed as the last one
+of the block. However, if the printed work is read upside down, this
+column correctly appears as the first of the block.
+
+Obviously, also this column contains the continuation of the novel:
+
+\bigskip
+{\slshape%
+
+  \textbf{CHAPTER 2}
+
+  \emph{Mastro Cherry gives the piece of wood to his friend Geppetto,
+    who takes it to make himself a Marionette that will dance,
+    fence, and turn somersaults}
+  \medskip
+  
+  In that very instant, a loud knock sounded on the door.
+  "Come in," said the carpenter, not having an atom of
+  strength left with which to stand up.
+  
+  At the words, the door opened and a dapper little old man came in.
+  His name was Geppetto, but to the boys of the neighborhood he was
+  Polendina\footnote{Corneal mush}, on account of the wig he always
+  wore which was just the color of yellow corn.
+  
+}
+
+\bigbreak
+
+Here we make a small break in the story. Please, take a second to
+observe how the column content is rotated, while the page headers and
+footers, comprising the page number, are printed with the standard
+orientation. Take also a quick look at the footnote and observe that
+it is in the right place.
+
+Note also that in order to introduce a frame, the rotated columns are
+slightly smaller (i.e.\@ they contain a little less text than the
+normal ones.)  
+
+After this informative bit, it is time for some more Pinocchio:
+
+\bigskip
+{\slshape%
+  Geppetto had a very bad temper.  Woe to the one who
+  called him Polendina!  He became as wild as a beast and
+  no one could soothe him.
+  
+  "Good day, Mastro Antonio," said Geppetto.  "What
+  are you doing on the floor?"
+  
+  "I am teaching the ants their A B C's."
+  
+  "Good luck to you!"
+  
+  "What brought you here, friend Geppetto?"
+  
+  "My legs.  And it may flatter you to know, Mastro
+  Antonio, that I have come to you to beg for a favor."
+  
+  "Here I am, at your service," answered the carpenter,
+  raising himself on to his knees.
+  
+  "This morning a fine idea came to me."
+  
+  "Let's hear it."
+  
+  "I thought of making myself a beautiful wooden
+  Marionette.  It must be wonderful, one that will be able to
+  dance, fence, and turn somersaults.  With it I intend to go
+  around the world, to earn my crust of bread and cup of
+  wine.  What do you think of it?"
+  
+  "Bravo, Polendina!" cried the same tiny voice which
+  came from no one knew where.
+  
+  On hearing himself called Polendina, Mastro Geppetto
+  turned the color of a red pepper and, facing the carpenter,
+  said to him angrily:
+  
+  "Why do you insult me?"
+  
+  "Who is insulting you?"
+  
+  "You called me Polendina."
+  
+  "I did not."
+  
+  "I suppose you think \_I\_ did!  Yet I KNOW it was you."
+  
+  "No!"
+  
+  "Yes!"
+  
+  "No!"
+  
+  "Yes!"
+  
+  And growing angrier each moment, they went from
+  words to blows, and finally began to scratch and bite and
+  slap each other.
+  
+  When the fight was over, Mastro Antonio had Geppetto's
+  yellow wig in his hands and Geppetto found the carpenter's
+  curly wig in his mouth.
+  
+  "Give me back my wig!" shouted Mastro Antonio in a surly voice.
+  
+  "You return mine and we'll be friends."
+  
+  The two little old men, each with his own wig back on
+  his own head, shook hands and swore to be good friends
+  for the rest of their lives.
+  
+  "Well then, Mastro Geppetto," said the carpenter, to
+  show he bore him no ill will, "what is it you want?"
+  
+  "I want a piece of wood to make a Marionette.  Will you give it to
+  me?"
+    
+  Mastro Antonio, very glad indeed, went immediately
+  to his bench to get the piece of wood which had frightened
+  him so much.  But as he was about to give it to his friend,
+  with a violent jerk it slipped out of his hands and hit
+  against poor Geppetto's thin legs.
+  
+  "Ah!  Is this the gentle way, Mastro Antonio, in which
+  you make your gifts?  You have made me almost lame!"
+  
+  "I swear to you I did not do it!"
+  
+  "It was \_I\_, of course!"
+  
+  "It's the fault of this piece of wood."
+  
+  "You're right; but remember you were the one to throw it at my legs."
+  
+  "I did not throw it!"
+  
+  "Liar!"
+  
+  "Geppetto, do not insult me or I shall call you Polendina."
+  
+  "Idiot."
+  
+  "Polendina!"
+  
+  "Donkey!"
+  
+  "Polendina!"
+  
+  "Ugly monkey!"
+  
+  "Polendina!"
+  
+  On hearing himself called Polendina for the third time,
+  Geppetto lost his head with rage and threw himself upon
+  the carpenter.  Then and there they gave each other a
+  sound thrashing.
+  
+  After this fight, Mastro Antonio had two more scratches
+  on his nose, and Geppetto had two buttons missing from
+  his coat.  Thus having settled their accounts, they shook
+  hands and swore to be good friends for the rest of their lives.
+  
+  Then Geppetto took the fine piece of wood,
+  thanked Mastro Antonio, and limped away toward home.
+}
+\endrotboxpages 
+
+And the normal behaviur of \LaTeX is back!
+Exiting isn't it? So don't forget to tell your friends about this new
+package!
+\end{document}

--- a/tagging-status/testfiles/selnolig/selnolig-01.tex
+++ b/tagging-status/testfiles/selnolig/selnolig-01.tex
@@ -1,0 +1,37 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,title,math,table,firstaid}
+  }
+\documentclass[english]{article}
+
+\usepackage{fontspec}
+\setmainfont{Libertinus Serif}
+\usepackage{babel}
+\usepackage[hdlig,broadf]{selnolig}
+
+\title{selnolig tagging test}
+
+\begin{document}
+
+\uselig{fj}
+
+grounds\breaklig keeper
+
+shelfful shelffuls bookshelfful selffulfilling
+
+beefless briefless hoofless leafless roofless selfless turfless selflessly selflessness
+
+calflike dwarflike elflike gulflike hooflike leaflike rooflike serflike sheaflike shelflike surflike turflike waiflike wolflike
+
+halflife shelflife
+halflives shelflives
+
+halfline roofline
+halflines rooflines
+
+leaflet leaflets leafleted leafleting leafletting leafletted leafleteer
+
+\end{document}

--- a/tagging-status/testfiles/spark-otf/spark-otf-01.tex
+++ b/tagging-status/testfiles/spark-otf/spark-otf-01.tex
@@ -1,0 +1,36 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,title,math,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{xcolor}
+\usepackage{spark-otf}
+
+\title{spark-otf tagging test}
+
+\begin{document}
+
+Text \sparkBar{14,95,68,9,19,41,91,1,81,97,79,45,96,76,17,65,8,92} Text
+
+Text \sparkBar[Medium]{14,95,68,9,19,41,91,1,81,97,79,45,96,76,17,65,8,92} Text
+
+Text \sparkBar[Medium][14]{14,95,68,9,19,41,91,1,81,97,79,45,96,76,17,65,8,92}[92] Text
+
+Text \sparkBar{!14,95,68,9,19,41,91,1,81,97,79,45,96,76,17,65,8,!92} Text
+
+\sparkBar[Narrow]{!19,32,93,4,95,46,13,23,50,86,94,68,58,41,89,57,74,!8}
+
+\sparkBar[Extranarrow]{!19,32,93,4,95,46,13,23,50,86,94,68,58,41,89,57,74,!8}
+
+\sparkDot{!54,39,26,65,29,58,36,99,16,56,76,69,71,77,7,40,79,!1}
+
+\sparkDotline{!1,79,88,46,54,77,91,24,70,22,27,29,40,33,31,95,26,!76}
+
+\sparkBar*{9,4,2,1,6,7,3,8,3,7,1,4,9,2,8,5,1,8}
+
+\sparkDotline*{9,4,2,1,6,7,3,8,3,7,1,4,9,2,8,5,1,8}
+
+\end{document}

--- a/tagging-status/testfiles/trivfloat/trivfloat-01.tex
+++ b/tagging-status/testfiles/trivfloat/trivfloat-01.tex
@@ -1,0 +1,34 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,title,math,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{trivfloat}
+
+\title{trivfloat tagging test}
+
+\trivfloat{graph}
+
+\begin{document}
+
+\listofgraphs
+
+\listoffigures
+
+\begin{graph}
+\centering
+Something for a graph
+\caption{My graph}
+\end{graph}
+
+% compare with
+\begin{figure}
+\centering
+Something for a figure
+\caption{My figure}
+\end{figure}
+
+\end{document}

--- a/tagging-status/testfiles/xevlna/xevlna-01.tex
+++ b/tagging-status/testfiles/xevlna/xevlna-01.tex
@@ -1,0 +1,40 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,title,math,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{fontspec}
+\setmainfont{Libertinus Serif}
+\usepackage{xevlna}
+
+\title{xevlna tagging test}
+
+\setlength{\textwidth}{3in}
+
+\begin{document}
+
+Příliš žluťoučký kůň úpěl ďábelské ódy.
+Text s krátkými souhláskami a samohláskami i dalšími jevy
+z nabídky možností (v textu možnými).
+
+I začátek odstavce je třeba řešit, i když výskyt zalomení
+není pravděpodobný.
+
+Co třeba í znaky š diakritikou?
+
+Různé možnosti [v závorkách <i jiných znacích
+
+Podpora iniciál a titulů: M. J. Hegel, Ing. Běháková, Ph.D., Ž. Zíbrt,
+Ch. Borner.
+
+Podpora jednotek: 100,5 MN\textperiodcentered s, 100.5 kJ, 200 μA, $-1$ dag,
+12 MiB.
+1http://tex.stackexchange.com/a/28128/2891
+2
+Uvnitř matematiky by mělo být zpracování vypnuté: $k \in N$.
+Pokračujeme v příkladu.
+
+\end{document}

--- a/tagging-status/testfiles/zhnumber/zhnumber-01.tex
+++ b/tagging-status/testfiles/zhnumber/zhnumber-01.tex
@@ -1,0 +1,65 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,title,math,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{ctex}
+\usepackage{zhnumber}
+
+\title{zhnumber tagging test}
+
+\begin{document}
+
+\zhnumber{2012020120}\par
+\zhnumber{2 012 020 120}\par
+\zhnumber{2,012,020,120}\par
+\zhnumber{2012.020120}\par
+\zhnumber{2012.}\par
+\zhnumber{.2012}\par
+\zhnumber{20120/20120}\par
+\zhnumber{/2012}\par
+\zhnumber{2012/}\par
+\zhnumber{201;2020/120}
+
+\zhdigits{2012020120}\par
+\zhdigits*{2012020120}
+
+\zhnum{section}
+
+\zhdig{section}
+
+\zhweekday{2012/5/20}
+
+\zhdate{2012/5/21}\par
+\zhdate*{2012/5/21}
+
+\zhtoday
+
+\zhtime{23:56}
+
+\zhcurrtime
+
+\zhtiangan{1} \zhtiangan{2} \zhtiangan{3}
+\zhtiangan{4} \zhtiangan{5} \zhtiangan{10}
+
+\zhdizhi{1} \zhdizhi{2} \zhdizhi{3}
+\zhdizhi{4} \zhdizhi{5} \zhdizhi{12}
+
+\zhganzhi{1} \zhganzhi{2} \zhganzhi{3} \par
+\zhganzhi{4} \zhganzhi{5} \zhganzhi{60}
+
+\zhganzhinian{1898} \zhganzhinian{-246} \par
+\zhganzhinian{-2697} \zhganzhinian{\year}
+
+\zhnumsetup{time=Chinese}
+\zhtoday\zhcurrtime
+
+\zhnumsetup{style={Traditional,Financial}}
+\zhnumber{62012.3}\par
+\zhnumsetup{style=Ancient}
+\zhnumber{21}
+
+\end{document}


### PR DESCRIPTION
Lists arabicfront, filecontentsdef, gettitlestring, hanging, luavlna, numspell, rotpages, selnolig,     xevlna, and zhnumber as compatible with tests.

Lists mfb-oldstyle as compatible without tests.

Lists fnumprint, numprint, pxpic, and spark-otf as partially-compatible (see comments).

Lists chemfig, clrstrip, decorule, easylist, footnotehyper, pythontex, and trivfloat as currently-incompatible (see issues and comments).