### PR TITLE
add several packages

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -358,6 +358,7 @@
    included-in: [tlc3, arxiv01]
    priority: 2
    issues: [131]
+   tests: true
    updated: 2024-07-14
 
  - name: almendra
@@ -3626,13 +3627,12 @@
 
  - name: fontsetup
    type: package
-   status: unknown
+   status: compatible
    included-in:
    priority: 9
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   updated: 2024-08-13
 
  - name: fontspec
    type: package
@@ -4401,13 +4401,13 @@
 
  - name: hypdestopt
    type: package
-   status: unknown
+   status: compatible
    included-in:
    priority: 9
-   issues:
+   issues: [525]
    tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   comments: "Ignored if `\\DocumentMetadata` is detected."
+   updated: 2024-08-13
 
  - name: hypdoc
    type: package
@@ -5680,6 +5680,25 @@
    tests: false
    updated: 2024-07-15
 
+ - name: marginfit
+   type: package
+   status: partially-compatible
+   included-in:
+   priority: 9
+   issues: [549]
+   tests: true
+   comments: "Needs luatex85 with lualatex."
+   updated: 2024-08-13
+
+ - name: marginfix
+   type: package
+   status: currently-incompatible
+   included-in:
+   priority: 9
+   issues: [547]
+   tests: true
+   updated: 2024-08-13
+
  - name: marginnote
    type: package
    status: currently-incompatible
@@ -6255,13 +6274,12 @@
 
  - name: mwe
    type: package
-   status: unknown
+   status: compatible
    included-in: [arxiv01]
    priority: 6
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   updated: 2024-08-13
 
  - name: mweights
    type: package
@@ -8002,6 +8020,15 @@
    tasks: needs tests
    updated: 2024-07-28
 
+ - name: sanitize-umlaut
+   type: package
+   status: compatible
+   included-in:
+   priority: 9
+   issues:
+   tests: true
+   updated: 2024-08-13
+
  - name: sansmath
    type: package
    status: compatible
@@ -8369,6 +8396,15 @@
    tests: true
    updated: 2024-07-26
 
+ - name: sidenotes
+   type: package
+   status: currently-incompatible
+   included-in:
+   priority: 9
+   issues: [555]
+   tests: true
+   updated: 2024-08-13
+
  - name: sillypage
    type: package
    status: compatible
@@ -8543,6 +8579,15 @@
    issues: [168]
    tests: true
    updated: 2024-07-17
+
+ - name: stabular
+   type: package
+   status: currently-incompatible
+   included-in:
+   priority: 9
+   issues: [548]
+   tests: true
+   updated: 2024-08-13
 
  - name: stackengine
    type: package
@@ -9542,6 +9587,17 @@
    tests: true
    updated: 2024-07-31
 
+ - name: turnstile
+   type: package
+   status: compatible
+   included-in: [arxiv001]
+   priority: 7
+   supported-through: [phase-III,math]
+   comments: "Use of math tagging currently requires support from external tools."
+   issues:
+   tests: true
+   updated: 2024-08-13
+
  - name: turnthepage
    type: package
    status: compatible
@@ -10485,6 +10541,7 @@
    status: currently-incompatible
    included-in:
    priority: 2
+   tests: false
    updated: 2024-07-07
 
  - name: book
@@ -10615,6 +10672,7 @@
    priority: 2
    comments: "Some code showing the needed adjustments can be found in the
               [bible example](https://github.com/latex3/tagging-project/blob/main/project-examples/ASV/bible.tex)"
+   tests: false
    updated: 2024-07-05
 
 #------------------------ NNN ----------------------------
@@ -10681,6 +10739,7 @@
    included-in:
    priority: 9
    issues:
+   tests: false
    tasks: needs tests
    updated: 2024-07-17
 
@@ -10692,6 +10751,7 @@
    included-in: [tlc3,arxiv01]
    priority: 2
    related-issues: [88]
+   tests: false
    updated: 2024-07-10
 
  - name: scrbook
@@ -10700,6 +10760,7 @@
    included-in: [tlc3, arxiv001]
    priority: 2
    related-issues: [88]
+   tests: false
    updated: 2024-07-10
 
  - name: scrlttr2
@@ -10708,6 +10769,7 @@
    included-in:
    priority: 9
    related-issues: [88]
+   tests: false
    updated: 2024-07-10
 
  - name: scrreport
@@ -10716,6 +10778,7 @@
    included-in: [tlc3, arxiv001]
    priority: 2
    related-issues: [88]
+   tests: false
    updated: 2024-07-10
 
  - name: standalone
@@ -10728,3 +10791,26 @@
    comments: "Content is lost at pdf level due to being boxed."
    updated: 2024-08-07
 
+#------------------------ TTT ----------------------------
+
+ - name: tufte-book
+   ctan-pkg: tufte-latex
+   type: class
+   status: no-support
+   included-in:
+   priority: 9
+   issues: [551]
+   tests: false
+   comments:
+   updated: 2024-08-13
+
+ - name: tufte-handout
+   ctan-pkg: tufte-latex
+   type: class
+   status: no-support
+   included-in:
+   priority: 9
+   issues: [551]
+   tests: false
+   comments:
+   updated: 2024-08-13

--- a/tagging-status/testfiles/marginfit/marginfit-01.tex
+++ b/tagging-status/testfiles/marginfit/marginfit-01.tex
@@ -1,0 +1,19 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,title,math,table,firstaid}
+  }
+\documentclass{article}
+
+%\usepackage{luatex85} % needed with luatex
+\usepackage{marginfit}
+
+\begin{document}
+
+text\marginpar{right text} % no warnings
+
+text\marginpar[left text]{right text} % parent-child warnings
+
+\end{document}

--- a/tagging-status/testfiles/marginfix/marginfix-01.tex
+++ b/tagging-status/testfiles/marginfix/marginfix-01.tex
@@ -1,0 +1,18 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,title,math,table,firstaid}
+  }
+\documentclass{article}
+
+\usepackage{marginfix}
+
+\title{marginfix tagging test}
+
+\begin{document}
+
+text\marginpar{margin text}
+
+\end{document}

--- a/tagging-status/testfiles/sanitize-umlaut/sanitize-umlaut-01.tex
+++ b/tagging-status/testfiles/sanitize-umlaut/sanitize-umlaut-01.tex
@@ -1,0 +1,32 @@
+% arara: pdflatex
+% arara: makeindex: { style: german.ist, german: true }
+% arara: pdflatex
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\begin{filecontents}{german.ist}
+actual '=' % as replacement for @
+quote '!' % as replacement for "
+level '>' % as replacement for ! 
+\end{filecontents}
+\documentclass[a4paper,12pt]{article}
+\usepackage[T1]{fontenc}
+\usepackage[ngerman]{babel}
+\usepackage{makeidx}
+\usepackage{sanitize-umlaut}
+\usepackage[hyperindex,colorlinks]{hyperref}
+\makeindex
+\begin{document}
+\section{Basic Example}
+Test äöüÄÖÜß.
+\index{Aber} \index{Arg} \index{Ärger}
+\index{Ofen} \index{Ö - wie schön} \index{oberhalb}
+\index{Ufer} \index{Übermaß}
+\index{Latex=\LaTeX} \index{Ärger>Index}
+Test äöüÄÖÜß.
+\printindex
+\end{document}

--- a/tagging-status/testfiles/sidenotes/sidenotes-01.tex
+++ b/tagging-status/testfiles/sidenotes/sidenotes-01.tex
@@ -1,0 +1,35 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+
+\usepackage{sidenotes}
+\usepackage{graphicx}
+
+\title{sidenotes tagging test}
+
+\begin{document}
+
+text\sidenote{Some side text} % okay, uses \marginpar
+
+%text\sidenote[][2cm]{Some side text} % errors, uses \marginnote
+
+%\begin{figure}
+%\centering
+%\includegraphics[alt=example,scale=0.3]{example-image}
+%\sidecaption{An example image} % errors
+%\end{figure}
+
+text
+\begin{marginfigure} % parent-child warnings
+\centering
+\includegraphics[alt=example,scale=0.3]{example-image}
+\caption{An example margin image}
+\end{marginfigure}
+more text
+
+\end{document}

--- a/tagging-status/testfiles/stabular/stabular-01.tex
+++ b/tagging-status/testfiles/stabular/stabular-01.tex
@@ -1,0 +1,21 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,title,math,table,firstaid}
+  }
+\documentclass{article}
+
+\usepackage[
+%  array % errors with or without
+  ]{stabular}
+
+\begin{document}
+
+\begin{stabular}{cc}
+A & B \\
+C & D
+\end{stabular}
+
+\end{document}

--- a/tagging-status/testfiles/turnstile/turnstile-01.tex
+++ b/tagging-status/testfiles/turnstile/turnstile-01.tex
@@ -1,0 +1,20 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+
+\usepackage{turnstile}
+
+\title{turnstile tagging test}
+
+\begin{document}
+
+$\Gamma \sststile{\mathrm{LPD}}{x,y} P$
+
+\[\Gamma \stststile{\mathrm{LC}}{x,y,z,w} P\]
+
+\end{document}


### PR DESCRIPTION
Adds missing `tests:` to several entries.

Lists fontsetup, hypdestop and mwe as compatible without tests.

Lists sanitize-umlaut and turnstile as compatible with tests.

Lists marginfit as partially-compatible with a test.

Lists marginfix, sidenotes, and stabular as currently-incompatible with tests.

Lists tufte-book and tufte-handout as no-support.