### PR TITLE
add fitch compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -3379,13 +3379,13 @@
 
  - name: fitch
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in:
    priority: 9
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   comments: "`fitchproof` is tagged as combined list/table."
+   updated: 2024-08-13
 
  - name: fix-cm
    type: package

--- a/tagging-status/testfiles/fitch/fitch-01.tex
+++ b/tagging-status/testfiles/fitch/fitch-01.tex
@@ -1,0 +1,61 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{fitch}
+
+\begin{document}
+
+$\begin{nd}
+\hypo {1} {P\vee Q}
+\hypo {2} {\neg Q}
+\open
+\hypo {3} {P}
+\have {4} {P} \r{3}
+\close
+\open
+\hypo {aa} {Q}
+\have {6} {\neg Q} \r{2}
+\have {7} {\bot} \ne{aa,6}
+\have {8} {P} \be{7}
+\close
+\have {9} {P} \oe{1,3-4,aa-8}
+\end{nd}$
+
+$
+\begin{nd}
+\hypo {a} {A \Rightarrow B}
+\by{Premise}{}
+\hypo {b} {A} \by{Premise}{}
+\have {c} {B}
+\by{\ndref{a,b}
+(but \emph{how?})}{}
+\have {d} {A \wedge B} \by{}{b,c}
+\end{nd}
+$
+
+\begin{fitchproof}[arrayenv=tabular]
+\hypo {1} {P\vee Q}
+\hypo {2} {\neg Q}
+\open
+\hypo {3} {P}
+\have {4} {P} \r{3}
+\close
+\open
+\hypo {aa} {Q}
+\have {6} {\neg Q} \r{2}
+\end{fitchproof}
+Derivations can be interrupted and
+resumed at any point.
+\begin{fitchproof*}[arrayenv=tabular]
+\have {7} {\bot} \ne{aa,6}
+\have {8} {P} \be{7}
+\close
+\have {9} {P} \oe{1,3-4,aa-8}
+\end{fitchproof*}
+
+\end{document}


### PR DESCRIPTION
Lists [fitch](https://ctan.org/pkg/fitch) as currently-incompatible because the `fitchproof` environment is tagged as a combined list/table with many formulas.