### PR TITLE
add alphabeta and textalpha compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -370,6 +370,16 @@
    tests: false
    updated: 2024-07-13
 
+ - name: alphabeta
+   ctan-pkg: greek-fontenc
+   type: package
+   status: compatible
+   included-in: [arxiv001]
+   priority: 7
+   issues:
+   tests: true
+   updated: 2024-08-14
+
  - name: alphalph
    type: package
    status: compatible
@@ -9085,6 +9095,16 @@
    issues:
    tests: true
    updated: 2024-07-25
+
+ - name: textalpha
+   ctan-pkg: greek-fontenc
+   type: package
+   status: compatible
+   included-in: [arxiv001]
+   priority: 7
+   issues:
+   tests: true
+   updated: 2024-08-14
 
  - name: textcase
    type: package

--- a/tagging-status/testfiles/alphabeta/alphabeta-01.tex
+++ b/tagging-status/testfiles/alphabeta/alphabeta-01.tex
@@ -1,0 +1,96 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{iftex}
+\ifTUTeX
+  \usepackage{fontspec}
+  \setmainfont{Libertinus Serif}
+  \setsansfont{Libertinus Sans}
+\else
+  \usepackage{lmodern}
+  \usepackage[LGR,T1]{fontenc}
+\fi
+\usepackage[normalize-symbols]{alphabeta}
+
+\ProvideTextCommandDefault{\textvarstigma}{} % only in LGR
+
+\begin{document}
+
+$\epsilon\Lambda\varphi$
+
+\Alpha\par
+\Beta\par
+\Gamma\par
+\Delta\par
+\Epsilon\par
+\Zeta\par
+\Eta\par
+\Theta\par
+\Iota\par
+\Kappa\par
+\Lambda\par
+\Mu\par
+\Nu\par
+\Xi\par
+\Omicron\par
+\Pi\par
+\Rho\par
+\Sigma\par
+\Tau\par
+\Upsilon\par
+\Phi\par
+\Chi\par
+\Psi\par
+\Omega\par
+\alpha\par
+\beta\par
+\gamma\par
+\delta\par
+\epsilon\par
+\zeta\par
+\eta\par
+\theta\par
+\iota\par
+\kappa\par
+\lambda\par
+\mu\par
+\nu\par
+\xi\par
+\omicron\par
+\pi\par
+\rho\par
+\sigma\par
+\varsigma\par
+\finalsigma\par
+\tau\par
+\upsilon\par
+\phi\par
+\chi\par
+\psi\par
+\omega\par
+\digamma\par
+\Digamma\par
+\stigma\par
+\varstigma\par
+\koppa\par
+\Koppa\par
+\qoppa\par
+\Qoppa\par
+\Stigma\par
+\Sampi\par
+\sampi\par
+\varepsilon\par
+\varphi\par
+\varbeta\par
+\varkappa\par
+\varpi\par
+\varrho\par
+\varTheta\par
+\vartheta\par
+
+\end{document}

--- a/tagging-status/testfiles/textalpha/textalpha-01.tex
+++ b/tagging-status/testfiles/textalpha/textalpha-01.tex
@@ -1,0 +1,121 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{iftex}
+\ifTUTeX
+  \usepackage{fontspec}
+  \setmainfont{Libertinus Serif}
+  \setsansfont{Libertinus Sans}
+\else
+  \usepackage{lmodern}
+  \usepackage[LGR,T1]{fontenc}
+\fi
+\usepackage[
+  normalize-symbols,
+  keep-semicolon
+  ]{textalpha}
+
+\ProvideTextCommandDefault{\textvarstigma}{} % only in LGR
+
+\begin{document}
+
+a\textsemicolon{} b
+
+\ensuregreek{a\textsemicolon{} b}
+
+\textAlpha\par
+\textBeta\par
+\textGamma\par
+\textDelta\par
+\textEpsilon\par
+\textZeta\par
+\textEta\par
+\textTheta\par
+\textIota\par
+\textKappa\par
+\textLambda\par
+\textMu\par
+\textNu\par
+\textXi\par
+\textOmicron\par
+\textPi\par
+\textRho\par
+\textSigma\par
+\textTau\par
+\textUpsilon\par
+\textPhi\par
+\textChi\par
+\textPsi\par
+\textOmega\par
+\textalpha\par
+\textbeta\par
+\textgamma\par
+\textdelta\par
+\textepsilon\par
+\textzeta\par
+\texteta\par
+\texttheta\par
+\textiota\par
+\textkappa\par
+\textlambda\par
+\textmu\par
+\textnu\par
+\textxi\par
+\textomicron\par
+\textpi\par
+\textrho\par
+\textsigma\par
+\textfinalsigma\par
+\textautosigma\par
+\texttau\par
+\textupsilon\par
+\textphi\par
+\textchi\par
+\textpsi\par
+\textomega\par
+\textpentedeka\par
+\textpentehekaton\par
+\textpenteqilioi\par
+%\textpentemurioi\par % errors
+\textstigma\par
+\textvarstigma\par
+\textKoppa\par
+\textkoppa\par
+\textqoppa\par
+\textQoppa\par
+\textStigma\par
+\textSampi\par
+\textsampi\par
+\textanoteleia\par
+\texterotimatiko\par
+\textdigamma\par
+\textDigamma\par
+\textdexiakeraia\par
+\textaristerikeraia\par
+\textmicro
+
+\ifTUTeX
+\textvarbeta\par
+\textvarkappa\par
+\textvarTheta\par
+\textvartheta\par
+\textvarpi\par
+\textvarrho\par
+\textvarepsilon\par
+\textvarphi
+\fi
+
+\<'\textalpha % same as below with unicode engine
+
+\ensuregreek{\<'\textalpha}
+
+\accpsili\textalpha % same as below with unicode engine
+
+\ensuregreek{\accpsili\textalpha}
+
+\end{document}


### PR DESCRIPTION
Lists alphabeta and textalpha as compatible with tests.