### PR TITLE
add incompatible packages

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -283,13 +283,12 @@
 
  - name: algorithm2e
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in: [arxiv1]
    priority: 2
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   issues: [564]
+   tests: true
+   updated: 2024-08-14
 
  - name: algorithm
    ctan-pkg: algorithms
@@ -1426,13 +1425,12 @@
 
  - name: bytefield
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in: [arxiv001]
    priority: 7
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   issues: [565]
+   tests: true
+   updated: 2024-08-14
 
 #------------------------ CCC ----------------------------
 
@@ -1651,13 +1649,12 @@
 
  - name: ccaption
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in: [arxiv001]
    priority: 7
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   issues: [562]
+   tests: true
+   updated: 2024-08-14
 
  - name: ccfonts
    type: package
@@ -1732,13 +1729,12 @@
 
  - name: changepage
    type: package
-   status: unknown
+   status: partially-compatible
    included-in: [arxiv01]
    priority: 6
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   issues: [566]
+   tests: true
+   updated: 2024-08-14
 
  - name: changes
    type: package
@@ -2241,23 +2237,21 @@
 
  - name: cuted
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in: [arxiv01]
    priority: 6
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   issues: [563]
+   tests: true
+   updated: 2024-08-14
 
  - name: cutwin
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in: [arxiv001]
    priority: 7
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   updated: 2024-08-14
 
  - name: cyklop
    type: package
@@ -2642,13 +2636,12 @@
 
  - name: ebproof
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in: [arxiv001]
    priority: 7
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   issues: [568]
+   tests: true
+   updated: 2024-08-14
 
  - name: econlipsum
    type: package
@@ -3538,13 +3531,12 @@
 
  - name: fncychap
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in: [arxiv001]
    priority: 7
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   issues: [570]
+   tests: true
+   updated: 2024-08-14
 
  - name: fncylab
    type: package
@@ -4226,13 +4218,12 @@
 
  - name: gridset
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in:
    priority: 9
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   issues: [559]
+   tests: true
+   updated: 2024-08-14
 
  - name: grmath
    ctan-pkg: babel-greek
@@ -6263,13 +6254,12 @@
 
  - name: musixtex
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in:
    priority: 9
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   issues: [572]
+   tests: true
+   updated: 2024-08-14
 
  - name: mwe
    type: package
@@ -9420,13 +9410,12 @@
 
  - name: tocdata
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in: [tlc3]
    priority: 2
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-15
+   issues: [557]
+   tests: true
+   updated: 2024-08-14
 
  - name: tocloft
    type: package
@@ -9848,6 +9837,15 @@
    tests: true
    updated: 2024-07-10
 
+ - name: vcell
+   type: package
+   status: currently-incompatible
+   included-in: [arxiv001]
+   priority: 7
+   issues: [575]
+   tests: true
+   updated: 2024-08-14
+
  - name: venturis
    ctan-pkg: venturisadf
    type: package
@@ -9868,6 +9866,15 @@
    issues: [156]
    tests: true
    updated: 2024-07-17
+
+ - name: verbatimbox
+   type: package
+   status: currently-incompatible
+   included-in: [arxiv001]
+   priority: 7
+   issues: [571]
+   tests: true
+   updated: 2024-08-14
 
  - name: verbdef
    type: package

--- a/tagging-status/testfiles/algorithm2e/algorithm2e-01.tex
+++ b/tagging-status/testfiles/algorithm2e/algorithm2e-01.tex
@@ -1,0 +1,31 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{algorithm2e}
+
+\begin{document}
+
+text
+\begin{algorithm}
+\SetAlgoLined
+\KwData{this text}
+\KwResult{how to write algorithm with \LaTeX2e }
+initialization\;
+\While{not at end of this document}{
+read current\;
+\eIf{understand}{
+go to next section\;
+current section becomes this one\;
+}{
+go back to the beginning of current section\;
+}
+}
+\caption{How to write algorithms}
+\end{algorithm}
+
+\end{document}

--- a/tagging-status/testfiles/bytefield/bytefield-01.tex
+++ b/tagging-status/testfiles/bytefield/bytefield-01.tex
@@ -1,0 +1,35 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{bytefield}
+
+\begin{document}
+
+text
+
+\bigskip
+
+\begin{bytefield}[bitwidth=1.1em]{32}
+\bitheader{0-31} \\
+\begin{rightwordgroup}{RTP \\ Header}
+\bitbox{2}{V=2} & \bitbox{1}{P} & \bitbox{1}{X}
+& \bitbox{4}{CC} & \bitbox{1}{M} & \bitbox{7}{PT}
+& \bitbox{16}{sequence number} \\
+\bitbox{32}{timestamp}
+\end{rightwordgroup} \\
+\bitbox{32}{synchronization source (SSRC) identifier} \\
+\wordbox[tlr]{1}{contributing source (CSRC) identifiers} \\
+\wordbox[blr]{1}{$\cdots$} \\
+\begin{rightwordgroup}{RTP \\ Payload}
+\wordbox[tlr]{3}{MPEG-4 Visual stream (byte aligned)} \\
+\bitbox[blr]{16}{}
+& \bitbox{16}{\dots\emph{optional} RTP padding}
+\end{rightwordgroup}
+\end{bytefield}
+
+\end{document}

--- a/tagging-status/testfiles/ccaption/ccaption-01.tex
+++ b/tagging-status/testfiles/ccaption/ccaption-01.tex
@@ -1,0 +1,128 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{longtable}
+\usepackage{ccaption}
+\usepackage{graphicx}
+\usepackage{hyperref}
+
+\title{ccaption tagging test}
+
+%\precaption{\rule{\linewidth}{0.4pt}\par} % has no effect
+%\postcaption{\rule{\linewidth}{0.4pt}} % has no effect
+
+\newfixedcaption{\tabcaption}{table}
+
+\newfloatlist{diagram}{dgm}{List of Diagrams}{Diagram}
+
+\begin{document}
+
+\listoftables
+\listofdiagram % parent-child warnings
+
+\begin{table}
+\centering
+\caption{A multi-part table} \label{tab:m}
+First table
+\end{table}
+
+\begin{table}
+\centering
+\contcaption{Continued}
+Second table
+\end{table}
+
+\begin{table}
+\centering
+\contcaption{Concluded}
+Third table
+\end{table}
+
+\begin{table}
+\centering
+\caption{Another table} \label{tab:legend}
+Fourth table
+\legend{The legend} % wrong formatting
+\end{table}
+
+% formatting commands have no effect
+\begin{table}
+\centering
+\captionnamefont{\sffamily}
+\captiondelim{}
+\captionstyle{\\}
+\captiontitlefont{\scshape}
+\setlength{\belowcaptionskip}{10pt}
+\caption{Redesigned table caption style} \label{tab:style}
+Fifth table
+\end{table}
+
+\begin{table}
+\centering
+\captionnamefont{\sffamily}
+\captiontitlefont{\itshape}
+\namedlegend{Named legendary table}
+Sixth table
+\end{table}
+
+\begin{center}
+Some nonfloating table
+\tabcaption{Caption for nonfloating table}
+\end{center}
+
+\begin{table}
+\centering
+EXAMPLE TABLE WITH BITWONUMCAPTION
+\bitwonumcaption[fig:bi1]{}{Long}{Bild}{  }{Lang} 
+\end{table}
+
+\begin{table}
+\centering
+EXAMPLE TABLE WITH BIONENUMCAPTION
+\bionenumcaption[fig:bi3]{}{Long English}{Bild}{  }{Lang Deutsch} 
+\end{table}
+
+\begin{table}
+\centering
+EXAMPLE TABLE WITH BICAPTION
+\bicaption[fig:bi2]{Short English}{Longingly}{Bild}{Langlauf}
+\end{table}
+
+\begin{table}
+\centering
+EXAMPLE TABLE WITH BICONTCAPTION
+\bicontcaption{Longingly}{Bild}{Langlauf}
+\end{table}
+
+\begin{diagram}
+\centering
+Diagram content
+\caption{Some diagram}
+\end{diagram}
+
+\section{Warnings with longtable} % ccaption redefines some things
+
+\begin{longtable}{cc}
+\caption[Short caption]{Long caption}\\ % doesn't go into list of tables
+A & B \\
+C & D
+\end{longtable}
+
+\begin{longtable}{cc}
+\longbitwonumcaption{}{Long}{Bild}{  }{Lang} \\ % same here
+A & B \\
+C & D
+\end{longtable}
+
+\begin{longtable}{cc}
+\longbicaption{Short English}{Longingly}{Bild}{Langlauf} \\ % same here
+A & B \\
+C & D
+\end{longtable}
+
+\end{document}

--- a/tagging-status/testfiles/changepage/changepage-01.tex
+++ b/tagging-status/testfiles/changepage/changepage-01.tex
@@ -1,0 +1,60 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,table,title,firstaid}
+  }
+\documentclass{article}
+\usepackage[strict]{changepage}
+\usepackage{kantlipsum,graphicx}
+
+\title{changepage tagging test}
+
+\begin{document}
+
+\checkoddpage
+\ifoddpage
+odd
+\else
+even
+\fi
+
+\newpage
+
+\checkoddpage
+\ifoddpage
+odd
+\else
+even
+\fi
+
+\kant[1]
+\begin{adjustwidth}{}{-8em}
+\kant[2-5]
+\end{adjustwidth}
+\begin{adjustwidth}{-4em}{-4em}
+\kant[3]
+\end{adjustwidth}
+
+\begin{figure}
+\begin{adjustwidth}{-2em}{-2em}
+\includegraphics[alt={example}]{example-image}
+\caption{Wide figure}
+\end{adjustwidth}
+\end{figure}
+
+\clearpage
+\changetext{-5\baselineskip}{10em}{-5em}{-5em}{}
+\twocolumn
+\kant[1-3]
+\clearpage
+\changetext{5\baselineskip}{-10em}{5em}{5em}{}
+\onecolumn
+\kant[1-3]
+\changetext{0pt}{5em}{}{}{}%
+\kant[4-5]
+\changetext{0pt}{-5em}{}{}{}
+\kant[6-7]
+
+\end{document}

--- a/tagging-status/testfiles/cuted/cuted-01.tex
+++ b/tagging-status/testfiles/cuted/cuted-01.tex
@@ -1,0 +1,26 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass[twocolumn]{article}
+\usepackage{cuted}
+\usepackage{kantlipsum}
+
+\title{cuted tagging test}
+
+\preCutedStrip{PRE-BLUB}
+\postCutedStrip{POST-BLUB}
+
+\begin{document}
+
+\kant[1-2]
+\begin{strip}
+\kant[3]\footnotemark
+\end{strip}
+\footnotetext{Some footnote}
+\kant[4-5]
+
+\end{document}

--- a/tagging-status/testfiles/cutwin/cutwin-01.tex
+++ b/tagging-status/testfiles/cutwin/cutwin-01.tex
@@ -1,0 +1,34 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{cutwin}
+
+\title{cutwin tagging test}
+
+\begin{document}
+\opencutleft
+\begin{cutout}{5}{0pt}{0.5\textwidth}{10}
+   Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Ut purus elit, vesti-
+   bulum ut, placerat ac, adipiscing vitae, felis. Curabitur dictum gravida mauris.
+   Nam arcu libero, nonummy eget, consectetuer id, vulputate a, magna. Donec
+   vehicula augue eu neque. Pellentesque habitant morbi tristique senectus et ne-
+   tus et malesuada fames ac turpis egestas. Mauris ut leo. Cras viverra metu
+   Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Ut purus elit, vesti-
+   bulum ut, placerat ac, adipiscing vitae, felis. Curabitur dictum gravida mauris.
+   Nam arcu libero, nonummy eget, consectetuer id, vulputate a, magna. Donec\\
+
+   Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Ut purus elit, vesti-
+   bulum ut, placerat ac, adipiscing vitae, felis. Curabitur dictum gravida mauris.
+   Nam arcu libero, nonummy eget, consectetuer id, vulputate a, magna. Donec
+   vehicula augue eu neque. Pellentesque habitant morbi tristique senectus et ne-
+   tus et malesuada fames ac turpis egestas. Mauris ut leo. Cras viverra metu
+   Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Ut purus elit, vesti-
+   bulum ut, placerat ac, adipiscing vitae, felis. Curabitur dictum gravida mauris.
+   Nam arcu libero, nonummy eget, consectetuer id, vulputate a, magna. Donec
+\end{cutout}
+\end{document}

--- a/tagging-status/testfiles/ebproof/ebproof-01.tex
+++ b/tagging-status/testfiles/ebproof/ebproof-01.tex
@@ -1,0 +1,51 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+
+\usepackage{ebproof}
+\usepackage{xcolor}
+
+\title{ebproof tagging test}
+
+\begin{document}
+
+\begin{prooftree}
+\hypo{ \Gamma, A &\vdash B }
+\infer1[abs]{ \Gamma &\vdash A\to B }
+\hypo{ \Gamma \vdash A }
+\infer2[app]{ \Gamma \vdash B }
+\end{prooftree}
+
+\bigskip
+
+\begin{prooftree}
+\hypo{ \Gamma &\vdash A }
+\ellipsis{foo}{ \Gamma &\vdash A, B }
+\end{prooftree}
+
+\bigskip
+
+\begin{prooftree}
+\hypo{ \Gamma, A &\vdash B }
+\infer1[abs]{ \Gamma &\vdash A\to B }
+\rewrite{\color{red}\box\treebox}
+\hypo{ \Gamma \vdash A }
+\infer2[app]{ \Gamma \vdash B }
+\end{prooftree}
+
+\bigskip
+
+\begin{prooftree}
+\hypo{ A_1 \vee \cdots \vee A_n }
+\hypo{ [A_i] }
+\ellipsis{}{ B }
+\delims{ \left( }{ \right)_{1\leq i\leq n} }
+\infer2{ B }
+\end{prooftree}
+
+\end{document}

--- a/tagging-status/testfiles/fncychap/fncychap-01.tex
+++ b/tagging-status/testfiles/fncychap/fncychap-01.tex
@@ -1,0 +1,22 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{report}
+% styles that don't warn: Sonny, Glenn, Conny, Bjarne
+% styles that give warnings: Lenny, Rejne, Bjornstrup
+\usepackage[Bjornstrup]{fncychap}
+\usepackage{hyperref}
+
+\begin{document}
+
+\tableofcontents
+
+\chapter{Fancy chapter}
+
+\section{Normal section}
+
+\end{document}

--- a/tagging-status/testfiles/gridset/gridset-01.tex
+++ b/tagging-status/testfiles/gridset/gridset-01.tex
@@ -1,0 +1,16 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{gridset}
+
+\begin{document}
+
+text
+\SavePos{abc}
+
+\end{document}

--- a/tagging-status/testfiles/musixtex/musixtex-01.tex
+++ b/tagging-status/testfiles/musixtex/musixtex-01.tex
@@ -1,0 +1,35 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,title,math,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{musixtex}
+
+\title{musixtex tagging test}
+
+\begin{document}
+
+text
+
+\begin{music}
+\parindent10mm
+\instrumentnumber{1} % a single instrument
+\setname1{Piano} % whose name is Piano
+\setstaffs1{2} % with two staffs
+\generalmeter{\meterfrac44} % 4/4 meter chosen
+\startextract % starting real score
+\Notes\ibu0f0\qb0{cge}\tbu0\qb0g|\hl j\en
+\Notes\ibu0f0\qb0{cge}\tbu0\qb0g|\ql l\sk\ql n\en
+\bar
+\Notes\ibu0f0\qb0{dgf}|\qlp i\en
+\notes\tbu0\qb0g|\ibbl1j3\qb1j\tbl1\qb1k\en
+\Notes\ibu0f0\qb0{cge}\tbu0\qb0g|\hl j\en
+\zendextract % terminate excerpt
+\end{music}
+
+more text
+
+\end{document}

--- a/tagging-status/testfiles/tocdata/tocdata-01.tex
+++ b/tagging-status/testfiles/tocdata/tocdata-01.tex
@@ -1,0 +1,39 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+
+\usepackage{tocdata}
+\usepackage{hyperref}
+
+\title{tocdata tagging test}
+
+\begin{document}
+
+\tableofcontents
+
+\listoffigures
+
+\tocdata{toc}{Some author}
+\section{Some section}
+\subsection{Some subsection}
+
+\tocdata{toc}{Another author}
+\section{Another section}
+
+\begin{figure}
+Content.
+\tocdata{lof}{Some author}
+\caption{Some figure}
+\end{figure}
+
+\begin{figure}
+Content.
+\captionauthor{Some figure}{Some}{Author}
+\end{figure}
+
+\end{document}

--- a/tagging-status/testfiles/vcell/vcell-01.tex
+++ b/tagging-status/testfiles/vcell/vcell-01.tex
@@ -1,0 +1,32 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{booktabs}
+\usepackage{vcell}
+
+\begin{document}
+
+\begin{tabular}{@{}c@{}lcr@{}}
+\toprule
+& Top cell
+& Middle cell
+& Bottom cell
+\\ \midrule
+\savecellbox{\rule{0pt}{40pt}}
+& \savecellbox{Top}
+& \savecellbox{Middle}
+& \savecellbox{Bottom}
+\\[-\rowheight]
+\printcellmiddle
+& \printcelltop
+& \printcellmiddle
+& \printcellbottom
+\\ \bottomrule
+\end{tabular}
+
+\end{document}

--- a/tagging-status/testfiles/verbatimbox/verbatimbox-01.tex
+++ b/tagging-status/testfiles/verbatimbox/verbatimbox-01.tex
@@ -1,0 +1,22 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,title,math,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{verbatimbox}
+
+\title{verbatimbox tagging test}
+
+\begin{document}
+
+\begin{verbbox}[\(\bullet\)\hspace{1ex}]
+first line
+second line
+third line
+\end{verbbox}
+\theverbbox
+
+\end{document}


### PR DESCRIPTION
Lists algorithm2e, bytefield, ccaption, cuted, cutwin, ebproof, fncychap, gridset, musixtex, tocdata, vcell, and verbatimbox as currently-incompatible with tests.

Lists changepage as partially-compatible with a test.