### PR TITLE
corrections and additions

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -3802,6 +3802,16 @@
    tests: false
    updated: 2024-07-21
 
+ - name: fp
+   type: package
+   status: unknown
+   included-in: [arxiv01]
+   priority: 6
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-08-14
+
  - name: framed
    type: package
    status: partially-compatible

--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -597,8 +597,8 @@
  - name: apacite
    type: package
    status: unknown
-   included-in: [arxiv001]
-   priority: 7
+   included-in: [arxiv01]
+   priority: 6
    issues:
    tests: false
    tasks: needs tests
@@ -613,6 +613,16 @@
    issues:
    tests: false
    updated: 2024-07-31
+
+ - name: apptools
+   type: package
+   status: unknown
+   included-in: [arxiv001]
+   priority: 7
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-08-14
 
  - name: arabi
    type: package
@@ -879,8 +889,8 @@
    ctan-pkg: boondox
    type: package
    status: compatible
-   included-in:
-   priority: 9
+   included-in: [arxiv001]
+   priority: 7
    issues:
    tests: false
    updated: 2024-08-05
@@ -2324,6 +2334,16 @@
    tests: false
    updated: 2024-07-13
 
+ - name: dashbox
+   type: package
+   status: unknown
+   included-in: [arxiv001]
+   priority: 7
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-08-14
+
  - name: dashrule
    type: package
    status: partially-compatible
@@ -2590,8 +2610,8 @@
  - name: dutchcal
    type: package
    status: compatible
-   included-in:
-   priority: 9
+   included-in: [arxiv001]
+   priority: 7
    issues:
    tests: false
    updated: 2024-08-05
@@ -2923,6 +2943,15 @@
    issues:
    tests: true
    updated: 2024-08-02
+
+ - name: eqnarray
+   type: package
+   status: currently-incompatible
+   included-in: [arxiv01]
+   priority: 6
+   issues:
+   tests: true
+   updated: 2024-08-14
 
  - name: eqparbox
    type: package
@@ -4257,6 +4286,16 @@
    issues:
    tests: false
    updated: 2024-07-21
+
+ - name: halloweenmath
+   type: package
+   status: unknown
+   included-in: [arxiv001]
+   priority: 7
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-08-14
 
  - name: hanging
    type: package
@@ -5632,6 +5671,16 @@
    tests: false
    updated: 2024-07-25
 
+ - name: makebox
+   type: package
+   status: unknown
+   included-in: [arxiv001]
+   priority: 7
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-08-14
+
  - name: makecell
    type: package
    status: unknown
@@ -6354,6 +6403,26 @@
    tests: false
    tasks: needs tests
    updated: 2024-07-18
+
+ - name: ncccropbox
+   type: package
+   status: unknown
+   included-in: [arxiv001]
+   priority: 7
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-08-14
+
+ - name: ncccropmark
+   type: package
+   status: unknown
+   included-in: [arxiv001]
+   priority: 7
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-08-14
 
  - name: nccfoots
    type: package
@@ -7962,8 +8031,8 @@
  - name: romannum
    type: package
    status: compatible
-   included-in: [arxiv001]
-   priority: 7
+   included-in: [arxiv01]
+   priority: 6
    issues:
    tests: true
    updated: 2024-08-06
@@ -8363,6 +8432,16 @@
    issues: [115]
    tests: true
    updated: 2024-07-11
+
+ - name: showlabels
+   type: package
+   status: unknown
+   included-in: [arxiv001]
+   priority: 7
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-08-14
 
  - name: showkeys
    type: package
@@ -8826,6 +8905,16 @@
    tasks: needs tests
    updated: 2024-07-15
 
+ - name: svn-prov
+   type: package
+   status: unknown
+   included-in: [arxiv001]
+   priority: 7
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-08-14
+
  - name: systeme
    type: package
    status: currently-incompatible
@@ -8890,6 +8979,16 @@
    issues: [171]
    tests: true
    updated: 2024-07-17
+
+ - name: tabstackengine
+   type: package
+   status: unknown
+   included-in: [arxiv001]
+   priority: 7
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-08-14
 
  - name: tabto
    type: package

--- a/tagging-status/testfiles/eqnarray/eqnarray-01.tex
+++ b/tagging-status/testfiles/eqnarray/eqnarray-01.tex
@@ -1,0 +1,24 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{eqnarray}
+
+%\RegisterMathEnvironment{equationarray}
+
+\begin{document}
+
+\newcolumntype{e}{@{\quad}}
+\arraycolsep 0.2em
+\begin{equationarray}{p{2.5em}erclecercl}
+now: & - i\partial_t \psi & = & H\,\psi & \Rightarrow
+& \psi (t) & = & \psi (0) \exp (iEt) \\[3ex]
+then: & - i\partial_t \psi & = & (H+E_0) \,\psi & \Rightarrow
+& \psi (t) & = & \psi (0) \exp [i(E+E_0)t]
+\end{equationarray}
+
+\end{document}


### PR DESCRIPTION
Corrects priority in a few places.

Adds apptools, dashbox, fp, halloweenmath, makebox, ncccropbox, ncccropmark, showlabels, svn-prov, and tabstackengine without commenting on status (all arxiv001 or above).

Lists eqnarray as incompatible with a test.