### PR TITLE
add pdfoverlay compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -7332,13 +7332,14 @@
 
  - name: pdfoverlay
    type: package
-   status: unknown
+   status: partially-compatible
    included-in:
    priority: 9
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   comments: "pdf added to shipout/background so corresponding tag appears at end
+              of page"
+   updated: 2024-08-15
 
  - name: pdfpages
    type: package

--- a/tagging-status/testfiles/pdfoverlay/pdfoverlay-01.tex
+++ b/tagging-status/testfiles/pdfoverlay/pdfoverlay-01.tex
@@ -1,0 +1,19 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{pdfoverlay}
+\usepackage{kantlipsum}
+
+\pdfoverlaySetPDF{example-image.pdf}
+\pdfoverlaySetGraphicsOptions{alt=overlaid pdf,keepaspectratio,width=\paperwidth}
+
+\begin{document}
+
+\kant[1-6]
+
+\end{document}


### PR DESCRIPTION
Lists [pdfoverlay](https://ctan.org/pkg/pdfoverlay) as partially-compatible and adds a test. The pdf is included in `shipout/background` so is tagged at the end of the page. Not sure what the expected result is here because the goal of the package is to
> add annotations or text overlaying the PDF

which seems tagging-unfriendly. This won't matter if the changes suggested in #483 are implemented.