### PR TITLE
add picinpar compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -7534,6 +7534,15 @@
    tests: true
    updated: 2024-07-26
 
+ - name: picinpar
+   type: package
+   status: currently-incompatible
+   included-in: [arxiv001]
+   priority: 7
+   issues:
+   tests: true
+   updated: 2024-08-15
+
  - name: picins
    type: package
    status: unknown
@@ -7542,6 +7551,7 @@
    issues:
    tests: false
    tasks: needs tests
+   comments: Not distributed with texlive.
    updated: 2024-07-18
 
  - name: pict2e

--- a/tagging-status/testfiles/picinpar/picinpar-01.tex
+++ b/tagging-status/testfiles/picinpar/picinpar-01.tex
@@ -1,0 +1,29 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{picinpar}
+
+\font\yn=cmss17 scaled \magstep5
+\setlength{\parindent}{0pt}
+
+\begin{document}
+
+\begin{window}[0,l,{\yn V},{}]
+or einigen Jahren wurde von Donald E.~Knuth im TUGboat ein kleines
+Problem mit der Bitte um L"osung vorgestellt. Es handelte sich darum,
+in einem Paragraphen ein Fenster zu erzeugen, in das man beliebigen Text
+oder eine Zeichnung hineinsetzen kann. Prompt kamen dann in den folgenden
+Ausgaben L"osungsvorschl"age: Einer von DEK pers"onlich, der andere von
+Alan Hoenig. Der letztgenannte brachte die elegantere L"osung, die keine
+manuellen Korrekturen mehr notwendig machte. Sein Makro verlangte lediglich
+in den Parametern Informationen "uber die Breite und H"ohe der
+freizulassenden Stelle im Paragraphen. Die Einz"uge und der Satz der
+Fragmente des Abschnitts erfolgten automatisch.
+\end{window}
+
+\end{document}


### PR DESCRIPTION
Lists [picinpar](https://ctan.org/pkg/picinpar) as currently-incompatible with a test. It could probably be listed as obsolete.

Also, adds a note that picins is not distributed with texlive.