### PR TITLE
add obsolete comments

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -8873,6 +8873,8 @@
    priority: 4
    issues:
    tests: false
+   tasks: needs tests
+   comments: Obsolete
    updated: 2024-07-28
 
  - name: subfiles
@@ -9590,6 +9592,7 @@
    issues:
    tests: false
    tasks: needs tests
+   comments: Obsolete
    updated: 2024-07-15
 
  - name: tocvsec2


### PR DESCRIPTION
Adds `comments: Obsolete` to the entries for subfigure and tocstyle.