### PR TITLE
add showlabels compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -8462,13 +8462,12 @@
 
  - name: showlabels
    type: package
-   status: unknown
+   status: compatible
    included-in: [arxiv001]
    priority: 7
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-08-14
+   tests: true
+   updated: 2024-08-15
 
  - name: showkeys
    type: package

--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -8462,11 +8462,12 @@
 
  - name: showlabels
    type: package
-   status: compatible
+   status: partially-compatible
    included-in: [arxiv001]
    priority: 7
    issues:
    tests: true
+   tasks: "Determine how to tag the shown labels, matching showkeys."
    updated: 2024-08-15
 
  - name: showkeys

--- a/tagging-status/testfiles/showlabels/showlabels-01.tex
+++ b/tagging-status/testfiles/showlabels/showlabels-01.tex
@@ -1,0 +1,30 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+
+\usepackage{hyperref}
+\usepackage{xcolor}
+\usepackage[
+%  inline % works okay too
+  ]{showlabels}
+
+\showlabels[\color{green}]{cite}
+
+\begin{document}
+
+\section{Some section}
+\label{sec}
+
+Some text
+
+\cite{inbook-full}
+
+\bibliographystyle{amsalpha}
+\bibliography{xampl}
+
+\end{document}


### PR DESCRIPTION
Lists [showlabels](https://ctan.org/pkg/showlabels) as compatible and adds a test. The labels are correctly tagged as artifacts.