### PR TITLE
add titleref compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -9500,13 +9500,13 @@
 
  - name: titleref
    type: package
-   status: unknown
+   status: partially-compatible
    included-in:
    priority: 9
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   comments: "Incompatible with hyperref."
+   updated: 2024-08-15
 
  - name: titlesec
    type: package

--- a/tagging-status/testfiles/titleref/titleref-01.tex
+++ b/tagging-status/testfiles/titleref/titleref-01.tex
@@ -1,0 +1,32 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+
+\usepackage{titleref}
+
+\title{titleref tagging test}
+
+\begin{document}
+
+\tableofcontents
+
+\section[short]{Some section}
+\label{sec}
+
+Some text.
+
+\section{Another section}
+
+See \titleref{sec}.
+
+\section*{An unnumbered section}
+\label{unnum}
+
+\titleref{unnum}
+
+\end{document}


### PR DESCRIPTION
Lists titleref as partially-compatible because it is incompatible with hyperref. Otherwise it looks okay.