### PR TITLE
add fncylab compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -3578,13 +3578,13 @@
 
  - name: fncylab
    type: package
-   status: unknown
+   status: compatible
    included-in:
    priority: 9
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   comments: Unnecessary with current LaTeX.
+   updated: 2024-08-15
 
  - name: fnlineno
    type: package


### PR DESCRIPTION
Lists fncylab as compatible with a comment that it's unnecessary with a current LaTeX.