### PR TITLE
add ghsystem compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -4114,13 +4114,14 @@
 
  - name: ghsystem
    type: package
-   status: unknown
+   status: partially-compatible
    included-in:
    priority: 9
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   comments: "Uses math where it doesn't need to. `\\ghspic` should have Alt text
+              by default."
+   updated: 2024-08-15
 
  - name: gillius
    type: package

--- a/tagging-status/testfiles/ghsystem/ghsystem-01.tex
+++ b/tagging-status/testfiles/ghsystem/ghsystem-01.tex
@@ -1,0 +1,42 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+
+\ExplSyntaxOn % see https://github.com/cgnieder/ghsystem/issues/13
+\cs_new:Npn \chemmacros_load_module:n #1 {}
+\ExplSyntaxOff
+\usepackage{ghsystem}
+\usepackage{longtable}
+\usepackage{booktabs}
+
+\begin{document}
+
+\ghs{h}{200} \par
+\ghs{H}{224} \par
+\ghs{euh}{001} \par
+\ghs{Euh}{202} \par
+\ghs{p}{201}
+
+\ghs[fill-in]{h}{340}
+
+\ghs[exposure=This is how you get exposed.]{h}{340} \par
+\ghs[effect=These are the effects.]{h}{360} \par
+\ghs[organs=to this organ]{h}{370} \par
+\ghs[substance=substance]{euh}{208}
+
+\ghs[text=contact physician!]{p}{301} \par
+\ghs[dots=here]{p}{401} \par
+\ghs[C-temperature=50, F-temperature=122]{p}{411} \par
+\ghs[kg-mass=5.0, lbs-mass=11, C-temperature=50, F-temperature=122]{p}{413}
+
+%\ghspic{skull} % should have alt text by default
+\ghspic[includegraphics={alt=skull}]{skull}
+
+\ghslistall[fill-in,table-rules=booktabs]
+
+\end{document}


### PR DESCRIPTION
Lists [ghsystem](https://ctan.org/pkg/ghsystem) as partially-compatible because it uses math where it doesn't need to and images inserted with `\ghspic` should have Alt text by default.