### PR TITLE
add axodraw2 compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -870,6 +870,8 @@
    priority: 9
    issues:
    tests: true
+   comments: "`axopicture` environment can take same optional argument as `picture`
+             to set `alt`, `artifact`, etc."
    updated: 2024-08-16
 
 #------------------------ BBB ----------------------------

--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -865,13 +865,12 @@
 
  - name: axodraw2
    type: package
-   status: unknown
+   status: compatible
    included-in:
    priority: 9
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   updated: 2024-08-16
 
 #------------------------ BBB ----------------------------
 

--- a/tagging-status/testfiles/axodraw2/axodraw2-01.tex
+++ b/tagging-status/testfiles/axodraw2/axodraw2-01.tex
@@ -1,0 +1,42 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{axodraw2}
+
+\title{axodraw2 tagging test}
+
+\begin{document}
+Example of Feynman graph using axodraw2 macros:
+\begin{center}
+\begin{axopicture}[alt=Feynman graph](200,110)
+\SetColor{Red}
+\Arc[arrow](100,50)(40,0,180)
+\Text(100,100){$\alpha P_1 + \beta P_2 + k_\perp$}
+\SetColor{Black}
+\Arc[arrow](100,50)(40,180,360)
+\Gluon(0,50)(60,50){5}{4}
+\Vertex(60,50){2}
+\Gluon(140,50)(200,50){5}{4}
+\Vertex(140,50){2}
+\end{axopicture}
+\end{center}
+\begin{center}
+\begin{axopicture}[alt=text example](100,100)
+\SetPFont{Helvetica}{20}
+\Text(10,10)[l]{left}
+\Text(45,45){centered}
+\Text(80,80)[rt]{right-top}
+\Text(20,60)(45){$e^{i\pi/4}$}
+\SetColor{Red}
+\Vertex(10,10){1.5}
+\Vertex(45,45){1.5}
+\Vertex(80,80){1.5}
+\end{axopicture}
+\end{center}
+
+\end{document}


### PR DESCRIPTION
Lists [axodraw2](https://ctan.org/pkg/axodraw2) as compatible and adds a test. Because the definition of `axopicture` is in terms of `picture` it can pick up the new optional argument to set alt text or artifact (of course, this is not documented anywhere).