### PR TITLE
add incompatible packages

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -1334,13 +1334,12 @@
 
  - name: boldline
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in: [tlc3, arxiv01]
    priority: 2
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-14
+   issues: [604]
+   tests: true
+   updated: 2024-08-16
 
  - name: booklet
    type: package
@@ -3065,13 +3064,12 @@
 
  - name: etoc
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in: [arxiv001]
    priority: 7
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   issues: [598]
+   tests: true
+   updated: 2024-08-16
 
  - name: etoolbox
    type: package
@@ -3704,13 +3702,13 @@
 
  - name: footnotebackref
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in: [arxiv001]
    priority: 7
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   issues: [588]
+   tests: true
+   comments: "Works with `numberlinked=false`."
+   updated: 2024-08-16
 
  - name: footnotehyper
    type: package
@@ -4902,13 +4900,12 @@
 
  - name: kanbun
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in:
    priority: 9
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   issues: [596]
+   tests: true
+   updated: 2024-08-16
 
  - name: kantlipsum
    type: package
@@ -5388,13 +5385,12 @@
 
  - name: longdivision
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in:
    priority: 9
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   updated: 2024-08-16
 
  - name: longtable
    type: package
@@ -7325,13 +7321,12 @@
 
  - name: pdfmarginpar
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in:
    priority: 9
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   issues: [584]
+   tests: true
+   updated: 2024-08-16
 
  - name: pdfmsym
    type: package
@@ -7490,13 +7485,12 @@
  - name: pgfpages
    ctan-pkg: pgf
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in: [arxiv001]
    priority: 7
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   issues: [590]
+   tests: true
+   updated: 2024-08-16
 
  - name: pgfplots
    type: package
@@ -9007,13 +9001,12 @@
 
  - name: tableof
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in:
    priority: 9
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   issues: [589]
+   tests: true
+   updated: 2024-08-16
 
  - name: tabls
    type: package

--- a/tagging-status/testfiles/boldline/boldline-01.tex
+++ b/tagging-status/testfiles/boldline/boldline-01.tex
@@ -1,0 +1,44 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{boldline,longtable}
+
+\title{boldline tagging test}
+
+\begin{document}
+
+\begin{tabular}{ccc}\hlineB{2.7}
+1st &First &I \\ \hlineB{2.7}
+2nd &Second &II \\ \clineB{1-2}{0.5}
+3rd &Third &III\\ \hlineB{2.7}
+\end{tabular}
+
+\bigskip
+
+% compare with
+\begin{tabular}{ccc}\hline
+1st &First &I \\ \hline
+2nd &Second &II \\ \cline{1-2}
+3rd &Third &III\\ \hline
+\end{tabular}
+
+\begin{center}
+\begin{tabular}{V{2.7}c|c|cV{2.7}}\hlineB{2.7}
+1st &First  &I  \\\hline
+2nd &Second &II \\ %\clineB{1-2}{.5}
+3rd &Third  &III\\\hlineB{2.7}
+\end{tabular}
+\end{center}
+
+\begin{longtable}{V{2.7}c|c|cV{2.7}}\hlineB{2.7}
+1st &First  &I  \\\hline
+2nd &Second &II \\ %\clineB{1-2}{.5}
+3rd &Third  &III\\\hlineB{2.7}
+\end{longtable}
+
+\end{document}

--- a/tagging-status/testfiles/etoc/etoc-01.tex
+++ b/tagging-status/testfiles/etoc/etoc-01.tex
@@ -1,0 +1,19 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+
+\usepackage{etoc}
+
+\begin{document}
+
+\tableofcontents
+
+\section{blub}
+\subsection{blub blub}
+
+\end{document}

--- a/tagging-status/testfiles/footnotebackref/footnotebackref-01.tex
+++ b/tagging-status/testfiles/footnotebackref/footnotebackref-01.tex
@@ -1,0 +1,18 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage[
+  symbol=\textuparrow,
+%  numberlinked=false % toggle comment
+  ]{footnotebackref}
+
+\begin{document}
+Some text with a footnote\footnote{The first footnote.}
+
+Text with the second footnote\footnote[4]{The second footnote.}
+\end{document}

--- a/tagging-status/testfiles/kanbun/kanbun-01.tex
+++ b/tagging-status/testfiles/kanbun/kanbun-01.tex
@@ -1,0 +1,19 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{luatexja}
+\usepackage{kanbun}
+\begin{document}
+\Kanbun
+月落チ烏啼キテ霜満ツ[レ]天ニ，
+江楓漁火対ス[二]愁眠ニ[一]。
+姑(こ)蘇(そ)城外ノ寒山寺，
+夜半ノ鐘声到ル[二]客船ニ[一]。
+\EndKanbun
+\printkanbun
+\end{document}

--- a/tagging-status/testfiles/longdivision/longdivision-01.tex
+++ b/tagging-status/testfiles/longdivision/longdivision-01.tex
@@ -1,0 +1,20 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+
+\usepackage{longdivision}
+
+\title{longdivision tagging test}
+
+\begin{document}
+
+\longdivision{100}{22}
+
+\intlongdivision{100}{22}
+
+\end{document}

--- a/tagging-status/testfiles/pdfmarginpar/pdfmarginpar-01.tex
+++ b/tagging-status/testfiles/pdfmarginpar/pdfmarginpar-01.tex
@@ -1,0 +1,19 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+
+%\usepackage{luatex85} % needed for lualatex
+\usepackage{pdfmarginpar}
+
+\title{pdfmarginpar tagging test}
+
+\begin{document}
+
+some text\pdfmarginpar{annotation text}
+
+\end{document}

--- a/tagging-status/testfiles/pgfpages/pgfpages-01.tex
+++ b/tagging-status/testfiles/pgfpages/pgfpages-01.tex
@@ -1,0 +1,29 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+
+\usepackage{pgfpages}
+\pgfpagesuselayout{6 on 1}[a4paper,landscape,border shrink=5mm]
+
+\title{pgfpages tagging test}
+
+\begin{document}
+First
+\clearpage
+Second
+\clearpage
+Third
+\clearpage
+Fourth
+\clearpage
+Fifth
+\clearpage
+Sixth
+\clearpage
+Seventh
+\end{document}

--- a/tagging-status/testfiles/tableof/tableof-01.tex
+++ b/tagging-status/testfiles/tableof/tableof-01.tex
@@ -1,0 +1,36 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{book}
+
+\usepackage{tableof}
+
+\title{tableof tagging test}
+
+\begin{document}
+
+\tableofcontents
+\chapter*{Table of A Content}
+\tableof{a}
+\chapter*{Table of B Content}
+\tableof{b}
+
+\newpage
+\section{Introduction}
+
+\chapter{First}
+\toftagthis{a}
+\section{Topic A}
+something
+\toftagthis{a}
+\section{Topic A}
+something
+\toftagthis{b}
+\section{Topic B}
+something
+
+\end{document}


### PR DESCRIPTION
Lists boldline, etoc, footnotebackref, kanbun, longdivision, pdfmarginpar, pgfpages, and tableof as currently-incompatible with tests and links to issues.