### PR TITLE
add aurical compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -781,6 +781,16 @@
    tests: false
    updated: 2024-07-14
 
+ - name: aurical
+   type: package
+   status: partially-compatible
+   included-in: [arxiv001]
+   priority: 7
+   issues:
+   tests: true
+   comments: "Some characters with `\\Fontamici` are not correctly mapped to Unicode."
+   updated: 2024-08-19
+
  - name: authblk
    type: package
    status: unknown

--- a/tagging-status/testfiles/aurical/aurical-01.tex
+++ b/tagging-status/testfiles/aurical/aurical-01.tex
@@ -1,0 +1,22 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+
+\usepackage{aurical}
+\usepackage{kantlipsum}
+
+\title{aurical tagging test}
+
+\begin{document}
+
+{\Fontauri\kant[2]}
+{\Fontskrivan\kant[2]}
+{\Fontlukas\kant[2]}
+{\Fontamici\kant[2]}
+
+\end{document}


### PR DESCRIPTION
Lists [aurical](https://www.ctan.org/pkg/aurical) as partially-compatible because some characters with `\Fontamici` are not correctly mapped to unicode.