### PR TITLE
add frcursive compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -3823,6 +3823,16 @@
    tests: true
    updated: 2024-07-21
 
+ - name: frcursive
+   type: package
+   status: currently-incompatible
+   included-in: [arxiv001]
+   priority: 7
+   issues:
+   tests: true
+   comments: "Text not correctly mapped to Unicode."
+   updated: 2024-08-19
+
  - name: french
    ctan-pkg: e-french
    type: package

--- a/tagging-status/testfiles/frcursive/frcursive-01.tex
+++ b/tagging-status/testfiles/frcursive/frcursive-01.tex
@@ -1,0 +1,31 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+
+\usepackage[default]{frcursive}
+\usepackage{kantlipsum}
+
+\title{frcursive tagging test}
+
+\begin{document}
+
+\kant[1-2]
+\begin{calseries}
+\kant[3]
+\end{calseries}
+\begin{ftseries}
+\kant[4]
+\end{ftseries}
+\begin{wideseries}
+\kant[5]
+\end{wideseries}
+\begin{acadshape}
+\kant[6]
+\end{acadshape}
+
+\end{document}


### PR DESCRIPTION
Lists [frcursive](https://www.ctan.org/pkg/frcursive) as currently-incompatible because the text is not correctly mapped to unicode.