### PR TITLE
add pigpen compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -7592,6 +7592,17 @@
    tests: true
    updated: 2024-07-25
 
+ - name: pigpen
+   type: package
+   status: partially-compatible
+   included-in: [arxiv001]
+   priority: 7
+   issues:
+   comments: "With pdftex, spaces are lost. Tagged as the input, not cipher, text."
+   tests: true
+   tasks: "How should a cipher font be tagged?"
+   updated: 2024-08-19
+
  - name: pinlabel
    type: package
    status: unknown

--- a/tagging-status/testfiles/pigpen/pigpen-01.tex
+++ b/tagging-status/testfiles/pigpen/pigpen-01.tex
@@ -1,0 +1,20 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+
+\usepackage{pigpen}
+
+\title{pigpen tagging test}
+
+\begin{document}
+
+normal text
+
+{\pigpenfont X MARKS THE SPOT} % with pdflatex spaces are lost
+
+\end{document}


### PR DESCRIPTION
Lists [pigpen](https://www.ctan.org/pkg/pigpen) as partially-compatible because with pdflatex it ignores spaces and the text is tagged the same as it's input, not in the unicode characters of the cipher font (they are in fact in unicode). I don't know what the correct behavior is here so I added a task note.