### PR TITLE
add smartref compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -8573,6 +8573,16 @@
    tests: true
    updated: 2024-07-26
 
+ - name: smartref
+   type: package
+   status: partially-compatible
+   included-in: [arxiv001]
+   priority: 7
+   issues:
+   tests: true
+   comments: "No links with hyperref."
+   updated: 2024-08-19
+
  - name: snapshot
    type: package
    status: compatible

--- a/tagging-status/testfiles/smartref/smartref-01.tex
+++ b/tagging-status/testfiles/smartref/smartref-01.tex
@@ -1,0 +1,42 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+
+\usepackage[byname]{smartref}
+\usepackage{hyperref}
+
+\title{smartref tagging test}
+
+\addtoreflist{section}
+\def\shortsectionname{sec.}
+
+\begin{document}
+
+\section{First section}
+\subsection{First subsection}
+\subsection[second subsec.]{Second subsection}
+\label{sec}
+
+\sectionref{sec}
+
+\ssectionref{sec}
+
+\srefsectionref{sec}
+
+\byshortname{sec}
+
+\byname{sec}
+
+\section{Second section}
+
+\sectionref{sec}
+
+\ssectionref{sec}
+
+\srefsectionref{sec}
+\end{document}


### PR DESCRIPTION
Lists [smartref](https://www.ctan.org/pkg/smartref) as partially-compatible because it doesn't produce links with hyperref. The `\byshortname` and `\byname` commands also produce `Suppressing link with empty target` warnings with hyperref.