### PR TITLE
add romanbar compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -8056,6 +8056,16 @@
    tests: false
    updated: 2024-07-15
 
+ - name: romanbar
+   type: package
+   status: partially-compatible
+   included-in: [arxiv001]
+   priority: 7
+   issues:
+   tests: true
+   comments: "`\\Romanbar` produces rules that should be tagged as Artifacts."
+   updated: 2024-08-19
+
  - name: romande
    ctan-pkg: romandeadf
    type: package

--- a/tagging-status/testfiles/romanbar/romanbar-01.tex
+++ b/tagging-status/testfiles/romanbar/romanbar-01.tex
@@ -1,0 +1,34 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+
+\usepackage{romanbar}
+
+\title{romanbar tagging test}
+
+\begin{document}
+
+\Romanbar{MMXII}
+
+\Romanbar{2012}
+
+\Romanbar{-12}
+
+\Romanbar{0}
+
+\Romanbar{Caesar}
+
+\Romanbar{AgjpqyW}
+
+\Romanbar{555}
+
+\romannum{2012}
+
+\Romannum{2012}
+
+\end{document}


### PR DESCRIPTION
Lists [romanbar](https://www.ctan.org/pkg/romanbar) as partially-compatible because `\Romanbar` produces rules that should be tagged as Artifacts.