### PR TITLE
add several packages

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -369,6 +369,15 @@
    tests: false
    updated: 2024-07-13
 
+ - name: alnumsec
+   type: package
+   status: compatible
+   included-in:
+   priority: 9
+   issues:
+   tests: true
+   updated: 2024-08-20
+
  - name: alphabeta
    ctan-pkg: greek-fontenc
    type: package
@@ -842,6 +851,15 @@
    issues:
    tests: true
    updated: 2024-07-21
+
+ - name: autonum
+   type: package
+   status: currently-incompatible
+   included-in: [arxiv001]
+   priority: 7
+   issues: [619]
+   tests: true
+   updated: 2024-08-20
 
  - name: auxhook
    type: package
@@ -2066,6 +2084,15 @@
    tasks: needs tests
    updated: 2024-07-18
 
+ - name: collref
+   type: package
+   status: currently-incompatible
+   included-in: [arxiv001]
+   priority: 7
+   issues: [628]
+   tests: true
+   updated: 2024-08-20
+
  - name: colonequals
    type: package
    status: compatible
@@ -2472,6 +2499,17 @@
    tests: true
    updated: 2024-07-10
 
+ - name: delimset
+   type: package
+   status: compatible
+   included-in: [arxiv001]
+   priority: 7
+   supported-through: [phase-III,math]
+   comments: "Use of math tagging currently requires support from external tools."
+   issues:
+   tests: true
+   updated: 2024-08-20
+
  - name: derivative
    type: package
    status: compatible
@@ -2512,6 +2550,15 @@
    issues:
    tests: true
    updated: 2024-07-25
+
+ - name: dirtree
+   type: package
+   status: currently-incompatible
+   included-in: [arxiv001]
+   priority: 7
+   issues: [613]
+   tests: true
+   updated: 2024-08-20
 
  - name: doc
    type: package
@@ -2623,8 +2670,8 @@
  - name: duckuments
    type: package
    status: compatible
-   included-in:
-   priority: 9
+   included-in: [arxiv001]
+   priority: 7
    issues:
    tests: true
    updated: 2024-08-12
@@ -3374,6 +3421,17 @@
    tasks: needs tests
    updated: 2024-08-01
 
+ - name: fge
+   type: package
+   status: compatible
+   included-in: [arxiv001]
+   priority: 7
+   supported-through: [phase-III,math]
+   comments: "Use of math tagging currently requires support from external tools."
+   issues:
+   tests: true
+   updated: 2024-08-20
+
  - name: fibnum
    type: package
    status: compatible
@@ -3535,13 +3593,12 @@
 
  - name: floatrow
    type: package
-   status: unknown
+   status: no-support
    included-in: [arxiv01]
    priority: 6
-   issues:
+   issues: [497]
    tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   updated: 2024-08-20
 
  - name: flowfram
    type: package
@@ -3837,13 +3894,12 @@
 
  - name: fp
    type: package
-   status: unknown
+   status: compatible
    included-in: [arxiv01]
    priority: 6
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-08-14
+   updated: 2024-08-20
 
  - name: framed
    type: package
@@ -3904,6 +3960,15 @@
    issues: [110]
    tests: true
    updated: 2024-07-11
+
+ - name: ftnxtra
+   type: package
+   status: currently-incompatible
+   included-in: [arxiv001]
+   priority: 7
+   issues: [625]
+   tests: true
+   updated: 2024-08-20
 
  - name: fullpage
    type: package
@@ -5174,6 +5239,15 @@
    comments: "Drawn frames should be Artifacts. Pictures need Alt text."
    updated: 2024-08-05
 
+ - name: lcg
+   type: package
+   status: compatible
+   included-in: [arxiv001]
+   priority: 7
+   issues:
+   tests: false
+   updated: 2024-08-20
+
  - name: leftidx
    type: package
    status: compatible
@@ -6251,6 +6325,15 @@
    tests: false
    updated: 2024-07-15
 
+ - name: moreenum
+   type: package
+   status: compatible
+   included-in: [arxiv001]
+   priority: 7
+   issues:
+   tests: false
+   updated: 2024-08-20
+
  - name: morefloats
    type: package
    status: compatible
@@ -6332,6 +6415,15 @@
    issues:
    tests: false
    updated: 2024-08-06
+
+ - name: multienum
+   type: package
+   status: currently-incompatible
+   included-in: [arxiv001]
+   priority: 7
+   issues:
+   tests: true
+   updated: 2024-08-20
 
  - name: multiexpand
    type: package
@@ -6903,13 +6995,12 @@
 
  - name: numerica-tables
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in:
    priority: 9
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   issues: [627]
+   tests: true
+   updated: 2024-08-20
 
  - name: numprint
    type: package
@@ -7305,13 +7396,12 @@
 
  - name: pbox
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in: [arxiv01]
    priority: 6
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-08-01
+   issues: [628]
+   tests: true
+   updated: 2024-08-20
 
  - name: pdfcol
    type: package
@@ -7737,6 +7827,15 @@
    tests: false
    tasks: needs tests
    updated: 2024-07-17
+
+ - name: polynom
+   type: package
+   status: currently-incompatible
+   included-in: [arxiv001]
+   priority: 7
+   issues: [612]
+   tests: true
+   updated: 2024-08-20
 
  - name: postnotes
    type: package
@@ -8488,13 +8587,12 @@
 
  - name: shapepar
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in: [arxiv001]
    priority: 7
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   issues: [630]
+   tests: true
+   updated: 2024-08-20
 
  - name: shellesc
    type: package
@@ -8503,6 +8601,15 @@
    priority: 2
    issues:
    updated: 2024-07-07
+
+ - name: shorttoc
+   type: package
+   status: currently-incompatible
+   included-in: [arxiv001]
+   priority: 7
+   issues: [610]
+   tests: true
+   updated: 2024-08-20
 
  - name: shortvrb
    type: package
@@ -8635,13 +8742,12 @@
 
  - name: skak
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in: [arxiv001]
    priority: 7
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-28
+   issues: [607]
+   tests: true
+   updated: 2024-08-20
 
  - name: slantsc
    type: package
@@ -9047,13 +9153,12 @@
 
  - name: svn-prov
    type: package
-   status: unknown
+   status: compatible
    included-in: [arxiv001]
    priority: 7
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-08-14
+   updated: 2024-08-20
 
  - name: systeme
    type: package
@@ -9601,6 +9706,15 @@
    tests: true
    updated: 2024-08-06
 
+ - name: titlefoot
+   type: package
+   status: currently-incompatible
+   included-in: [arxiv001]
+   priority: 7
+   issues: [611]
+   tests: true
+   updated: 2024-08-20
+
  - name: titleps
    type: package
    status: compatible
@@ -10083,6 +10197,15 @@
    issues: [5]
    updated: 2024-07-06
 
+ - name: usebib
+   type: package
+   status: compatible
+   included-in:
+   priority: 9
+   issues:
+   tests: true
+   updated: 2024-08-20
+
  - name: utopia
    type: package
    status: compatible
@@ -10424,6 +10547,15 @@
    comments: "Drawn rules should be tagged as Artifacts."
    tests: true
    updated: 2024-07-26
+
+ - name: xindex
+   type: package
+   status: compatible
+   included-in:
+   priority: 9
+   issues:
+   tests: true
+   updated: 2024-08-20
 
  - name: xint
    type: package

--- a/tagging-status/testfiles/alnumsec/alnumsec-01.tex
+++ b/tagging-status/testfiles/alnumsec/alnumsec-01.tex
@@ -1,0 +1,29 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+
+\usepackage{alnumsec}
+\usepackage{hyperref}
+
+\title{alnumsec tagging test}
+
+\alnumsecstyle{RLg}
+\surroundLetter{[}{]}
+
+\begin{document}
+
+\tableofcontents
+
+\section{Some section}
+\subsection{Some subsection}
+\subsubsection{Some subsubsection}\label{sssec}
+Normal text
+\section{Another section}
+
+Subsubsection \ref{sssec}
+\end{document}

--- a/tagging-status/testfiles/autonum/autonum-01.tex
+++ b/tagging-status/testfiles/autonum/autonum-01.tex
@@ -1,0 +1,25 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+
+\usepackage{autonum}
+
+\title{autonum tagging test}
+
+\begin{document}
+
+\begin{equation}\label{a}
+a
+\end{equation}
+\begin{equation}\label{b}
+b
+\end{equation}
+
+\ref{a}
+
+\end{document}

--- a/tagging-status/testfiles/collref/collref-01.tex
+++ b/tagging-status/testfiles/collref/collref-01.tex
@@ -1,0 +1,23 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage[parsep]{collref}
+%\usepackage{hyperref}
+
+\title{collref tagging test}
+
+\begin{document}
+
+\cite{inbook-full}
+
+\cite{article-full,whole-set,manual-full}
+
+\bibliographystyle{unsrt}
+\bibliography{xampl}
+
+\end{document}

--- a/tagging-status/testfiles/delimset/delimset-01.tex
+++ b/tagging-status/testfiles/delimset/delimset-01.tex
@@ -1,0 +1,144 @@
+% taken from delimset doc
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass[12pt]{article}
+
+\usepackage[margin=2cm]{geometry}
+\usepackage{amsmath,amsfonts}
+\usepackage{delimset}
+
+\title{delimset tagging test}
+
+\begin{document}
+
+sizes for default brackets:
+\[
+\brk^0{x},\quad
+\brk^1{x},\quad
+\brk^2{x},\quad
+\brk^3{x},\quad
+\brk^4{x}
+\]
+
+styles for default brackets:
+\[
+\brk[r]{x},\quad
+\brk[s]{x},\quad
+\brk[c]{x},\quad
+\brk[a]{x}
+\]
+
+nested brackets:
+\[
+\brk[c]^2{\brk[s]!{\brk{ax+b}x+c}x+d}
+\]
+
+default absolute value, norm and default evaluations:
+\[
+\abs*{\frac{ax+b}{cx+d}},\qquad
+\norm*{\frac{ax+b}{cx+d}},\qquad
+\eval*{\frac{ax+b}{cx+d}}_{x=0},\qquad
+\eval[s]*{\frac{ax+b}{cx+d}}_{x=0}^{x=\infty}
+\]
+
+outer delimiter spacing:
+\begin{align*}
+&\square\brk^0{x}\square,&&\square\brk^1{A^k}\square,
+\\
+&\square\brk*{x}\square,&&\square\brk*{A^k}\square
+\end{align*}
+
+delimiter sizes in exponents:
+\[
+e^{\brk{ax+b}},\qquad
+e^{\brk!{ax+b}}
+\]
+
+delimiter declaration:
+\DeclareMathDelimiterSet{\braket}[2]
+  {\selectdeliml<#1\selectdelim|#2\selectdelimr>}
+\[
+\braket!{\psi}{\psi},
+\quad
+\braket*{\psi}{\psi\big.}
+\]
+
+delimiter usage:
+\[
+\delimpair<|>!{\psi}{\psi}
+\]
+
+conditional set, alternative layouts:
+\[
+\delimpair\{{[m]|}\}!{2n}{n\in\mathbb{Z}},
+\quad
+\delimpair\{{[b]|}\}!{2n}{n\in\mathbb{Z}},
+\quad
+\delimpair\{{[i]|}\}!{2n}{n\in\mathbb{Z}},
+\quad
+\delimpair\{{[p]|}\}!{2n}{n\in\mathbb{Z}},
+\quad
+\delimpair\{|\}!{2n}{n\in\mathbb{Z}},
+\quad
+\delimpair\{{*;}\}!{2n}{n\in\mathbb{Z}}
+\]
+conditional set, alternative layouts with variable size:
+\[
+\delimpair\{{[m]|}\}*{2n}{n\in\mathbb{Z}\big.},
+\quad
+\delimpair\{{[b]|}\}*{2n}{n\in\mathbb{Z}\big.},
+\quad
+\delimpair\{{[i]|}\}*{2n}{n\in\mathbb{Z}\big.},
+\quad
+\delimpair\{{[p]|}\}*{2n}{n\in\mathbb{Z}\big.},
+\quad
+\delimpair\{|\}*{2n}{n\in\mathbb{Z}\big.},
+\quad
+\delimpair\{{*;}\}*{2n}{n\in\mathbb{Z}\big.}
+\]
+
+delimiter definition:
+\newcommand{\comm}{\delimpair[{*,}]}
+\[
+\comm!{\comm{A}{B}}{C}
++\comm!{\comm{B}{C}}{A}
++\comm!{\comm{C}{A}}{B}
+=0
+\]
+
+alternative representation:
+\renewcommand{\comm}{\delimpair[{*;}]}
+\[
+\comm!{\comm{A}{B}}{C}
++\comm!{\comm{B}{C}}{A}
++\comm!{\comm{C}{A}}{B}
+=0
+\]
+
+display individual delimiters of a set:
+\renewcommand{\braket}{\delimpair<|>}
+\[
+\braket{A}{B}
+\to \braket( A \braket| B \braket),
+\quad
+\braket*( A\big. \braket*| B_{} \braket*),
+\quad
+\braket^1( A \braket^3| B \braket^2)
+\]
+
+placing indices before a bracket
+(does not work in variable-size mode because
+the final size is not available for the enclosed expressions):
+\DeclareMathDelimiterSet{\quadindex}[5]
+  {\selectdeliml.^{#2}_{#3}\mathord{}\selectdelim[o][
+  {#1}\selectdelim[o]]^{#4}_{#5}\selectdelimr.}
+\[
+\quadindex^2{\frac{x}{y}}{1}{2}{3}{4}
+\]
+
+\end{document}

--- a/tagging-status/testfiles/dirtree/dirtree-01.tex
+++ b/tagging-status/testfiles/dirtree/dirtree-01.tex
@@ -1,0 +1,40 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{dirtree}
+
+\title{dirtree tagging test}
+
+\begin{document}
+
+\dirtree{%
+.1 /.
+.2 bin.
+.2 home.
+.3 jeancome.
+.4 texmf.
+.5 tex.
+.6 latex.
+.7 dirtree.
+.3 jeancomeson.
+.3 jeancomedaughter.
+.2 usr.
+.3 bin.
+.3 games.
+.4 fortunes.
+.3 include.
+.3 local.
+.4 bin.
+.4 share.
+.5 texmf.
+.6 fonts.
+.6 metapost.
+.6 tex.
+.3 share.
+}
+\end{document}

--- a/tagging-status/testfiles/fge/fge-01.tex
+++ b/tagging-status/testfiles/fge/fge-01.tex
@@ -1,0 +1,57 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+
+\usepackage{fge}
+
+\title{fge tagging test}
+
+\begin{document}
+
+$\spirituslenis{\alpha}$\par
+$\spiritusasper{\alpha}$
+
+\ExplSyntaxOn
+\tl_map_inline:nn
+  {
+    \fgerighttwo
+    \fgerightB
+    \fgelefttwo
+    \fgeleftthree
+    \fgeleftB
+    \fgeleftC
+    \fgec
+    \fgee
+    \fgeeszett
+    \fgeA
+    \fged
+    \fgef
+    \fgeF
+    \fgestruckzero
+    \fgestruckone
+    \fgerightarrow
+    \fgeuparrow
+    \fgeupbracket
+    \fgecap
+    \fgecup
+    \fgecupbar
+    \fgecapbar
+    \fgebarcap
+    \fgecupacute
+    \fgebaracute
+    \fgemark
+    \fgelb
+    \fgeinfty
+    \fgelangle
+    \fges
+    \fgebackslash
+  }
+  { $#1$ \quad \cs_to_str:N #1 \par }
+\ExplSyntaxOff
+
+\end{document}

--- a/tagging-status/testfiles/ftnxtra/ftnxtra-01.tex
+++ b/tagging-status/testfiles/ftnxtra/ftnxtra-01.tex
@@ -1,0 +1,27 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+
+\usepackage{ftnxtra}
+
+\title{ftnxtra tagging test}
+
+\begin{document}
+
+text\footnote{a normal footnote}
+
+\begin{tabular}{cc}
+A & B\footnote{a tabular footnote}
+\end{tabular}
+
+\begin{figure}
+Figure content
+\caption{Some figure\footnote{a caption footnote}}
+\end{figure}
+
+\end{document}

--- a/tagging-status/testfiles/multienum/multienum-01.tex
+++ b/tagging-status/testfiles/multienum/multienum-01.tex
@@ -1,0 +1,27 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+
+\usepackage{multienum}
+
+\title{multienum tagging test}
+
+\begin{document}
+
+\begin{multienumerate}
+\mitemxxxx{Not}{Linear}{Not}{Quadratic}
+\mitemxxxo{Not}{Linear}{Not}
+\mitemxx{$(x_1,x_2)=(2+\frac{1}{3}t,t)$ or
+$(s,3s-6)$}{$(x_1,x_2,x_3)=(2+\frac{5}{2}s-3t,s,t)$}
+\mitemx{$(x_1,x_2,x_3,x_4)=
+(\frac{1}{4}+\frac{5}{4}s+\frac{3}{4}t-u,s,t,u)$
+or $(s,t,u,\frac{1}{4}-s+\frac{5}{4}t+\frac{3}{4}u)$}
+\mitemxxxx{$(2,-1,3)$}{None}{$(2,1,0,1)$}{$(0,0,0,0)$}
+\end{multienumerate}
+
+\end{document}

--- a/tagging-status/testfiles/numerica-tables/numerica-tables-01.tex
+++ b/tagging-status/testfiles/numerica-tables/numerica-tables-01.tex
@@ -1,0 +1,16 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,title,math,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{numerica}
+\usepackage{numerica-tables}
+
+\title{numerica-tables tagging test}
+
+\begin{document}
+\tabulate[rvar=x,rstep=0.2,rstop=1]{\sin x}[x=0]
+\end{document}

--- a/tagging-status/testfiles/pbox/pbox-01.tex
+++ b/tagging-status/testfiles/pbox/pbox-01.tex
@@ -1,0 +1,20 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,title,math,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{pbox}
+
+\title{pbox tagging test}
+
+\begin{document}
+\pbox[b]{0.5\textwidth}{Hello\\World!}%
+\pbox[t]{0.5\textwidth}{Bonjour\\monde!}
+
+% compare with
+\parbox[b]{1.5cm}{Hello\\World!}%
+\parbox[t]{1.5cm}{Bonjour\\monde!}
+\end{document}

--- a/tagging-status/testfiles/polynom/polynom-01.tex
+++ b/tagging-status/testfiles/polynom/polynom-01.tex
@@ -1,0 +1,25 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{polynom}
+
+\title{polynom tagging test}
+
+\begin{document}
+
+\polylongdiv{X^3+X^2-1}{X-1}
+
+\polyhornerscheme[x=1]{x^3+x^2-1}
+
+\polylonggcd{(X-1)(X-1)(X^2+1)}{(X-1)(X+1)(X+1)}
+
+\polyfactorize{(X-1)(X-1)(X^2+1)}
+
+$(X^2+1)(X-1)^2$
+
+\end{document}

--- a/tagging-status/testfiles/shapepar/shapepar-01.tex
+++ b/tagging-status/testfiles/shapepar/shapepar-01.tex
@@ -1,0 +1,49 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+
+\usepackage{shapepar}
+
+\title{shapepar tagging test}
+
+\begin{document}
+
+\shapepar{\nutshape} blah blah blah blah blah blah blah blah blah blah blah blah blah blah
+blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah
+
+\bigskip
+
+\squarepar{blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah
+blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah
+blah blah blah blah blah blah blah blah blah}
+
+\Shapepar{\circleshape} blah blah blah blah blah blah blah blah blah blah blah blah blah
+blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah
+blah blah blah blah blah blah blah blah blah blah blah blah
+
+\bigskip
+
+\font\cmsybig=cmsy10 at 1.2in
+\newcommand\BigO{{\cmsybig \char10}}
+\cutout{r}(-1cm,2\baselineskip)
+\setlength\cutoutsep{6pt}
+\shapepar[1.7cm]{\circleshape}%
+\setlength\unitlength{1cm}%
+\begin{picture}[alt=big O](0,0)%
+\put(1.0,-1.3){\makebox[0pt]{\BigO}}
+\end{picture}
+
+blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah
+blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah
+blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah
+blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah
+blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah
+blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah
+blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah
+
+\end{document}

--- a/tagging-status/testfiles/shorttoc/shorttoc-01.tex
+++ b/tagging-status/testfiles/shorttoc/shorttoc-01.tex
@@ -1,0 +1,24 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{shorttoc}
+
+\title{shorttoc tagging test}
+
+\begin{document}
+
+\shorttableofcontents{Short Contents}{1}
+\tableofcontents
+
+\section{Some section}
+\subsection{Some subsection}
+\subsubsection{Some subsubsection}
+
+\section{Another section}
+
+\end{document}

--- a/tagging-status/testfiles/skak/skak-01.tex
+++ b/tagging-status/testfiles/skak/skak-01.tex
@@ -1,0 +1,31 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{skak}
+
+\title{skak tagging test}
+
+\begin{document}
+
+\newgame
+\mainline{1.e4 e5 2. Nf3 Nc6 3.Bb5}
+
+\showboard
+
+\newgame
+\styleC
+
+\mainline{1.e4 c5 2.Nf3 Nc6}
+
+\wupperhand
+
+\devadvantage
+
+\samebishops
+
+\end{document}

--- a/tagging-status/testfiles/titlefoot/titlefoot-01.tex
+++ b/tagging-status/testfiles/titlefoot/titlefoot-01.tex
@@ -1,0 +1,23 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{titlefoot}
+
+\title{titlefoot tagging test}
+\author{Some author}
+\keywords{tagging, titlefoot}
+\runningtitle{A test for the titlefoot package}
+\amssubj{<enter classification>}
+
+\begin{document}
+
+\maketitle
+
+Some body text
+
+\end{document}

--- a/tagging-status/testfiles/usebib/usebib-01.tex
+++ b/tagging-status/testfiles/usebib/usebib-01.tex
@@ -1,0 +1,36 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\begin{filecontents}{usebib-test.bib}
+@book{newton1687,
+author={Newton, Isaac},
+title={Philosophiae Naturalis Principia Mathematica},
+publisher={Royal Society},
+address={London},
+year={1687},
+url={http://royalsociety.org},
+}
+\end{filecontents}
+\documentclass{article}
+
+\usepackage{hyperref}
+\usepackage{usebib}
+
+\title{usebib tagging test}
+
+\newbibfield{publisher}
+\newbibfield{address}
+\bibinput{usebib-test}
+
+\begin{document}
+
+\cite{newton1687} published by the \usebibentry{newton1687}{publisher} of \usebibentry{newton1687}{address}. See \usebibentryurl{newton1687}.
+
+\bibliographystyle{amsalpha}
+\bibliography{usebib-test}
+
+\end{document}

--- a/tagging-status/testfiles/xindex/xindex-01.tex
+++ b/tagging-status/testfiles/xindex/xindex-01.tex
@@ -1,0 +1,32 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+
+\usepackage{makeidx}
+\makeindex
+\usepackage{xindex}
+\usepackage{hyperref}
+
+\begin{document}
+
+\section{Escaping characters}
+\begin{itemize}
+\item Exclamation mark ! \index{Exclamation ("!)}\index{"!}
+\item Vertical bar | \index{Vertical bar ("|)}\index{"|}
+\item Doublequote \verb|"| \index{""}
+\item Double doublequote \verb|""| \index{""""}
+\item At character @ \index{At ("@)}\index{"@}
+\item Left parenthesis \{ \index{\braceLeft}
+\item Right parenthesis \} \index{\braceRight}
+\end{itemize}
+run \texttt{xindex -l fr <file.idx>}\index{file.idx@\texttt{<file.idx>}|textit}\index{123}
+\index{Etage} \index{Ètagé}
+
+\printindex
+
+\end{document}


### PR DESCRIPTION
Lists alnumsec, delimset, fge, usebib, and xindex as compatible with tests.

Lists fp, lcg, moreenum, and svn-prov as compatible without tests.

Lists autonum, collref, dirtree, ftnxtra, multienum, numerica-tables, pbox, polynom, shapepar, shorttoc, skak, and titlefoot as currently-incompatible with links to issues and tests.

Lists floatrow as no-support.

Fixes the priority for duckuments.