### PR TITLE
add eepic compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -2753,13 +2753,13 @@
 
  - name: eepic
    type: package
-   status: unknown
+   status: compatible
    included-in: [tlc3, arxiv01]
    priority: 2
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-14
+   tests: true
+   comments: "Does not work with pdflatex or lualatex."
+   updated: 2024-08-21
 
  - name: eforms
    type: package

--- a/tagging-status/testfiles/eepic/eepic-01.tex
+++ b/tagging-status/testfiles/eepic/eepic-01.tex
@@ -1,0 +1,35 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{eepic,epic}
+
+\begin{document}
+
+text
+
+\begin{picture}[alt=an ellipse](100,100)
+  \Thicklines
+  \put(50,50){\ellipse{80}{60}}
+  \thicklines
+  \dashline{4}(0,50)(100,50)
+  \dashline{4}(50,0)(50,100)
+\end{picture}
+
+\setlength{\unitlength}{1mm}
+\begin{picture}[alt=](100,100)(0,0)
+\put(0,0){\tiny \grid(100,100)(5,5)[0,0]}
+\drawline(10,5)(60,10)(85,20)(90,60)(100,95)
+\drawline[-50](10,0)(65,5)(90,15)(95,55)
+\thicklines
+\dottedline{1.4}(10,10)(60,20)(75,35)(95,95)
+\dashline{2}(80,90)(50,80)(30,50)(10,40)
+\dashline{2}[0.5](80,80)(50,70)(30,40)(10,30)
+\dashline[-30]{2}[0.5](80,70)(50,60)(30,30)(10,20)
+\end{picture}
+
+\end{document}


### PR DESCRIPTION
Lists eepic as compatible, though it only works with latex+dvips/dvipdfmx or xelatex, neither of which give good tagging. So let me know if status should be different.