### PR TITLE
add incompatible packages

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -1432,13 +1432,13 @@
 
  - name: breakurl
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in: [arxiv1]
    priority: 5
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   issues: [645]
+   tests: true
+   comments: "Requires latex->dvips->ps2pdf."
+   updated: 2024-08-22
 
  - name: breqn
    type: package
@@ -1892,13 +1892,12 @@
 
  - name: chessfss
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in:
    priority: 9
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-28
+   issues: [634]
+   tests: true
+   updated: 2024-08-22
 
  - name: chicago
    type: package
@@ -2384,13 +2383,12 @@
 
  - name: dashbox
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in: [arxiv001]
    priority: 7
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-08-14
+   issues: [650
+   tests: true
+   updated: 2024-08-22
 
  - name: dashrule
    type: package
@@ -3024,13 +3022,12 @@
 
  - name: eqparbox
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in: [arxiv01]
    priority: 6
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   issues: [633]
+   tests: true
+   updated: 2024-08-22
 
  - name: erewhon
    type: package
@@ -3442,13 +3439,12 @@
 
  - name: figcaps
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in:
    priority: 9
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   issues: [643]
+   tests: true
+   updated: 2024-08-22
 
  - name: filecontentsdef
    type: package
@@ -3902,13 +3898,14 @@
 
  - name: framed
    type: package
-   status: partially-compatible
+   status: currently-incompatible
    included-in: [arxiv1]
    priority: 5
-   comments: "Title in `titled-frame` environment is lost."
-   issues:
+   comments: "Title in `titled-frame` environment is lost. Content after page
+              break is lost with pdftex and xetex."
+   issues: [651]
    tests: true
-   updated: 2024-07-21
+   updated: 2024-08-22
 
  - name: frcursive
    type: package
@@ -6261,13 +6258,12 @@
 
  - name: minitoc
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in: [arxiv01]
    priority: 6
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   issues: [649]
+   tests: true
+   updated: 2024-08-22
 
  - name: minted
    type: package
@@ -6397,6 +6393,15 @@
    issues:
    tests: true
    updated: 2024-08-05
+
+ - name: multibibliography
+   type: package
+   status: currently-incompatible
+   included-in:
+   priority: 9
+   issues: [637]
+   tests: true
+   updated: 2024-08-22
 
  - name: multicol
    type: package
@@ -6843,13 +6848,12 @@
 
  - name: nmbib
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in:
    priority: 9
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-28
+   issues: [638]
+   tests: true
+   updated: 2024-08-22
 
  - name: nolbreaks
    type: package

--- a/tagging-status/testfiles/breakurl/breakurl-01.tex
+++ b/tagging-status/testfiles/breakurl/breakurl-01.tex
@@ -1,0 +1,12 @@
+\DocumentMetadata{}
+\documentclass{article}
+\usepackage{hyperref}
+\usepackage{breakurl}
+
+\begin{document}
+
+text
+
+\url{https://mirrors.mit.edu/CTAN/macros/latex/contrib/breakurl/breakurl.pdf}
+
+\end{document}

--- a/tagging-status/testfiles/chessfss/chessfss-01.tex
+++ b/tagging-status/testfiles/chessfss/chessfss-01.tex
@@ -1,0 +1,86 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{chessfss}
+\usepackage[LSB,LSBC3,T1]{fontenc}
+\usepackage{xcolor}
+
+\title{chessfss tagging test}
+
+\begin{document}
+
+\ExplSyntaxOn
+\tl_map_inline:nn
+  {
+    \king
+    \queen
+    \rook
+    \bishop
+    \knight
+    \pawn
+    \checksymbol
+    \castlinghyphen
+    \withattack
+    \withinit
+    \zugzwang
+    \withidea
+    \onlymove
+    \diagonal
+    \file
+    \centre
+    \weakpt
+    \ending
+    \qside
+    \kside
+    \etc
+    \morepawns
+    \timelimit
+    \moreroom
+    \counterplay
+    \capturesymbol
+    \bishoppair
+    \betteris
+    \wupperhand
+    \doublepawns
+    \bupperhand
+    \wbetter
+    \bbetter
+    \wdecisive
+    \bdecisive
+    \unclear
+    \chesssee
+    \mate
+    \compensation
+    \opposbishops
+    \seppawns
+    \passedpawn
+    \samebishops
+    \devadvantage
+    \unitedpawns
+    \with
+    \without
+    \comment
+    \castlingchar
+    \longcastling
+    \shortcastling
+    \novelty
+    \various
+  }
+  { #1 \quad \cs_to_str:N #1 \par }
+\ExplSyntaxOff
+
+\setboardfontcolors{
+  blackfieldmask=blue!30,
+  whitefieldmask=yellow!50,
+  blackfield=blue,
+  whiteonwhitepiecemask=red!50,
+  whitepiece=green,
+  blackpiece=gray}
+\setboardfontsize{30pt}%
+\showchessboardencoding{LSBC3}
+\end{document}

--- a/tagging-status/testfiles/dashbox/dashbox-01.tex
+++ b/tagging-status/testfiles/dashbox/dashbox-01.tex
@@ -1,0 +1,27 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{dashbox}
+
+\title{dashbox tagging test}
+
+\begin{document}
+
+\dbox{text}
+
+\dashbox[0.5\textwidth]{text}
+
+\lbox{\fbox{text}}
+
+\lbox[5]{\fbox{text}}
+
+\dlbox{\dbox{text}}
+
+\dlbox[5]{\dbox{text}}
+
+\end{document}

--- a/tagging-status/testfiles/eqparbox/eqparbox-01.tex
+++ b/tagging-status/testfiles/eqparbox/eqparbox-01.tex
@@ -1,0 +1,43 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{eqparbox}
+
+\title{eqparbox tagging test}
+
+\begin{document}
+
+\eqparbox{tag}{text}
+
+% real example
+
+%\eqparbox{place}{\textbf{Widgets, Inc.}} \hfill
+%\eqparbox{title}{\textbf{Senior Widget Designer}} \hfill
+%\eqparbox{dates}{\textbf{1/95--present}}
+%
+%\begin{itemize}
+%\item Supervised the development of the new orange and blue widget lines.
+%\item Improved the design of various widgets, making them less sticky
+%     and far less likely to explode.
+%\item Made widget management ten times more cost-effective.
+%\end{itemize}
+%
+%\noindent
+%\eqparbox{place}{\textbf{Thingamabobs, Ltd.}} \hfill
+%\eqparbox{title}{\textbf{Lead Engineer}} \hfill
+%\eqparbox{dates}{\textbf{9/92--12/94}}
+%
+%\begin{itemize}
+%\item Found a way to make thingamabobs run on solar power.
+%\item Drafted a blueprint for a new doohickey-compatibility module for
+%     all cool-mint thingamabobs.
+%\item Upgraded superthingamabob specification document from Microsoft
+%     Word to \LaTeXe.
+%\end{itemize}
+
+\end{document}

--- a/tagging-status/testfiles/figcaps/figcaps-01.tex
+++ b/tagging-status/testfiles/figcaps/figcaps-01.tex
@@ -1,0 +1,46 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,title,math,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{longtable}
+\usepackage{figcaps}
+
+\title{figcaps tagging test}
+
+\printfigures
+\figmarkon
+
+\begin{document}
+
+text
+\begin{figure}\centering
+First figure
+\caption{This is the first figure}
+\end{figure}
+\begin{longtable}{cc}
+\caption{A not-so-long table}\\
+A & B \\
+C & D
+\end{longtable}
+\begin{figure}\centering
+Second figure
+\caption{This is the second figure}
+\end{figure}
+\begin{table}\centering
+Some table
+\caption{This is a table}
+\end{table}
+\begin{figure}\centering
+Third figure
+\caption{This is the third figure}
+\end{figure}
+\begin{table}\centering
+Some other table
+\caption{This is another table}
+\end{table}
+
+\end{document}

--- a/tagging-status/testfiles/framed/framed-02.tex
+++ b/tagging-status/testfiles/framed/framed-02.tex
@@ -1,0 +1,20 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{framed}
+\usepackage{kantlipsum}
+
+\title{framed tagging test - 2}
+
+\begin{document}
+
+\begin{framed}
+\kant[1-6]
+\end{framed}
+
+\end{document}

--- a/tagging-status/testfiles/minitoc/minitoc-01.tex
+++ b/tagging-status/testfiles/minitoc/minitoc-01.tex
@@ -1,0 +1,31 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{report}
+\usepackage{minitoc}
+\usepackage{kantlipsum}
+
+\title{minitoc tagging test}
+
+\begin{document}
+\dominitoc
+\tableofcontents
+\chapter{Primum capitulum}
+\minitoc
+\section{Prima sectio}
+\kant[1-2]
+\section{Secunda sectio}
+\kant[3-4]
+\chapter{Secundum capitulum}
+\minitoc
+\section{Prima sectio}
+\kant[5-6]
+\section{Secunda sectio}
+\kant[7-8]
+\section{Tertia sectio}
+\kant[9-10]
+\end{document}

--- a/tagging-status/testfiles/multibibliography/multibibliography-01.tex
+++ b/tagging-status/testfiles/multibibliography/multibibliography-01.tex
@@ -1,0 +1,16 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+
+\usepackage{multibibliography}
+
+\title{multibibliography tagging test}
+
+\begin{document}
+text
+\end{document}

--- a/tagging-status/testfiles/nmbib/nmbib-01.tex
+++ b/tagging-status/testfiles/nmbib/nmbib-01.tex
@@ -1,0 +1,143 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\begin{filecontents}[noheader]{nmbib.bib}
+@Manual{Multibibliography,
+  title = 	 {The {M}ultibiliography package},
+  author =	 {Michael Cohen and Yannis Haralambous and Boris Veytsman},
+  month =	 {March},
+  year =	 2013,
+  note =	 {\url{http://www.ctan.org/pkg/multibibliography}}
+}
+
+@Article{Multibibliography13,
+  author = 	 {Michael Cohen and Yannis Haralambous and Boris Veytsman},
+  title = 	 {The multibibliography package},
+  journal = 	 {TUGboat},
+  year = 	 2013,
+  volume =	 34,
+  number =	 3,
+  pages =	 {340--343},
+  note =	 {\url{https://www.tug.org/members/TUGboat/tb34-3/tb108cohen.pdf}}
+}
+
+@Manual{Daly:Natbib,
+  title = 	 {Natural Sciences Citations and References
+                  (Author-Year and Numerical Schemes)},
+  author =	 {Patrick W. Daly},
+  month =	 {February},
+  year =	 2009,
+  note =	 {\url{http://mirrors.ctan.org/macros/latex/contrib/natbib}}
+}
+
+@Manual{Rahtz:Hyperref,
+  title = 	 {Hypertext Marks in \LaTeX: a Manual for Hyperref},
+  author =	 {Sebastian Rahtz and Heiko Oberdiek},
+  month =	 {November},
+  year =	 2012,
+  note =	 {\url{http://mirrors.ctan.org/macros/latex/contrib/hyperref}}
+}
+\end{filecontents}
+\begin{filecontents}[noheader]{type.bib}
+@string{TUB = "TUGboat: Communications of the {\TeX} Users Group"}
+@string{TUG = "TUG: {\TeX} Users Group Meeting"}
+
+@misc{Daly:Customizing_Bibliographic_Style_Files,
+	author = "Patrick W. Daly",
+	year = "2007",
+	title = "Customizing Bibliographic Style Files",
+	note = "\url{http://mirrors.ctan.org/macros/latex/contrib/custom-bib/makebst.pdf}"
+}
+
+@misc{Daly:merlin.mbs,
+	author = "Patrick W. Daly",
+	year = "2011",
+	month = oct,
+	title = "{A Master Bibliographic Style File for numerical, author--year, multilingual applications}",
+	note = "\url{http://mirrors.ctan.org/macros/latex/contrib/custom-bib/merlin.pdf} v.\,4.33"
+}
+
+@book{kopka03,
+	ISBN = {0-321-17385-6},
+	keywords = {Typography, LaTeX, Word Processing},
+	year = {2003},
+	author = {Helmut Kopka and Patrick W. Daly},
+	title = {Guide to LaTeX},
+	pages = {624},
+	edition = {4th},
+	publisher = {Addison-Wesley Professional}
+}
+
+@misc{Markey:Tame_the_BeaST,
+	author = "Nicolas Markey",
+	year = "2009",
+	month = oct,
+	title = "{Tame the BeaST: The B to X of Bib{\TeX}}",
+	note = "\url{http://mirrors.ctan.org/info/bibtex/tamethebeast/ttb_en.pdf}, v.\,1.4"
+}
+
+@article{Mori:Managing_bibliographies,
+	author = "Lapo F. Mori",
+	journal = TUG,
+	volume = 30,
+	number = 1,
+	year = 2009,
+	pages = "36-48",
+	title = "Managing bibliographies with {\LaTeX}"
+}
+
+@misc{Patashnik:bibtexing,
+	author = "Oren Patashnik",
+	year = "1998",
+	title = "Bib{\TeX}ing",
+	note = "\url{http://mirrors.ctan.org/biblio/bibtex/contrib/doc/btxdoc.pdf}"
+}
+\end{filecontents}
+\documentclass{article}
+\usepackage{nmbib}
+\usepackage{hyperref}
+\multibibliographystyle{timeline}{chronoplainnm}
+\multibibliographystyle{sequence}{unsrtnm}
+\multibibliographystyle{authors}{plainnm}
+\multibibliography{type,nmbib}
+
+\title{nmbib tagging test}
+
+\begin{document}
+
+\citep{Daly:Customizing_Bibliographic_Style_Files}
+
+\citet{kopka03}
+
+\citeauthor{Daly:Natbib}
+
+\citeyear{Mori:Managing_bibliographies}
+
+\citenum{Patashnik:bibtexing}
+
+\citealn{Multibibliography}
+
+\citeall{Markey:Tame_the_BeaST}
+
+\citep{Multibibliography, Multibibliography13}
+
+\citeall{Multibibliography,Multibibliography13}
+
+\citeall*{Multibibliography, Multibibliography13}
+
+\nmbibLink{Daly:Natbib}{authors}{Daly's package in the alphabetic list}
+
+\nmbibLink{kopka03}{sequence}{Kopka and Daly's book in the sequential list}.
+
+\clearpage
+\printbibliography{timeline}
+\clearpage
+\printbibliography{sequence}
+\clearpage
+\printbibliography{authors}
+
+\end{document}


### PR DESCRIPTION
Lists breakurl, chessfss, dashbox, eqparbox, figcaps, minitoc, multibibliography, and nmbib as incompatible with tests and links to issues.

Changes the status of framed from partially-compatible to currently-incompatible.