### PR TITLE
add several packages

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -125,13 +125,13 @@
 
  - name: abstract
    type: package
-   status: unknown
+   status: partially-compatible
    included-in: [tlc3, arxiv01]
    priority: 2
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-13
+   issues: [653]
+   tests: true
+   comments: Tagging is not ideal.
+   updated: 2024-08-23
 
  - name: academicons
    type: package
@@ -802,13 +802,12 @@
 
  - name: authblk
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in: [tlc3, arxiv1]
    priority: 2
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-13
+   issues: [654]
+   tests: true
+   updated: 2024-08-23
 
  - name: authordate1-4
    ctan-pkg: authordate
@@ -1175,13 +1174,12 @@
 
  - name: biblatex2bibitem
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in: [tlc3]
    priority: 2
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-14
+   issues: [655]
+   tests: true
+   updated: 2024-08-23
 
  - name: biblist
    type: package
@@ -2527,6 +2525,16 @@
    tests: true
    updated: 2024-08-05
 
+ - name: dialogue
+   type: package
+   status: unknown
+   included-in: [arxiv001]
+   priority: 7
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-08-23
+
  - name: diffcoeff
    type: package
    status: compatible
@@ -3011,6 +3019,16 @@
    tests: true
    updated: 2024-08-02
 
+ - name: eqlist
+   type: package
+   status: currently-incompatible
+   included-in: [arxiv001]
+   priority: 7
+   issues:
+   tests: true
+   comments: "Depends on incompatible eqparbox."
+   updated: 2024-08-23
+
  - name: eqnarray
    type: package
    status: currently-incompatible
@@ -3120,13 +3138,12 @@
 
  - name: ethiop
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in: [tlc3]
    priority: 2
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-14
+   issues: [656]
+   tests: true
+   updated: 2024-08-23
 
  - name: etoc
    type: package
@@ -3398,24 +3415,32 @@
 
  - name: feynmf
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in: [arxiv01]
    priority: 6
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-08-01
+   issues: [659]
+   tests: true
+   updated: 2024-08-23
 
  - name: feynmp
    ctan-pkg: feynmf
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in: [arxiv01]
    priority: 6
+   issues: [659]
+   tests: true
+   updated: 2024-08-23
+
+ - name: feynmp-auto
+   type: package
+   status: currently-incompatible
+   included-in: [arxiv001]
+   priority: 7
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-08-01
+   tests: true
+   comments: "See feynmp."
+   updated: 2024-08-23
 
  - name: fge
    type: package
@@ -4054,6 +4079,16 @@
    tests: false
    updated: 2024-07-14
 
+ - name: gastex
+   type: package
+   status: unknown
+   included-in: [arxiv001]
+   priority: 7
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-08-23
+
  - name: gb4e
    type: package
    status: unknown
@@ -4316,6 +4351,16 @@
    comments: "No way to add Alt text or Artifact status to `mpost` figures used
               directly. This can be done with `\\usempost`, however."
    updated: 2024-08-20
+
+ - name: gnuplottex
+   type: package
+   status: unknown
+   included-in: [arxiv001]
+   priority: 7
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-08-23
 
  - name: grabbox
    type: package
@@ -6200,6 +6245,16 @@
    tests: true
    updated: 2024-07-31
 
+ - name: mfpic
+   type: package
+   status: unknown
+   included-in: [arxiv001]
+   priority: 7
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-08-23
+
  - name: mhchem
    type: package
    status: unknown
@@ -6467,6 +6522,16 @@
    tests: false
    tasks: needs tests
    updated: 2024-07-18
+
+ - name: multind
+   type: package
+   status: unknown
+   included-in: [arxiv001]
+   priority: 7
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-08-23
 
  - name: multirow
    type: package
@@ -6872,6 +6937,16 @@
    issues: [363]
    tests: true
    updated: 2024-07-30
+
+ - name: nonfloat
+   type: package
+   status: unknown
+   included-in: [arxiv001]
+   priority: 7
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-08-23
 
  - name: nonumonpart
    type: package
@@ -7868,6 +7943,16 @@
    issues: [612]
    tests: true
    updated: 2024-08-20
+
+ - name: polytable
+   type: package
+   status: unknown
+   included-in: [arxiv001]
+   priority: 7
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-08-23
 
  - name: postnotes
    type: package
@@ -10364,6 +10449,16 @@
 
 #------------------------ WWW ----------------------------
 
+ - name: wallpaper
+   type: package
+   status: unknown
+   included-in: [arxiv001]
+   priority: 7
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-08-23
+
  - name: warpcol
    type: package
    status: currently-incompatible
@@ -10382,6 +10477,16 @@
    issues: [272]
    tests: false
    updated: 2024-07-25
+
+ - name: watermark
+   type: package
+   status: unknown
+   included-in: [arxiv001]
+   priority: 7
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-08-23
 
  - name: widetable
    type: package

--- a/tagging-status/testfiles/abstract/abstract-01.tex
+++ b/tagging-status/testfiles/abstract/abstract-01.tex
@@ -1,0 +1,33 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\NewEnvironmentCopy{origabstract}{abstract}
+\usepackage[
+  %runin,
+  %addtotoc, % gives warning
+  %number
+  ]{abstract}
+
+\title{abstract tagging test}
+\author{Some author}
+
+\begin{document}
+
+\maketitle
+
+\begin{origabstract}
+Some abstract text
+\end{origabstract}
+
+\begin{abstract}
+Some abstract text
+\end{abstract}
+
+\tableofcontents
+
+\end{document}

--- a/tagging-status/testfiles/authblk/authblk-01.tex
+++ b/tagging-status/testfiles/authblk/authblk-01.tex
@@ -1,0 +1,24 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,table,title,firstaid}
+  }
+\documentclass{article}
+\usepackage{authblk}
+
+\title{authblk tagging test - 1}
+\author{Person A}
+\author{Person B}
+\affil{Uni 1}
+\author{Person C}
+\affil{Uni 2}
+
+\begin{document}
+
+\maketitle
+
+text
+
+\end{document}

--- a/tagging-status/testfiles/authblk/authblk-02.tex
+++ b/tagging-status/testfiles/authblk/authblk-02.tex
@@ -1,0 +1,24 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,table,title,firstaid}
+  }
+\documentclass{article}
+\usepackage{authblk}
+
+\title{authblk tagging test - 2}
+\author[1]{Person A}
+\author[1]{Person B}
+\affil[1]{Uni 1}
+\author[2]{Person C}
+\affil[2]{Uni 2}
+
+\begin{document}
+
+\maketitle
+
+text
+
+\end{document}

--- a/tagging-status/testfiles/biblatex2bibitem/biblatex2bibitem-01.tex
+++ b/tagging-status/testfiles/biblatex2bibitem/biblatex2bibitem-01.tex
@@ -1,0 +1,20 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage[style=numeric,backend=biber]{biblatex}
+\usepackage{biblatex2bibitem}
+
+\addbibresource{biblatex-examples.bib}
+
+\begin{document}
+\cite{sigfridsson,knuth:ct:e}
+
+\printbibliography
+
+\printbibitembibliography
+\end{document}

--- a/tagging-status/testfiles/eqlist/eqlist-01.tex
+++ b/tagging-status/testfiles/eqlist/eqlist-01.tex
@@ -1,0 +1,35 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{eqlist}
+
+\title{eqlist tagging test}
+
+\begin{document}
+
+\begin{eqlist}
+\item[First item] Text
+\item[Second item] Text
+\longitem[A special very long item] Text
+\end{eqlist}
+
+\begin{eqlist*}
+\item[First item] Text
+\item[Second item] Text
+\longitem[A special very long item] Text
+\end{eqlist*}
+
+\begin{eqlist}[\eqliststarinit
+\def\makelabel#1{\bfseries#1:}\labelsep1em\eqlistauto{3cm}]
+\item[Short label] Descriptive text
+\item[A longer label] Descriptive text
+\item[An exceptionally long label] Descriptive text
+\item[Short again] Descriptive text
+\end{eqlist}
+
+\end{document}

--- a/tagging-status/testfiles/ethiop/ethiop-01.tex
+++ b/tagging-status/testfiles/ethiop/ethiop-01.tex
@@ -1,0 +1,20 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage[english]{babel}
+\usepackage{ethiop}
+
+\title{ethiop tagging test}
+
+\begin{document}
+
+\selectlanguage{english}'adis 'ababA
+
+\selectlanguage{ethiop}'adis 'ababA
+
+\end{document}

--- a/tagging-status/testfiles/feynmf/feynmf-01.tex
+++ b/tagging-status/testfiles/feynmf/feynmf-01.tex
@@ -1,0 +1,33 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{feynmf}
+
+\title{feynmf/feynmp tagging test}
+
+\begin{document}
+
+\begin{fmffile}{tt1} % math in label disappears with math tagging code
+\begin{fmfgraph*}(40,30) \fmfpen{thick}
+\fmfleft{i1,i2} \fmfright{o1,o2}
+\fmf{fermion}{i1,v1,o1} \fmf{fermion}{i2,v2,o2}
+\fmf{photon,label=p$q$}{v1,v2} \fmfdot{v1,v2}
+\end{fmfgraph*}
+\end{fmffile}
+
+\bigskip
+
+\begin{fmffile}{tt2} % unstarred env does not support labels
+\begin{fmfgraph}(40,30) \fmfpen{thick}
+\fmfleft{i1,i2} \fmfright{o1,o2}
+\fmf{fermion}{i1,v1,o1} \fmf{fermion}{i2,v2,o2}
+\fmf{photon,label=p$q$}{v1,v2} \fmfdot{v1,v2}
+\end{fmfgraph}
+\end{fmffile}
+
+\end{document}

--- a/tagging-status/testfiles/feynmp-auto/feynmp-auto-01.tex
+++ b/tagging-status/testfiles/feynmp-auto/feynmp-auto-01.tex
@@ -1,0 +1,33 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage[force]{feynmp-auto}
+
+\title{feynmp-auto tagging test}
+
+\begin{document}
+
+\begin{fmffile}{tt1} % math in label disappears with math tagging code
+\begin{fmfgraph*}(40,30) \fmfpen{thick}
+\fmfleft{i1,i2} \fmfright{o1,o2}
+\fmf{fermion}{i1,v1,o1} \fmf{fermion}{i2,v2,o2}
+\fmf{photon,label=p$q$}{v1,v2} \fmfdot{v1,v2}
+\end{fmfgraph*}
+\end{fmffile}
+
+\bigskip
+
+\begin{fmffile}{tt2} % unstarred env does not support labels
+\begin{fmfgraph}(40,30) \fmfpen{thick}
+\fmfleft{i1,i2} \fmfright{o1,o2}
+\fmf{fermion}{i1,v1,o1} \fmf{fermion}{i2,v2,o2}
+\fmf{photon,label=pTEXT$q$}{v1,v2} \fmfdot{v1,v2}
+\end{fmfgraph}
+\end{fmffile}
+
+\end{document}

--- a/tagging-status/testfiles/feynmp/feynmp-01.tex
+++ b/tagging-status/testfiles/feynmp/feynmp-01.tex
@@ -1,0 +1,34 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{feynmp} % or feynmf
+\DeclareGraphicsRule{*}{mps}{*}{}
+
+\title{feynmf/feynmp tagging test}
+
+\begin{document}
+
+\begin{fmffile}{tt1} % math in label disappears with math tagging code
+\begin{fmfgraph*}(40,30) \fmfpen{thick}
+\fmfleft{i1,i2} \fmfright{o1,o2}
+\fmf{fermion}{i1,v1,o1} \fmf{fermion}{i2,v2,o2}
+\fmf{photon,label=p$q$}{v1,v2} \fmfdot{v1,v2}
+\end{fmfgraph*}
+\end{fmffile}
+
+\bigskip
+
+\begin{fmffile}{tt2} % unstarred env does not support labels
+\begin{fmfgraph}(40,30) \fmfpen{thick}
+\fmfleft{i1,i2} \fmfright{o1,o2}
+\fmf{fermion}{i1,v1,o1} \fmf{fermion}{i2,v2,o2}
+\fmf{photon,label=p$q$}{v1,v2} \fmfdot{v1,v2}
+\end{fmfgraph}
+\end{fmffile}
+
+\end{document}


### PR DESCRIPTION
Lists abstract as partially-compatible with a test and link to issue.

Lists authblk, biblatex2bibitem, ethiop, feynmf, and feynmp as currently-incompatible with tests and links to issues.

Lists dialogue, gastex, gnuplottex, mfpic, multind, nonfloat, polytable, wallpaper, and watermark without commenting on status, all arxiv001.

Lists eqlist and feynmp-auto as currently-incompatible, both arxiv001, due to incompatible dependencies.