### PR TITLE
add doclicense compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -2567,13 +2567,14 @@
 
  - name: doclicense
    type: package
-   status: unknown
+   status: partially-compatible
    included-in:
    priority: 9
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   comments: "Graphics need Alt text. Metadata is set with hyperxmp which tagging
+              code disables."
+   updated: 2024-08-23
 
  - name: doi
    type: package

--- a/tagging-status/testfiles/doclicense/doclicense-01.tex
+++ b/tagging-status/testfiles/doclicense/doclicense-01.tex
@@ -1,0 +1,16 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass[english]{article}
+\usepackage[
+  type={CC},
+  modifier={by-sa},
+  version={4.0},
+  ]{doclicense}
+\begin{document}
+\doclicenseThis%
+\end{document}


### PR DESCRIPTION
Lists [doclicense](https://ctan.org/pkg/doclicense) as partially-compatible because the included graphics need Alt text and it currently sets metadata about the license with hyperxmp which the tagging code disables.