### PR TITLE
add multind compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -6524,12 +6524,13 @@
 
  - name: multind
    type: package
-   status: unknown
+   status: partially-compatible
    included-in: [arxiv001]
    priority: 7
    issues:
-   tests: false
-   tasks: needs tests
+   tests: true
+   comments: "Does not use section command for index headings. Not distributed
+              with texlive."
    updated: 2024-08-23
 
  - name: multirow

--- a/tagging-status/testfiles/multind/multind-01.tex
+++ b/tagging-status/testfiles/multind/multind-01.tex
@@ -1,0 +1,21 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+
+\usepackage{multind}
+\makeindex{books}
+\makeindex{authors}
+
+\begin{document}
+Text\index{books}{b1}, text\index{authors}{a1}.
+
+Text\index{books}{b2}\index{authors}{a2}. End of text.
+
+\printindex{books}{The Books index}
+\printindex{authors}{The Authors index}
+\end{document}


### PR DESCRIPTION
Lists [multind](https://ctan.org/pkg/multind) as partially-compatible because it does not use section commands for the index heading so the markup is not great.