### PR TITLE
add several packages

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -605,13 +605,13 @@
 
  - name: apacite
    type: package
-   status: unknown
+   status: partially-compatible
    included-in: [arxiv01]
    priority: 6
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-08-01
+   issues: [677]
+   tests: true
+   comments: "`natbibapa` option errors."
+   updated: 2024-08-26
 
  - name: apalike
    ctan-pkg: bibtex
@@ -1349,13 +1349,12 @@
 
  - name: bmpsize
    type: package
-   status: unknown
+   status: compatible
    included-in: [arxiv01]
    priority: 6
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   updated: 2024-08-26
 
  - name: boldline
    type: package
@@ -1488,15 +1487,16 @@
    tasks: needs tests
    updated: 2024-07-13
 
- - name: CTeX
+ - name: ctex
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in: [tlc3]
    priority: 2
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-13
+   issues: [673]
+   tests: true
+   comments: "Option `heading=true` breaks section heading tagging. Same problem
+              with classes ctexart, ctexbook, and ctexrep."
+   updated: 2024-08-26
 
  - name: CharisSIL
    type: package
@@ -2991,13 +2991,13 @@
 
  - name: epsf
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in: [arxiv10]
    priority: 4
-   comments: "Obsolete"
+   comments: "Obsolete. Images not tagged as Figure. No way to add Alt or ActualText."
    issues:
-   tests: false
-   updated: 2024-07-28
+   tests: true
+   updated: 2024-08-26
 
  - name: epsfig
    type: package
@@ -4373,13 +4373,13 @@
 
  - name: graphbox
    type: package
-   status: unknown
+   status: partially-compatible
    included-in: [arxiv01]
    priority: 6
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-08-01
+   tests: true
+   comments: "Inserts empty Div after every Figure."
+   updated: 2024-08-26
 
  - name: graphics
    type: package
@@ -4678,13 +4678,12 @@
 
  - name: hyphenat
    type: package
-   status: unknown
+   status: compatible
    included-in: [arxiv01]
    priority: 6
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   updated: 2024-08-26
 
  - name: hyphsubst
    type: package
@@ -4874,13 +4873,12 @@
 
  - name: import
    type: package
-   status: unknown
+   status: compatible
    included-in: [arxiv01]
    priority: 6
    issues:
    tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   updated: 2024-08-26
 
  - name: incgraph
    type: package
@@ -6362,7 +6360,8 @@
    tests: false
    updated: 2024-07-21
 
- - name: montex
+ - name: mls
+   ctan-pkg: montex
    type: package
    status: unknown
    included-in: [tlc3]
@@ -6936,13 +6935,12 @@
 
  - name: nonfloat
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in: [arxiv001]
    priority: 7
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-08-23
+   issues: [671]
+   tests: true
+   updated: 2024-08-26
 
  - name: nonumonpart
    type: package
@@ -7942,13 +7940,12 @@
 
  - name: polytable
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in: [arxiv001]
    priority: 7
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-08-23
+   issues: [670]
+   tests: true
+   updated: 2024-08-26
 
  - name: postnotes
    type: package
@@ -8027,6 +8024,16 @@
    tests: false
    tasks: needs tests
    updated: 2024-07-18
+
+ - name: pstool
+   type: package
+   status: unknown
+   included-in: [arxiv001]
+   priority: 7
+   issues:
+   tests: false
+   tasks: needs tests
+   updated: 2024-08-26
 
  - name: pstricks
    type: package

--- a/tagging-status/testfiles/apacite/apacite-01.tex
+++ b/tagging-status/testfiles/apacite/apacite-01.tex
@@ -1,0 +1,63 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\begin{filecontents}[noheader]{apacite-ex.bib}
+@article{apa6:ch7-ex1,
+  author  = {Herbst-Damm, Kathryn L. and Kulik, James A.},
+  year    = {2005},
+  title   = {Volunteer Support, Marital Status, and the Survival Times of
+             Terminally Ill Patients},
+  journal = {Health Psychology},
+  volume  = {24},
+  pages   = {225--229},
+  doi     = {10.1037/0278-6133.24.2.225},
+}
+@article{apa6:ch7-ex9,
+  key     = {{\APACciteatitle{Six Sites Meet}}},
+  title   = {Six Sites Meet for Comprehensive Anti-Gang
+             Initiative Conference},
+  year    = {2006},
+  month   = nov # "/" # dec,
+  journal = {OJJDP News @ a Glance},
+  url     =
+    {http://www.ncjrs.gov/html/ojjdp/news_at_glance/216684/topstory.html},
+}
+\end{filecontents}
+
+\documentclass{article}
+
+\usepackage[mask]{apacite}
+\usepackage{hyperref}
+
+\title{apacite tagging test - 1}
+
+\begin{document}
+\tableofcontents
+\section{A section}
+
+\cite<e.g.,>[p.~11]{apa6:ch7-ex1,apa6:ch7-ex9}
+
+\citeA<e.g.,>[p.~11]{apa6:ch7-ex1,apa6:ch7-ex9}
+
+\citeauthor<e.g.,>[p.~11]{apa6:ch7-ex1,apa6:ch7-ex9}
+
+\citeyear<e.g.,>[p.~11]{apa6:ch7-ex1,apa6:ch7-ex9}
+
+\citeyearNP<e.g.,>[p.~11]{apa6:ch7-ex1,apa6:ch7-ex9}
+
+\citeNP<e.g.,>[p.~11]{apa6:ch7-ex1,apa6:ch7-ex9}
+
+\fullcite<e.g.,>[p.~11]{apa6:ch7-ex1,apa6:ch7-ex9}
+
+\shortcite<e.g.,>[p.~11]{apa6:ch7-ex1,apa6:ch7-ex9}
+
+\maskcite<e.g.,>[p.~11]{apa6:ch7-ex1,apa6:ch7-ex9}
+
+\bibliographystyle{apacite}
+\bibliography{apacite-ex}
+
+\end{document}

--- a/tagging-status/testfiles/apacite/apacite-02.tex
+++ b/tagging-status/testfiles/apacite/apacite-02.tex
@@ -1,0 +1,16 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+
+\usepackage[natbibapa]{apacite}
+
+\title{apacite tagging test}
+
+\begin{document}
+text
+\end{document}

--- a/tagging-status/testfiles/ctex/ctex-01.tex
+++ b/tagging-status/testfiles/ctex/ctex-01.tex
@@ -1,0 +1,23 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{ctexart}
+%\documentclass{article}
+%\usepackage[heading = true]{ctex} % same effect on section tagging
+\title{ctex tagging test}
+\author{Some author}
+\begin{document}
+\maketitle
+\tableofcontents
+\section{Some section}
+\subsection{Some subsection}
+\paragraph{Some paragraph}
+\subparagraph{Some subparagraph}
+Body text
+
+\CTeX
+\end{document}

--- a/tagging-status/testfiles/epsf/epsf-01.tex
+++ b/tagging-status/testfiles/epsf/epsf-01.tex
@@ -1,0 +1,16 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{epsf}
+
+\title{epsf tagging test}
+
+\begin{document}
+\epsfxsize=0.5\textwidth
+\epsfbox{arrow-glow.ps}
+\end{document}

--- a/tagging-status/testfiles/graphbox/graphbox-01.tex
+++ b/tagging-status/testfiles/graphbox/graphbox-01.tex
@@ -1,0 +1,26 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+
+\usepackage{graphbox}
+
+\title{graphbox tagging test}
+
+\begin{document}
+
+text\includegraphics[alt=example image,scale=0.5]{example-image}
+
+text\includegraphics[alt=example image,scale=0.5,hide]{example-image}
+
+text\includegraphics[alt=example image,scale=0.5,align=c]{example-image}
+
+text\includegraphics[alt=example image,scale=0.5,smash=ml]{example-image}
+
+text\includegraphics[alt=example image,scale=0.5,margin=3cm]{example-image}
+
+\end{document}

--- a/tagging-status/testfiles/hyphenat/hyphenat-01.tex
+++ b/tagging-status/testfiles/hyphenat/hyphenat-01.tex
@@ -1,0 +1,30 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+
+\usepackage[
+  htt,
+%  none, % seems okay
+  ]{hyphenat}
+\usepackage{kantlipsum}
+
+\title{hyphenat tagging test}
+
+\begin{document}
+
+\kant[1-2]
+{\ttfamily\kant[1-2]}
+{\nhttfamily\kant[1-2]}
+\nohyphens{\kant[1-2]}
+letters\_\-with\_\-underscores
+
+first\bshyp{}second\fshyp{}third\dothyp{}fourth\colonhyp{}fifth\_sixth
+
+electromagnetic\hyp{}endioscopy
+
+\end{document}

--- a/tagging-status/testfiles/nonfloat/nonfloat-01.tex
+++ b/tagging-status/testfiles/nonfloat/nonfloat-01.tex
@@ -1,0 +1,32 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{nonfloat}
+
+\title{nonfloat tagging test}
+
+\begin{document}
+
+text
+\begin{center}
+\tabcaption{A non-floating table caption}
+\begin{tabular}{cc}
+ A & B \\
+ C & D
+\end{tabular}
+\end{center}
+
+\begin{table}
+\caption{A floating table caption}
+\begin{tabular}{cc}
+ A & B \\
+ C & D
+\end{tabular}
+\end{table}
+
+\end{document}

--- a/tagging-status/testfiles/polytable/polytable-01.tex
+++ b/tagging-status/testfiles/polytable/polytable-01.tex
@@ -1,0 +1,27 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{polytable}
+
+\title{polytable tagging test}
+
+\begin{document}
+
+\begin{ptboxed}
+\defaultcolumn{l|}\column{.}{|l|}
+\> left
+\=3 first of three \> second of three \> third of three
+\=r right \\
+\defaultcolumn{r|}\> left \=2 middle 1/2 \> middle 2/2 \=r right \\
+\> left \=3 middle 1/3 \> middle 2/3 \> middle 3/3 \=r right \\
+\> left
+\=2 first of two middle columns \> second of two middle columns
+\=r right \\
+\end{ptboxed}
+
+\end{document}


### PR DESCRIPTION
Lists apacite as partially-compatible because the natbibapa option errors but otherwise it works fine.

Lists graphbox as partially-compatible because it inserts an empty Div after every Figure.

Lists bmpsize and import as compatible without tests.

Lists hyphenat as compatible with a test.

Lists ctex, nonfloat, and polytable as currently-incompatible with tests and links to issues.

Lists epsf as currently-incompatible because it does not tag images as Figures and there is no way to add Alt or ActualText.

Adds an entry for pstool without commenting on status.

Changes the entry for montex to mls with ctan-pkg: montex.
