### PR TITLE
add several packages

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -746,13 +746,12 @@
 
  - name: asymptote
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in: [arxiv001]
    priority: 7
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   issues: [679]
+   tests: true
+   updated: 2024-08-28
 
  - name: atkinson
    type: package
@@ -994,13 +993,12 @@
 
  - name: balance
    type: package
-   status: unknown
+   status: compatible
    included-in: [arxiv1]
    priority: 5
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   updated: 2024-08-28
 
  - name: baskervald
    ctan-pkg: baskervaldadf
@@ -1092,6 +1090,15 @@
    issues:
    tests: false
    updated: 2024-07-14
+
+ - name: bez123
+   type: package
+   status: compatible
+   included-in:
+   priority: 9
+   issues:
+   tests: true
+   updated: 2024-08-28
 
  - name: bezier
    ctan-pkg: latex-base
@@ -1224,13 +1231,12 @@
 
  - name: bidi
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in: [tlc3]
    priority: 2
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-14
+   issues: [686]
+   tests: true
+   updated: 2024-08-28
 
  - name: bigdelim
    type: package
@@ -1367,13 +1373,12 @@
 
  - name: booklet
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in:
    priority: 9
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   issues: [682]
+   tests: true
+   updated: 2024-08-28
 
  - name: bookman
    ctan-pkg: psnfss
@@ -1905,6 +1910,16 @@
    issues:
    tests: false
    updated: 2024-07-31
+
+ - name: chngcntr
+   type: package
+   status: compatible
+   included-in: [arxiv01]
+   priority: 6
+   issues:
+   tests: false
+   comments: "Obsolete. Incorporated into the format."
+   updated: 2024-08-28
 
  - name: cinzel
    type: package
@@ -3126,13 +3141,13 @@
  - name: etex
    ctan-pkg: etex-pkg
    type: package
-   status: unknown
+   status: compatible
    included-in: [arxiv10]
    priority: 4
    comments: "Obsolete"
    issues:
    tests: false
-   updated: 2024-07-28
+   updated: 2024-08-28
 
  - name: ethiop
    type: package
@@ -3363,13 +3378,12 @@
 
  - name: fbox
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in:
    priority: 9
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   issues: [683]
+   tests: true
+   updated: 2024-08-28
 
  - name: fcolumn
    type: package
@@ -3499,13 +3513,12 @@
 
  - name: fitbox
    type: package
-   status: unknown
+   status: compatible
    included-in:
    priority: 9
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   tests: true
+   updated: 2024-08-28
 
  - name: fitch
    type: package
@@ -4628,13 +4641,12 @@
 
  - name: hypdvips
    type: package
-   status: unknown
+   status: no-support
    included-in:
    priority: 9
-   issues:
+   issues: [680]
    tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   updated: 2024-08-28
 
  - name: hyperbar
    type: package
@@ -4769,6 +4781,15 @@
    issues:
    tests: false
    updated: 2024-07-15
+
+ - name: ifmtarg
+   type: package
+   status: compatible
+   included-in: [arxiv001]
+   priority: 7
+   issues:
+   tests: false
+   updated: 2024-08-28
 
  - name: ifoddpage
    type: package
@@ -4986,6 +5007,15 @@
    issues:
    tests: true
    updated: 2024-08-14
+
+ - name: inversepath
+   type: package
+   status: compatible
+   included-in:
+   priority: 9
+   issues:
+   tests: true
+   updated: 2024-08-28
 
  - name: iwona
    type: package
@@ -5294,6 +5324,15 @@
    issues:
    tests: false
    updated: 2024-08-20
+
+ - name: leading
+   type: package
+   status: compatible
+   included-in:
+   priority: 9
+   issues:
+   tests: true
+   updated: 2024-08-28
 
  - name: leftidx
    type: package
@@ -7053,13 +7092,12 @@
 
  - name: ntheorem
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in: [tlc3, arxiv01]
    priority: 2
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-15
+   issues: [688]
+   tests: true
+   updated: 2024-08-28
 
  - name: numerica
    type: package
@@ -7992,6 +8030,15 @@
    tests: false
    tasks: needs tests
    updated: 2024-07-18
+
+ - name: printlen
+   type: package
+   status: compatible
+   included-in: [arxiv001]
+   priority: 7
+   issues:
+   tests: true
+   updated: 2024-08-28
 
  - name: prooftrees
    type: package
@@ -9798,13 +9845,13 @@
 
  - name: tipa
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in: [tlc3, arxiv01]
    priority: 2
    issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-15
+   tests: true
+   comments: "Symbols not correctly mapped to Unicode."
+   updated: 2024-08-28
 
  - name: titlecaps
    type: package
@@ -9862,13 +9909,12 @@
 
  - name: titling
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in: [tlc3, arxiv01]
    priority: 2
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-15
+   issues: [687]
+   tests: true
+   updated: 2024-08-28
 
  - name: tocbasic
    type: package
@@ -10601,13 +10647,12 @@
 
  - name: xcoffins
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in:
    priority: 9
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-17
+   issues: [345,684]
+   tests: true
+   updated: 2024-08-28
 
  - name: xcomment
    type: package
@@ -11024,10 +11069,12 @@
    status: unknown
    included-in: [tlc3, arxiv1]
    priority: 2
+   package-repository: "https://github.com/borisveytsman/acmart"
    issues:
    tests: false
    tasks: needs tests
-   updated: 2024-07-18
+   comments: "See acmart-tagged.cls."
+   updated: 2024-08-28
 
  - name: amsart
    type: class

--- a/tagging-status/testfiles/asymptote/asymptote-01.tex
+++ b/tagging-status/testfiles/asymptote/asymptote-01.tex
@@ -1,0 +1,95 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid},
+  }
+\documentclass{article}
+\usepackage[
+  inline % all labels are tagged
+  ]{asymptote}
+
+\title{asymptote tagging test}
+  
+\begin{document}
+
+text
+
+\begin{asydef}
+// Global Asymptote definitions can be put here.
+settings.prc=true;
+import three;
+usepackage("bm");
+texpreamble("\def\V#1{#1}");
+// One can globally override the default toolbar settings here:
+// settings.toolbar=true;
+\end{asydef}
+\def\A{A}
+\def\B{\V{B}}
+
+\begin{center}
+\begin{asy}%[alt={alt text}]
+size(4cm,0);
+pen colour1=red;
+pen colour2=green;
+pair z0=(0,0);
+pair z1=(-1,0);
+pair z2=(1,0);
+real r=1.5;
+path c1=circle(z1,r);
+path c2=circle(z2,r);
+fill(c1,colour1);
+fill(c2,colour2);
+picture intersection=new picture;
+fill(intersection,c1,colour1+colour2);
+clip(intersection,c2);
+add(intersection);
+draw(c1);
+draw(c2);
+//draw("$\A$",box,z1); // Requires [inline] package option.
+//draw(Label("$\B$","$B$"),box,z2); // Requires [inline] package option.
+draw("$A$",box,z1);
+draw("$\V{B}$",box,z2);
+pair z=(0,-2);
+real m=3;
+margin BigMargin=Margin(0,m*dot(unit(z1-z),unit(z0-z)));
+draw(Label("$A\cap B$",0),conj(z)--z0,Arrow,BigMargin);
+draw(Label("$A\cup B$",0),z--z0,Arrow,BigMargin);
+draw(z--z1,Arrow,Margin(0,m));
+draw(z--z2,Arrow,Margin(0,m));
+shipout(bbox(0.25cm));
+\end{asy}
+%\caption{Venn diagram}\label{venn}
+\end{center}
+
+\begin{center}
+\begin{asy}[height=4cm,inline=true,attach=false,viewportwidth=\linewidth]
+currentprojection=orthographic(5,4,2);
+draw(unitcube,blue);
+label("$V-E+F=2$",(0,1,0.5),3Y,blue+fontsize(17pt));
+\end{asy}
+\end{center}
+One can also scale the figure to the full line width:
+\begin{center}
+\begin{asy}[width=\the\linewidth,inline=true]
+pair z0=(0,0);
+pair z1=(2,0);
+pair z2=(5,0);
+pair zf=z1+0.75*(z2-z1);
+draw(z1--z2);
+dot(z1,red+0.15cm);
+dot(z2,darkgreen+0.3cm);
+label("$m$",z1,1.2N,red);
+label("$M$",z2,1.5N,darkgreen);
+label("$\hat{\ }$",zf,0.2*S,fontsize(24pt)+blue);
+pair s=-0.2*I;
+draw("$x$",z0+s--z1+s,N,red,Arrows,Bars,PenMargins);
+s=-0.5*I;
+draw("$\bar{x}$",z0+s--zf+s,blue,Arrows,Bars,PenMargins);
+s=-0.95*I;
+draw("$X$",z0+s--z2+s,darkgreen,Arrows,Bars,PenMargins);
+\end{asy}
+\end{center}
+
+\end{document}

--- a/tagging-status/testfiles/balance/balance-01.tex
+++ b/tagging-status/testfiles/balance/balance-01.tex
@@ -1,0 +1,53 @@
+% adapted from https://tex.stackexchange.com/a/559121/208544
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,title,math,table,firstaid}
+  }
+\documentclass[11pt,a4paper,twocolumn]{article}
+\usepackage[top=105pt, bottom=75pt, left=75pt, right=75pt]{geometry}
+\usepackage{graphicx}
+\usepackage{balance}
+\usepackage{lipsum}
+
+\newtheorem{thm}{Theorem}[section]
+\newtheorem{lem}[thm]{Lemma}
+
+\title{balance tagging test}
+\author{Some author}
+
+\begin{document}
+\maketitle
+
+\lipsum[1]
+
+\section{Using \texttt{balance}}
+
+\lipsum[2]
+\begin{thm}
+  \lipsum[3]
+\end{thm}
+
+\lipsum[4]
+
+Consider the following drawing\footnote{\lipsum[21]}.
+\begin{figure}[ht!]
+  \centering
+  \includegraphics[alt=example image,width=0.8\columnwidth]{example-image}
+  \caption{Example image}
+\end{figure}
+
+\lipsum[5]
+
+\balance
+
+As a consequence, we have\footnote{Well, well!  It appears in an
+  unexpected place.}
+
+\begin{lem}
+  \lipsum[6]
+\end{lem}
+
+\end{document}

--- a/tagging-status/testfiles/bez123/bez123-01.tex
+++ b/tagging-status/testfiles/bez123/bez123-01.tex
@@ -1,0 +1,101 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,title,math,table,firstaid}
+  }
+\documentclass{article}
+
+\usepackage{bez123}
+
+\title{bez123 tagging test}
+
+\begin{document}
+
+\setlength{\unitlength}{1mm}
+\begin{picture}[alt=first picture](70,80)
+\put(0,5){\begin{picture}(30,30)
+\thinlines
+\put(0,0){\circle{2}}
+\put(-2,0){\makebox(0,0)[br]{0}}
+\put(10,30){\circle{2}}
+\put(8,30){\makebox(0,0)[br]{1}}
+\put(20,0){\circle{2}}
+\put(22,0){\makebox(0,0)[bl]{2}}
+\put(30,30){\circle{2}}
+\put(32,30){\makebox(0,0)[bl]{3}}
+\put(0,0){\vector(1,3){10}}
+\put(10,30){\vector(1,-3){10}}
+\put(20,0){\vector(1,3){10}}
+\thicklines
+\cbezier[30](0,0)(10,30)(20,0)(30,30)
+\thinlines
+\end{picture}}
+\put(0,45){\begin{picture}(30,30)
+\thinlines
+\put(0,0){\circle{2}}
+\put(-2,0){\makebox(0,0)[br]{0, 3}}
+\put(30,0){\circle{2}}
+\put(32,0){\makebox(0,0)[bl]{1}}
+\put(0,30){\circle{2}}
+\put(2,30){\makebox(0,0)[bl]{2}}
+\put(0,0){\vector(1,0){30}}
+\put(30,0){\vector(-1,1){30}}
+\put(0,30){\vector(0,-1){30}}
+\thicklines
+\cbezier[30](0,0)(30,0)(0,30)(0,0)
+\thinlines
+\end{picture}}
+\put(45,0){\begin{picture}(30,30)
+\thinlines
+\put(0,0){\circle{2}}
+\put(-2,0){\makebox(0,0)[br]{0}}
+\put(10,30){\circle{2}}
+\put(8,30){\makebox(0,0)[br]{2}}
+\put(20,0){\circle{2}}
+\put(22,0){\makebox(0,0)[bl]{3}}
+\put(30,30){\circle{2}}
+\put(32,30){\makebox(0,0)[bl]{1}}
+\put(0,0){\vector(1,1){30}}
+\put(30,30){\vector(-1,0){20}}
+\put(10,30){\vector(1,-3){10}}
+\thicklines
+\cbezier(0,0)(30,30)(10,30)(20,0)
+\thinlines
+\end{picture}}
+\put(45,45){\begin{picture}(30,30)
+\thinlines
+\put(0,0){\circle{2}}
+\put(-2,0){\makebox(0,0)[br]{0}}
+\put(30,0){\circle{2}}
+\put(32,0){\makebox(0,0)[bl]{1}}
+\put(0,30){\circle{2}}
+\put(2,30){\makebox(0,0)[bl]{2}}
+\put(10,10){\circle{2}}
+\put(8,10){\makebox(0,0)[br]{3}}
+\put(0,0){\vector(1,0){30}}
+\put(30,0){\vector(-1,1){30}}
+\put(0,30){\vector(1,-2){10}}
+\thicklines
+\cbezier(0,0)(30,0)(0,30)(10,10)
+\thinlines
+\end{picture}}
+\end{picture}
+
+\bigskip
+
+\begin{picture}[alt=second picture](60,60)
+\put(30,20){\begin{picture}(30,20)
+\thinlines
+\put(0,10){\circle{2}}
+\put(30,0){\circle{2}}
+\put(30,20){\circle{2}}
+\lbezier[25](30,20)(0,10)
+\lbezier[25](0,10)(30,0)
+\thicklines
+\rqbezier[100](30,20)(0,10)(30,0)(2)
+\rqbezier[100](30,20)(0,10)(30,0)(-2)
+\end{picture}}
+\end{picture}
+\end{document}

--- a/tagging-status/testfiles/bidi/bidi-01.tex
+++ b/tagging-status/testfiles/bidi/bidi-01.tex
@@ -1,0 +1,39 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+
+\usepackage{amsmath} % has to be loaded before bidi
+\usepackage{hyperref} % has to be loaded before bidi
+\usepackage[
+  RTLdocument,
+%  extrafootnotefeatures,
+  ]{bidi}
+
+%\threecolumnfootnotes
+%\paragraphfootnotes
+
+\begin{document}
+
+text\footnote{a footnote}
+
+text\footnote{another footnote}
+
+\begin{equation}
+a=b
+\end{equation}
+
+\begin{enumerate} % output is wrong
+\item first item
+\item second item
+\begin{LTRitems}
+\item first LTR item
+\item second LTR item
+\end{LTRitems}
+\end{enumerate}
+
+\end{document}

--- a/tagging-status/testfiles/booklet/booklet-01.tex
+++ b/tagging-status/testfiles/booklet/booklet-01.tex
@@ -1,0 +1,40 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass[letterpaper,11pt]{book}
+%\usepackage{luatex85} % needed with luatex
+% typeblock size of 5.5 by 4 inches
+\setlength{\textheight}{419pt} \setlength{\textwidth}{289pt}
+\setlength{\oddsidemargin}{72pt} \setlength{\evensidemargin}{108pt}
+\setlength{\topmargin}{55.9pt} \setlength{\footskip}{27.5pt}
+\setlength{\headheight}{14.6pt} \setlength{\headsep}{19.9pt}
+\usepackage[print,1to1]{booklet} \nofiles
+\pagespersignature{16} % 16 pages per signature
+\setpdftargetpages
+\begin{document}
+\pagestyle{empty}
+% Want a blank sheet before the title page
+\hbox{}\cleardoublepage
+% half-title page here
+\cleardoublepage
+% title page here
+\clearpage
+% copyright page here
+\cleardoublepage
+\pagestyle{plain}
+\pagenumbering{roman}
+\tableofcontents
+\cleardoublepage
+\pagenumbering{arabic}
+\pagestyle{headings}
+\chapter{First}
+% and so on
+% want some blank endpapers to get enough pages into
+% the last signature for easy binding
+\clearpage
+\hbox{}\clearpage\hbox{}\cleardoublepage
+\end{document}

--- a/tagging-status/testfiles/fbox/fbox-01.tex
+++ b/tagging-status/testfiles/fbox/fbox-01.tex
@@ -1,0 +1,27 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+
+\usepackage{fbox}
+
+\newcommand\demoText{DuckDuckGo! Time to spread the word!
+Equipped with the talking points above, you’re
+ready to help anyone search and browse pro-
+tected.}
+
+\begin{document}
+
+\fbox*[bT]{foo gar baz}
+
+\fbox[Br,boxrule=5pt,bcolor=red]{foo gar baz}
+
+\fparbox{\demoText}
+
+\fparbox*[Br]{\demoText}
+
+\end{document}

--- a/tagging-status/testfiles/fitbox/fitbox-01.tex
+++ b/tagging-status/testfiles/fitbox/fitbox-01.tex
@@ -1,0 +1,31 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,title,math,table,firstaid}
+  }
+\documentclass{article}
+
+\usepackage{fitbox}
+\usepackage{graphicx}
+\usepackage{kantlipsum}
+
+\title{fitbox tagging test}
+
+\fitboxset{minheight=0pt,minwidth=0pt}
+
+\begin{document}
+\kant[1-2]
+\fitbox{\includegraphics[alt=example image]{example-image}}
+\clearpage
+\kant[1-3]
+\fitbox{\includegraphics[alt=example image]{example-image}}
+\clearpage
+\kant[1]
+\begin{figure}
+\fitbox*{\includegraphics[alt=example image]{example-image}}
+\caption{An example image}
+\end{figure}
+
+\end{document}

--- a/tagging-status/testfiles/inversepath/inversepath-01.tex
+++ b/tagging-status/testfiles/inversepath/inversepath-01.tex
@@ -1,0 +1,33 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,title,math,table,firstaid}
+  }
+\documentclass{article}
+
+\usepackage{inversepath}
+
+\title{inversepath tagging test}
+
+\makeatletter
+\begin{document}
+
+\inversepath*{one/two/three/four.tex}\par
+\ip@inversepath\par
+\ip@lastelement\par
+\ip@directpath
+
+[\inversepath*{one.tex}]\par
+\ip@inversepath\par
+\ip@lastelement\par
+[\ip@directpath]
+
+\absolutepath{/xyz/here/there/everywhere/}
+\inversepath*{../../one/two/three.tex}\par
+\ip@inversepath\par
+\ip@lastelement\par
+\ip@directpath
+
+\end{document}

--- a/tagging-status/testfiles/leading/leading-01.tex
+++ b/tagging-status/testfiles/leading/leading-01.tex
@@ -1,0 +1,25 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,title,math,table,firstaid}
+  }
+\documentclass{article}
+
+\usepackage{leading}
+\usepackage{kantlipsum}
+
+\title{leading tagging test}
+
+\begin{document}
+
+\kant[2]
+
+\leading{11pt}
+\kant[2]
+
+\leading{5mm}
+\kant[2]
+
+\end{document}

--- a/tagging-status/testfiles/ntheorem/ntheorem-01.tex
+++ b/tagging-status/testfiles/ntheorem/ntheorem-01.tex
@@ -1,0 +1,50 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,title,math,table,firstaid}
+  }
+\documentclass{article}
+
+\usepackage{amsmath}
+\usepackage[
+  amsmath,
+  thref,
+  hyperref, % parent-child warnings
+  thmmarks % parent-child warnings; redefines a lot of envs
+  ]{ntheorem}
+\usepackage{hyperref} % see above
+
+\title{ntheorem tagging test}
+
+\newtheorem{theorem}{Theorem}
+
+\theoremstyle{plain}
+\theoremsymbol{\ensuremath{\clubsuit}}
+\theoremseparator{.}
+\theoremprework{\bigskip\hrule}
+\theorempostwork{\hrule\bigskip}
+\newtheorem{definition}{Definition}
+
+\begin{document}
+
+\listtheorems{theorem} % output is wrong
+
+\begin{theorem}\label{thm}
+Some text
+\end{theorem}
+
+\begin{theorem}[A heading]
+Some more text
+\end{theorem}
+
+\ref{thm}
+
+\thref{thm}
+
+\begin{definition}
+Some text
+\end{definition}
+
+\end{document}

--- a/tagging-status/testfiles/printlen/printlen-01.tex
+++ b/tagging-status/testfiles/printlen/printlen-01.tex
@@ -1,0 +1,24 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,title,math,table,firstaid}
+  }
+\documentclass{article}
+
+\usepackage{printlen}
+
+\title{printlen tagging test}
+
+\begin{document}
+
+The \verb|\textwidth| is \printlength{\textwidth}
+
+\uselengthunit{in}\printlength{\textwidth}
+
+\uselengthunit{mm}\printlength{\textwidth}
+
+\rndprintlength{\textwidth}
+
+\end{document}

--- a/tagging-status/testfiles/tipa/tipa-01.tex
+++ b/tagging-status/testfiles/tipa/tipa-01.tex
@@ -1,0 +1,32 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,title,math,table,firstaid}
+  }
+\documentclass{article}
+
+\usepackage[tone,extra]{tipa}
+
+\title{tipa tagging test}
+
+\begin{document}
+
+\textipa{[""Ekspl@"neIS@n]}
+
+\textipa{v2v w\textsca w yLy [S]}
+
+\textipa{\*f \*k \*r \*t \*w}
+
+\textipa{\*j \*n \*h \*l \*z}
+
+\tone{15253545}
+
+\begin{IPA}
+[""Ekspl@"neIS@n]
+
+\*j \*n \*h \*l \*z
+\end{IPA}
+
+\end{document}

--- a/tagging-status/testfiles/titling/titling-01.tex
+++ b/tagging-status/testfiles/titling/titling-01.tex
@@ -1,0 +1,21 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,title,math,table,firstaid}
+  }
+\documentclass{article}
+
+\usepackage{titling}
+%\title[pdftitle=a different title]{titling tagging test} % errors
+%\author[pdfauthor=a different author]{Some author} % errors
+\title{titling tagging test}
+\author{Some author}
+
+\begin{document}
+
+\maketitle
+Some text
+
+\end{document}

--- a/tagging-status/testfiles/xcoffins/xcoffins-01.tex
+++ b/tagging-status/testfiles/xcoffins/xcoffins-01.tex
@@ -1,0 +1,22 @@
+\DocumentMetadata{%
+	pdfstandard=A-3b,
+	pdfversion=1.7,
+	lang=en-US,
+	testphase={phase-III},
+}
+\documentclass{article}
+
+\usepackage{xcoffins}
+\NewCoffin{\AuthorBlock}
+
+\begin{document}
+
+\SetHorizontalCoffin\AuthorBlock{%
+	\parbox{\textwidth}{John Steinbeck}% <=== parbox breaks tagging.
+%	\mbox{John Steinbeck}%               <=== mbox does not.
+}
+
+To the red country and part of the gray country of Oklahoma, the last rains came gently and they did not cut the scarred earth.
+
+The last rains lifted the corn quickly and scattered weed colonies and grass along the sides of the roads so that the gray country and the dark red country began to disappear under a green cover.  
+\end{document}

--- a/tagging-status/testfiles/xcoffins/xcoffins-02.tex
+++ b/tagging-status/testfiles/xcoffins/xcoffins-02.tex
@@ -1,0 +1,105 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass{article}
+
+\usepackage[a4paper,margin=5pt]{geometry}
+
+\usepackage{multicol}
+\usepackage{graphicx}
+\usepackage{tgheros}
+\usepackage{xcoffins}
+\usepackage{xcolor}
+\newcommand\cbox[2][.8]{{\setlength\fboxsep{0pt}\colorbox[gray]{#1}{#2}}}
+
+\pagestyle{empty}
+
+\begin{document}
+
+  \NewCoffin \Result
+  \NewCoffin \aaa
+  \NewCoffin \bbb
+  \NewCoffin \ccc
+  \NewCoffin \ddd
+  \NewCoffin \eee
+  \NewCoffin \fff
+  \NewCoffin \rulei
+  \NewCoffin \ruleii
+  \NewCoffin \ruleiii
+
+\SetHorizontalCoffin \Result {}
+\SetHorizontalCoffin \aaa {\fontsize{52}{50}\sffamily\bfseries mitteilungen}
+\SetHorizontalCoffin \bbb {\fontsize{52}{50}\sffamily\bfseries typographische}
+\SetHorizontalCoffin \ccc {\fontsize{12}{10}\sffamily
+                      \quad zeitschrift des bildungsverbandes der
+                      deutschen buchdrucker leipzig
+                     \textbullet{} oktoberheft 1925}
+\SetHorizontalCoffin \ddd {\fontsize{28}{20}\sffamily sonderheft}
+\SetVerticalCoffin \eee {180pt}
+                 {\raggedleft\fontsize{31}{36}\sffamily\bfseries
+                      elementare\\
+                      typographie}
+\SetVerticalCoffin \fff {140pt}
+                 {\raggedright \fontsize{13}{14}\sffamily\bfseries
+                       natan altman \\
+                       otto baumberger \\
+                       herbert mayer \\
+                       max burchartz \\
+                       el lissitzky \\
+                       ladislaus moholy-nagy \\
+                       moln\'ar f.~farkas \\
+                       johannes molzahn \\
+                       kurt schwitters \\
+                       mart stam \\
+                       ivan tschichold}
+
+\RotateCoffin \bbb {90}
+\RotateCoffin \ccc {270}
+
+\SetHorizontalCoffin \rulei  {\color{red}\rule{6.5in}{1pc}}
+\SetHorizontalCoffin \ruleii {\color{red}\rule{1pc}{23.5cm}}
+\SetHorizontalCoffin \ruleiii{\color{black}\rule{10pt}{152pt}}
+
+
+\JoinCoffins \Result                \aaa
+\JoinCoffins \Result[\aaa-t,\aaa-r] \rulei   [b,r](0pt,2mm)
+\JoinCoffins \Result[\aaa-b,\aaa-l] \bbb     [B,r](2pt,0pt)
+\JoinCoffins \Result[\bbb-t,\bbb-r] \ruleii  [t,r](-2mm,0pt)
+\JoinCoffins \Result[\aaa-B,\aaa-r] \ccc     [B,l](66pt,14pc)
+\JoinCoffins \Result[\bbb-l,\ccc-B] \fff     [t,r](-2mm,0pt)
+\JoinCoffins \Result[\fff-b,\fff-r] \ruleiii [b,l](2mm,0pt)
+\JoinCoffins \Result[\ccc-r,\fff-l] \eee     [B,r]
+\JoinCoffins \Result[\eee-T,\eee-r] \ddd     [B,r](0pt,4pc)
+
+\vspace*{3cm}
+\begin{center}
+  {\Large Title page of ``elementare typographie'' by Ivan Tschichold\par}
+
+\large
+\vspace*{1cm}
+
+  1. first the scanned original from 1925
+
+\vspace*{6mm}
+
+  2. then the recreated \TeX{} version from 2010 using coffins---not
+     attempting\\ to match the fonts and size but the structure
+
+\vspace*{6mm}
+
+  3. and finally the source code used.
+
+     This document uses the new
+     implementation by Joseph in \texttt{l3coffins-new}.
+
+\end{center}
+
+\newpage
+
+\TypesetCoffin \Result
+
+\end{document}


### PR DESCRIPTION
Lists asymptote, bidi, booklet, fbox, ntheorem, titling, and xcoffins as currently-incompatible with tests and links to issues.

Lists tipa as currently-incompatible because the symbols are not correctly mapped to Unicode.

Lists hypdvips as no-support.

Lists balance, bez123, fitbox, inversepath, leading, and printlen as compatible with tests.

Lists ifmtarg and etex as compatible without tests.

Lists chngcntr as compatible with a note about it being incorporated into the format.

Adds `package-repository` for acmart and a note about the experimental `acmart-tagged.cls`.