### PR TITLE
add normalcolor, scrwfile, and sublabel compat

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -7778,6 +7778,15 @@
    tests: true
    updated: 2024-08-01
 
+ - name: normalcolor
+   type: package
+   status: compatible
+   included-in:
+   priority: 9
+   issues:
+   tests: true
+   updated: 2024-09-03
+
  - name: notes2bib
    type: package
    status: compatible
@@ -9392,6 +9401,15 @@
    tasks: needs tests
    updated: 2024-07-15
 
+ - name: scrwfile
+   type: package
+   status: currently-incompatible
+   included-in:
+   priority: 9
+   issues: [696]
+   tests: true
+   updated: 2024-09-03
+
  - name: secdot
    type: package
    status: compatible
@@ -10043,6 +10061,15 @@
    issues:
    tests: true
    updated: 2024-08-05
+
+ - name: sublabel
+   type: package
+   status: compatible
+   included-in: [arxiv001]
+   priority: 7
+   issues:
+   tests: true
+   updated: 2024-09-03
 
  - name: superiors
    type: package

--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -9403,12 +9403,12 @@
 
  - name: scrwfile
    type: package
-   status: currently-incompatible
+   status: compatible
    included-in:
    priority: 9
    issues: [696]
    tests: true
-   updated: 2024-09-03
+   updated: 2024-09-13
 
  - name: secdot
    type: package

--- a/tagging-status/testfiles/normalcolor/normalcolor-01.tex
+++ b/tagging-status/testfiles/normalcolor/normalcolor-01.tex
@@ -1,0 +1,25 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,title,math,table,firstaid}
+  }
+% this is normalcolor-example.tex
+\documentclass{article}
+
+\usepackage{normalcolor}
+\setnormalcolor{green}
+\usepackage{xcolor}
+
+\usepackage{blindtext}
+\begin{document}
+\color{blue}
+\tableofcontents
+\blinddocument
+\setnormalcolor{red}
+\blinddocument
+
+\resetnormalcolor
+\blinddocument
+\end{document}

--- a/tagging-status/testfiles/scrwfile/scrwfile-01.tex
+++ b/tagging-status/testfiles/scrwfile/scrwfile-01.tex
@@ -1,0 +1,21 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,table,title,firstaid}
+  }
+\documentclass{article}
+\usepackage{scrwfile}
+\TOCclone[Summary Contents]{toc}{stoc}
+%\usepackage{hyperref}
+\addtocontents{stoc}{\protect\value{tocdepth}=1}
+
+\begin{document}
+
+\tableofcontents
+\section{A section}
+\subsection{A subsection}
+\listofstoc
+
+\end{document}

--- a/tagging-status/testfiles/sublabel/sublabel-01.tex
+++ b/tagging-status/testfiles/sublabel/sublabel-01.tex
@@ -1,0 +1,46 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,title,math,table,firstaid}
+  }
+\documentclass{article}
+
+\usepackage{sublabel}
+
+\title{sublabel tagging test}
+
+\begin{document}
+\begin{figure}
+Regular figure
+\caption{Regular figure caption}
+\label{reg}
+\end{figure}
+\sublabon{figure}
+\begin{figure}
+Some figure
+\caption{Some figure caption}
+\label{nonreg}
+\end{figure}
+\begin{figure}
+Another figure
+\caption{Another figure caption}
+\end{figure}
+\sublaboff{figure}
+\begin{figure}
+Another regular figure
+\caption{Another regular figure caption}
+\end{figure}
+\ref{reg} and \ref{nonreg}
+\begin{align}
+x & = a \label{eq:x}\\%--> 1
+\sublabon{equation}
+y & = b \label{eq:y}\\%--> 2a
+z & = c \label{eq:z}\\%--> 2b
+\sublaboff{equation}
+w & = d \label{eq:w} %--> 3
+\end{align}
+
+\eqref{eq:x} and \eqref{eq:y}
+\end{document}


### PR DESCRIPTION
Lists normalcolor and sublabel as compatible with tests.

Lists scrwfile as currently-incompatible with a test and link to issue.