### PR TITLE
add subfig, tocbasic, and tocstyle compatibility

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -4751,6 +4751,7 @@
    issues:
    tests: false
    tasks: needs tests
+   comments: Obsolete
    updated: 2024-07-14
 
  - name: froufrou
@@ -10006,13 +10007,12 @@
 
  - name: subfig
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in: [tlc3, arxiv5]
    priority: 2
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-15
+   issues: [702]
+   tests: true
+   updated: 2024-09-10
 
  - name: subfigure
    type: package
@@ -10696,13 +10696,12 @@
 
  - name: tocbasic
    type: package
-   status: unknown
+   status: currently-incompatible
    included-in: [arxiv01]
    priority: 6
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-17
+   issues: [701]
+   tests: true
+   updated: 2024-09-10
 
  - name: tocbibind
    type: package
@@ -10743,14 +10742,13 @@
 
  - name: tocstyle
    type: package
-   status: unknown
+   status: no-support
    included-in: [tlc3]
    priority: 2
-   issues:
+   issues: [700]
    tests: false
-   tasks: needs tests
    comments: Obsolete
-   updated: 2024-07-15
+   updated: 2024-09-10
 
  - name: tocvsec2
    type: package

--- a/tagging-status/testfiles/subfig/subfig-01.tex
+++ b/tagging-status/testfiles/subfig/subfig-01.tex
@@ -1,0 +1,35 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,title,math,table,firstaid}
+  }
+\documentclass{article}
+\usepackage{subfig}
+\usepackage{hyperref}
+
+\begin{document}
+
+\listoffigures
+
+\begin{figure}
+Some figure
+\caption{Some caption}
+\label{fig}
+\end{figure}
+
+\begin{figure}
+\centering
+\subfloat[First.]{First subfloat}\qquad
+\subfloat[Second figure.]{Second subfloat}\\
+\subfloat[Third.]{\label{3figs-c}Third subfloat}
+\caption{Three sub-floats.}
+\label{3figs}
+\end{figure}
+
+\ref{fig}
+
+\subref{3figs-c}
+
+\end{document}

--- a/tagging-status/testfiles/tocbasic/tocbasic-01.tex
+++ b/tagging-status/testfiles/tocbasic/tocbasic-01.tex
@@ -1,0 +1,21 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,title,math,table,firstaid}
+  }
+\documentclass{article}
+
+\usepackage{tocbasic}
+\DeclareTOCStyleEntry{largetocline}{section}
+\DeclareTOCStyleEntry{tocline}{subsection}
+
+\begin{document}
+
+\tableofcontents
+
+\section{Section heading}
+\subsection{Subsection heading}
+\subsubsection{Subsubsection heading}
+\end{document}


### PR DESCRIPTION
Lists subfig and tocbasic as currently incompatible and adds tests.

Lists tocstyle as no-support.

Adds "Obsolete" to the frenchle entry.