### PR TITLE
Update postnotes status

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -8775,13 +8775,13 @@
 
  - name: postnotes
    type: package
-   status: partially-compatible
+   status: compatible
    included-in:
-   priority: 9
-   comments: "Does not error but `\\postnote`s are not tagged as `<Note>`s."
+   comments: "Also works for phase-II with listenv=none"
    issues:
    tests: true
-   updated: 2024-07-23
+   supported-through: [phase-III]
+   updated: 2024-10-16
 
  - name: prelim2e
    type: package

--- a/tagging-status/testfiles/postnotes/postnotes-01.tex
+++ b/tagging-status/testfiles/postnotes/postnotes-01.tex
@@ -1,22 +1,54 @@
-\DocumentMetadata
-  {
-    lang=en-US,
-    pdfversion=2.0,
-    pdfstandard=ua-2,
-    testphase={phase-III,math,title,table,firstaid}
-  }
-\documentclass{book}
+\DocumentMetadata{
+  testphase={phase-III,title} ,
+  pdfversion=2.0,
+  pdfstandard=ua-2,
+  % alternatively:
+  % pdfversion=1.7,
+  % pdfstandard=ua-1,
+  lang=en,
+}
+
+\documentclass{article}
+
+% This file focuses on the document elements which are actually being tagged
+% by the support provided by the package: the notes themselves, the marks,
+% cross-references (both LaTeX and PDF ones), and some special cases.
 \usepackage{postnotes}
+\postnotesetup{multiple}
+
+\usepackage{zref-user,zref-hyperref}
 \usepackage{hyperref}
+\hypersetup{hidelinks}
+
+\title{Example file for postnotes PDF tagging support}
+
 \begin{document}
-\chapter{First chapter}
-\postnotesection{\section*{Notes to chapter \pnthechapter}}
-Foo.\postnote{Foo note.}
-Bar.\postnote{Bar note.}
-\chapter{Second chapter}
-\postnotesection{\section*{Notes to chapter \pnthechapter}}
-\setcounter{postnote}{0}
-Baz.\postnote{Baz note.}
-Boo.\postnote{Boo note.}
+
+\section{Section 1}
+
+\postnote[label=en:mark:1,zlabel=zen:mark:1]{%
+  \label{en:text:1}\zlabel{zen:text:1}1}
+
+\postnoteref{en:text:1}\par
+\postnotezref{zen:text:1}\par
+\postnoteref{en:mark:1}\par
+\postnotezref{zen:mark:1}
+
+\postnote[label=en:mark:2,zlabel=zen:mark:2]{%
+  \label{en:text:2}\zlabel{zen:text:2}2}
+
+\postnoteref{en:text:2}\par
+\postnotezref{zen:text:2}\par
+\postnoteref{en:mark:2}\par
+\postnotezref{zen:mark:2}
+
+% A nomark note is tagged as a NonStruct element, but gets all references.
+\postnote[nomark]{\label{en:text:3}3}
+\postnoteref{en:text:3}
+
+% The multisep is tagged as an artifact.
+\postnote{4}\postnote{5}
+
 \printpostnotes
+
 \end{document}

--- a/tagging-status/testfiles/postnotes/postnotes-02.tex
+++ b/tagging-status/testfiles/postnotes/postnotes-02.tex
@@ -1,22 +1,56 @@
-\DocumentMetadata
-  {
-    lang=en-US,
-    pdfversion=2.0,
-    pdfstandard=ua-2,
-    testphase={phase-III,math,title,table,firstaid}
-  }
+\DocumentMetadata{
+  testphase={phase-III,title} ,
+  pdfversion=2.0,
+  pdfstandard=ua-2,
+  lang=en,
+}
+
 \documentclass{book}
+
 \usepackage{postnotes}
-\postnotesetup{heading={\section*{\pntitle}}}
+
+% 'style=endnotes' sets 'listenv=none'. With that, \printpostnotes is typeset
+% without a list environment, hence the tagged structure is different.
+\postnotesetup{style=endnotes}
+
+\usepackage{lipsum}
 \usepackage{hyperref}
+\hypersetup{hidelinks}
+
+\title{Example file for postnotes PDF tagging support}
+
 \begin{document}
-\chapter{First chapter}
-Foo.\postnote{Foo note.}
-Bar.\postnote{Bar note.}
+
+\chapter{Chapter 1}
+
+\lipsum[1]\postnote[label=en:mark:1]{\label{en:text:1}\lipsum[2-3]}
+
+\postnoteref{en:text:1}\par
+\postnoteref{en:mark:1}
+
+\lipsum[4]\postnote{\lipsum[5]}
+
+\lipsum[6]\postnote{\lipsum[7]}
+
+\chapter{Chapter 2}
+
+\lipsum[8]\postnote[label=en:mark:3]{\label{en:text:3}\lipsum[9-10]}
+
+\postnoteref{en:text:3}\par
+\postnoteref{en:mark:3}
+
+\lipsum[11]\postnote{\lipsum[12]}
+
+\lipsum[13]\postnote{\lipsum[14]}
+
+\chapter{Chapter 3}
+
+\lipsum[15]\postnote{\lipsum[16-17]}
+
+\lipsum[18]\postnote{\lipsum[19]}
+
+\lipsum[20]\postnote{\lipsum[21]}
+
 \printpostnotes
-\chapter{Second chapter}
-\setcounter{postnote}{0}
-Baz.\postnote{Baz note.}
-Boo.\postnote{Boo note.}
-\printpostnotes
+
 \end{document}

--- a/tagging-status/testfiles/postnotes/postnotes-03.tex
+++ b/tagging-status/testfiles/postnotes/postnotes-03.tex
@@ -1,25 +1,56 @@
-\DocumentMetadata
-  {
-    lang=en-US,
-    pdfversion=2.0,
-    pdfstandard=ua-2,
-    testphase={phase-III,math,title,table,firstaid}
-  }
+\DocumentMetadata{
+  testphase={phase-III,title} ,
+  pdfversion=2.0,
+  pdfstandard=ua-2,
+  lang=en,
+}
+
 \documentclass{book}
+
 \usepackage{postnotes}
+
+% A document with postnotesections and per chapter resetting of the counter.
+\AddToHook{cmd/chapter/before}{%
+  \postnotesection{\section*{Notes to chapter \pnthechapternextnote}}}
+\counterwithin*{postnote}{chapter}
+
+\usepackage{lipsum}
 \usepackage{hyperref}
+
+\title{Example file for postnotes PDF tagging support}
+
 \begin{document}
-\chapter{First chapter}
-\postnote{1}
-\postnote{2}
-\begin{table}[p]
-\caption{Table}
-Table.\postnote[mark=5]{3}
-\end{table}
-\postnote{4}
-\postnote{5}
-\stepcounter{postnote}
-\clearpage
-\postnote{6}
+
+\chapter{Chapter 1}
+
+\lipsum[1]\postnote[label=en:mark:1]{\label{en:text:1}\lipsum[2-3]}
+
+\postnoteref{en:text:1}\par
+\postnoteref{en:mark:1}
+
+\lipsum[4]\postnote{\lipsum[5]}
+
+\lipsum[6]\postnote{\lipsum[7]}
+
+\chapter{Chapter 2}
+
+\lipsum[8]\postnote[label=en:mark:3]{\label{en:text:3}\lipsum[9-10]}
+
+\postnoteref{en:text:3}\par
+\postnoteref{en:mark:3}
+
+\lipsum[11]\postnote{\lipsum[12]}
+
+\lipsum[13]\postnote{\lipsum[14]}
+
+\chapter{Chapter 3}
+
+\lipsum[15]\postnote{\lipsum[16]}
+
+\lipsum[17]\postnote{\lipsum[18]}
+
+\lipsum[19]\postnote{\lipsum[20]}
+
 \printpostnotes
+
 \end{document}

--- a/tagging-status/testfiles/postnotes/postnotes-04.tex
+++ b/tagging-status/testfiles/postnotes/postnotes-04.tex
@@ -1,22 +1,60 @@
-\DocumentMetadata
-  {
-    lang=en-US,
-    pdfversion=2.0,
-    pdfstandard=ua-2,
-    testphase={phase-III,math,title,table,firstaid}
-  }
+\DocumentMetadata{
+  testphase={phase-III,title} ,
+  pdfversion=2.0,
+  pdfstandard=ua-2,
+  lang=en,
+}
+
 \documentclass{book}
+
 \usepackage{postnotes}
+
+% A document with printpostnotes at the end of each chapter and counter
+% resetting.
+\postnotesetup{heading={\section*{\pntitle}}}
+\counterwithin*{postnote}{chapter}
+
+\usepackage{lipsum}
 \usepackage{hyperref}
+
+\title{Example file for postnotes PDF tagging support}
+
 \begin{document}
-\chapter{First chapter}
-\postnotesection{\section*{Notes to chapter \pnthechapter}}
-Foo.\postnote{Foo note.}
-Bar.\postnote{Bar note.}
-\chapter{Second chapter}
-\postnotesection{\section*{Notes to chapter \pnthechapter}}
-\setcounter{postnote}{0}
-Baz.\postnote{Baz note.}
-Boo.\postnote{Boo note.}
+
+\chapter{Chapter 1}
+
+\lipsum[1]\postnote[label=en:mark:1]{\label{en:text:1}\lipsum[2-3]}
+
+\postnoteref{en:text:1}\par
+\postnoteref{en:mark:1}
+
+\lipsum[4]\postnote{\lipsum[5]}
+
+\lipsum[6]\postnote{\lipsum[7]}
+
 \printpostnotes
+
+\chapter{Chapter 2}
+
+\lipsum[8]\postnote[label=en:mark:3]{\label{en:text:3}\lipsum[9-10]}
+
+\postnoteref{en:text:3}\par
+\postnoteref{en:mark:3}
+
+\lipsum[11]\postnote{\lipsum[12]}
+
+\lipsum[13]\postnote{\lipsum[14]}
+
+\printpostnotes
+
+\chapter{Chapter 3}
+
+\lipsum[15]\postnote{\lipsum[16]}
+
+\lipsum[17]\postnote{\lipsum[18]}
+
+\lipsum[19]\postnote{\lipsum[20]}
+
+\printpostnotes
+
 \end{document}

--- a/tagging-status/testfiles/postnotes/postnotes-05.tex
+++ b/tagging-status/testfiles/postnotes/postnotes-05.tex
@@ -1,0 +1,42 @@
+\DocumentMetadata{
+  testphase={phase-III,title} ,
+  pdfversion=2.0,
+  pdfstandard=ua-2,
+  lang=en,
+}
+
+\documentclass{book}
+
+\usepackage{postnotes}
+% An example involving floats, manual counter setting, manual mark, sorting,
+% etc.
+
+\usepackage{hyperref}
+
+\title{Example file for postnotes PDF tagging support}
+
+\begin{document}
+
+\chapter{First chapter}
+
+\postnote{1}
+
+\postnote{2}
+
+\begin{table}[p]
+\caption{Table}
+Table.\postnote[markstr=5*,sortnum=5]{3}
+\end{table}
+
+\postnote{4}
+
+\postnote{5}
+
+\stepcounter{postnote}
+\clearpage
+
+\postnote{6}
+
+\printpostnotes
+
+\end{document}


### PR DESCRIPTION
Tagging support for `postnotes` was added on v0.3.0 which was sent to CTAN on
Tuesday, so hopefully it has already reached you folks.

The PR includes updated testfiles for you to play with. The first two are
arguably the most relevant since they emphasize the part of the tagging
support which is actually being done by `postnotes`.
