### PR TITLE
add jlreq status; mention AMS and beamer issues

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -11885,22 +11885,24 @@
    status: partially-compatible
    included-in: [tlc3, arxiv10]
    priority: 2
+   issues: [443,737]
    supported-through: [phase-III,firstaid,title]
    comments: "theorem environments not compatible, see amsthm. Currently `\\maketitle` will need adjustment. Used by project example arxiv3"
    tests: false
    tasks: needs further tests
-   updated: 2024-07-07
+   updated: 2024-10-18
 
  - name: amsbook
    type: class
    status: partially-compatible
    included-in: [tlc3, arxiv001]
    priority: 2
+   issues: [443,737]
    supported-through: [phase-III,firstaid,title]
    comments: "theorem environments not compatible, see amsthm.  Currently `\\maketitle` will need adjustment."
    tests: false
    tasks: needs further tests
-   updated: 2024-07-07
+   updated: 2024-10-18
 
  - name: amsldoc
    ctan-pkg: amscls
@@ -11908,21 +11910,23 @@
    status: currently-incompatible
    included-in:
    priority: 2
+   issues: [737]
    comments: "See some needed adjustments in project example `amsldoc`"
    tests: false
    tasks: needs further tests
-   updated: 2024-07-07
+   updated: 2024-10-18
 
  - name: amsproc
    type: class
    status: partially-compatible
    included-in: [arxiv01]
    priority: 6
+   issues: [443,737]
    supported-through: [phase-III,firstaid,title]
    comments: "theorem environments not compatible, see amsthm.  Currently `\\maketitle` will need adjustment."
    tests: false
    tasks: needs further tests
-   updated: 2024-08-06
+   updated: 2024-10-18
 
  - name: article
    type: class
@@ -11939,8 +11943,10 @@
    status: currently-incompatible
    included-in:
    priority: 2
+   issues: [710]
    tests: false
-   updated: 2024-07-07
+   tasks: needs tests
+   updated: 2024-10-18
 
  - name: book
    type: class
@@ -11990,13 +11996,12 @@
 
  - name: jlreq
    type: class
-   status: unknown
+   status: currently-incompatible
    included-in:
    priority: 9
-   issues:
-   tests: false
-   tasks: needs tests
-   updated: 2024-07-18
+   issues: [719]
+   tests: true
+   updated: 2024-10-18
 
 #------------------------ KKK ----------------------------
 

--- a/tagging-status/testfiles/jlreq/jlreq-01.tex
+++ b/tagging-status/testfiles/jlreq/jlreq-01.tex
@@ -1,0 +1,21 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,title,table,firstaid}
+  }
+\documentclass[report]{jlreq}
+
+\title{jlreq tagging test}
+
+\begin{document}
+
+\tableofcontents % errors
+
+\chapter{Chapter} % errors
+\section{Section} % parent-child warnings
+\subsection{Subsection} % parent-child warnings
+text
+
+\end{document}


### PR DESCRIPTION
Lists jlreq as currently-incompatible. Adds issues for the AMS classes and beamer.