### PR TITLE
update pstricks status

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -8902,14 +8902,15 @@
 
  - name: pstricks
    type: package
-   status: currently-incompatible
+   status: partially-compatible
    included-in: [tlc3, arxiv1]
    priority: 2
-   comments: "Tagging passes validation but is suboptimal. Future compatibility
-              will only be with lualatex; dvips cannot properly support PDF/UA."
+   comments: "Compatibility is only with lualatex; dvips cannot properly support PDF/UA.
+             Offers `alt`, `actualtext`, `artifact`, and `correct-BBox` keys.
+             Not tagged as figures."
    issues:
    tests: true
-   updated: 2024-07-12
+   updated: 2024-11-19
 
  - name: px-ds
    ctan-pkg: pxtxalfa

--- a/tagging-status/testfiles/pstricks/pstricks-02.tex
+++ b/tagging-status/testfiles/pstricks/pstricks-02.tex
@@ -1,0 +1,61 @@
+% !TeX program = txs:///lualatex | txs:///view-pdf
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase={phase-III,math,table,title,firstaid},
+  }
+\documentclass{article}
+
+\usepackage{pstricks,multido}
+
+\begin{document}
+
+Some text
+\psset{unit=1.2cm}
+\begin{pspicture}[alt=A pie chart](-2.2,-2.2)(2.2,2.2)
+\pswedge[fillstyle=solid,fillcolor=gray]{2}{0}{70}
+\pswedge[fillstyle=solid,fillcolor=lightgray]{2}{70}{200}
+\pswedge[fillstyle=solid,fillcolor=darkgray]{2}{200}{360}
+\SpecialCoor
+\psset{framesep=1.5pt}
+\rput(1.2;35){\psframebox*{\small\$9.0M}}
+\uput{2.2}[45](0,0){Oreos}
+\rput(1.2;135){\psframebox*{\small\$16.7M}}
+\uput{2.2}[135](0,0){Heath}
+\rput(1.2;280){\psframebox*{\small\$23.1M}}
+\uput{2.2}[280](0,0){M\&M}
+\end{pspicture}
+
+Some more text
+
+\begin{pspicture}[tag=artifact](-3.4,-3.4)(3.4,3.4)
+\newgray{mygray}{0} % Initialize ‘mygray’ for benefit
+\psset{fillstyle=solid,fillcolor=mygray} % of this line.
+\SpecialCoor
+\degrees[1.1]
+\multido{\n=0.0+.1}{11}{%
+\newgray{mygray}{\n}
+\psset{fillcolor=mygray}%
+\rput{\n}{\pswedge{3}{-.05}{.05}}
+\uput{3.2}[\n](0,0){\small\n}}
+\end{pspicture}
+
+And more text
+
+\begin{pspicture}[actualtext=A pie chart](-2.2,-2.2)(2.2,2.2)
+\pswedge[fillstyle=solid,fillcolor=gray]{2}{0}{70}
+\pswedge[fillstyle=solid,fillcolor=lightgray]{2}{70}{200}
+\pswedge[fillstyle=solid,fillcolor=darkgray]{2}{200}{360}
+\SpecialCoor
+\psset{framesep=1.5pt}
+\rput(1.2;35){\psframebox*{\small\$9.0M}}
+\uput{2.2}[45](0,0){Oreos}
+\rput(1.2;135){\psframebox*{\small\$16.7M}}
+\uput{2.2}[135](0,0){Heath}
+\rput(1.2;280){\psframebox*{\small\$23.1M}}
+\uput{2.2}[280](0,0){M\&M}
+\end{pspicture}
+
+\end{document}


### PR DESCRIPTION
In [this update](https://tug.org/svn/texlive/trunk/Master/texmf-dist/tex/generic/pstricks/pstricks.tex?r1=71752&r2=72868&sortby=rev&sortdir=down) pstricks added the `alt`, `actualtext`, `artifact`, and `correct-BBox` keys. Like luamplib, these use the internal tagpdf commands. The `pspicture`s are also not tagged as figures. Not sure what the correct tagging is here so changed it to partially-compatible.