### PR TITLE
remove stray sectioning commands

### DIFF
--- a/project-examples/SilvanusThompson/33283-tagged.tex
+++ b/project-examples/SilvanusThompson/33283-tagged.tex
@@ -264,8 +264,10 @@
     \small
     \phantomsection
     \pdfbookmark[0]{Transcriber's Note}{TransNote\themytnote}
-    \subsection*{\centering\normalfont\scshape%
-      \normalsize\MakeLowercase{\TransNote}}%
+    %\subsection*{
+    \centering\normalfont\scshape%
+      \normalsize\MakeLowercase{\TransNote}
+      %}%
 
     \raggedright
     #1
@@ -1135,6 +1137,7 @@ hard. Master these thoroughly, and the rest will
 follow. What one fool can do, another can.
 \DPPageSep{012.png}{xii}%
 \DPPageSep{013.png}{1}%
+
 \mainmatter
 \phantomsection\pdfbookmark[-1]{Main Matter}{Main Matter}
 
@@ -9928,6 +9931,7 @@ of differentiating them are set down on the left; the
 results of integrating them are set down on the right.
 May you find them useful!
 \DPPageSep{261.png}{249}%
+
 \backmatter
 \phantomsection
 \pdfbookmark[-1]{Back Matter}{Back Matter}
@@ -10241,7 +10245,10 @@ $ 2a·\sin 2ax$ & $\sin^2 ax$ & $\dfrac{x}{2} - \dfrac{\sin 2ax}{4a} + C $ \\
 \item[(7)] $\dfrac{30}{(3x + 2)^3}$,\quad $-\dfrac{270}{(3x + 2)^4}$.
 \end{itemize}
 
-\paragraph{\normalfont(\textit{Examples}, \Pageref{examples3}):}
+%\paragraph{\normalfont
+(\textit{Examples}, \Pageref{examples3}):
+%}
+
 \begin{itemize}
 \item[(1)] $\dfrac{6a}{b^2} x$,\quad $\dfrac{6a}{b^2}$.\hfil
 (2) $\dfrac{3a \sqrt{b}} {2 \sqrt{x}} - \dfrac{6b \sqrt[3]{a}}{x^3}$,\quad


### PR DESCRIPTION
Removes warnings about faulty sectioning nesting from the silvanusthompson example (a subsection command inside a minipage and a paragraph in the middle of a list). The empty lines before mainmatter and backmatter are only needed temporarly until the bug in the sec code is corrected.