### PR TITLE
Tagging setup key

### DIFF
--- a/project-examples/ASV/bible-17.tex
+++ b/project-examples/ASV/bible-17.tex
@@ -19,13 +19,9 @@
 %%%
 \DocumentMetadata{
  lang=en,
- testphase={
-     phase-III
-     },
  pdfversion=1.7,
  pdfstandard=ua-1,
- ,
-% uncompress % too big for ngpdf
+ tagging=on
 }
 %
 

--- a/project-examples/ASV/bible.tex
+++ b/project-examples/ASV/bible.tex
@@ -20,7 +20,7 @@
  pdfversion=2.0,
  pdfstandard=ua-2,
  pdfstandard=a-4,
- tagging=0n
+ tagging=on
 }
 %
 

--- a/project-examples/ASV/bible.tex
+++ b/project-examples/ASV/bible.tex
@@ -17,13 +17,10 @@
 %%%
 \DocumentMetadata{
  lang=en,
- testphase={
-     phase-III
-     },
  pdfversion=2.0,
  pdfstandard=ua-2,
  pdfstandard=a-4,
-% uncompress % too big for ngpdf
+ tagging=0n
 }
 %
 

--- a/project-examples/DEIMS-2024/tb139mitt-deims24-17.tex
+++ b/project-examples/DEIMS-2024/tb139mitt-deims24-17.tex
@@ -1,8 +1,8 @@
 \DocumentMetadata{
- lang=en,testphase={phase-III,table,title},
-   pdfversion=1.7,
-   ,
-   pdfstandard=ua-1
+ lang=en,
+ tagging=on,
+ pdfversion=1.7,
+ pdfstandard=ua-1
 }
 
 \renewcommand\DocumentMetadata[1]{}

--- a/project-examples/DEIMS-2024/tb139mitt-deims24.ltx
+++ b/project-examples/DEIMS-2024/tb139mitt-deims24.ltx
@@ -5,7 +5,8 @@
 
 \iftrue
 
-\DocumentMetadata{testphase={phase-III,table,title},
+\DocumentMetadata{
+   tagging=on,
    pdfversion=2.0,
    pdfstandard=a-4,
    pdfstandard=ua-2

--- a/project-examples/PHY-5250A-notes/5250A-23-group-theory-17.tex
+++ b/project-examples/PHY-5250A-notes/5250A-23-group-theory-17.tex
@@ -2,10 +2,8 @@
    lang=en,
    pdfversion=1.7,
    pdfstandard=ua-1,
-   , %  AF not in document catalog dictionary
-   testphase = {phase-III,math,title}}
-\tagpdfsetup{math/mathml/sources=, math/alt/use}
-\ifx\pdfvariable\undefined\else \pdfvariable omitcidset=1 \fi
+   tagging=on
+   }
 
 \renewcommand\DocumentMetadata[1]{}
 

--- a/project-examples/PHY-5250A-notes/5250A-23-group-theory-luamml.tex
+++ b/project-examples/PHY-5250A-notes/5250A-23-group-theory-luamml.tex
@@ -1,13 +1,11 @@
-% \DocumentMetadata (in input file)
+\DocumentMetadata{
+   lang=en,
+   pdfversion=2.0,
+   pdfstandard=ua-2,
+   pdfstandard=a-4f, %  AF not in document catalog dictionary
+   tagging=on
+   }
 
-\providecommand\thispdftagsetup{
-\tagpdfsetup{
-% math/mathml/structelem,
- math/mathml/luamml=true,
-% math/mathml/sources=,
-%  math/mathml/write-dummy
- math/alt/use=false,
- math/tex/AF=true
-}
-}
+\renewcommand\DocumentMetadata[1]{}   
+
 \input{5250A-23-group-theory}

--- a/project-examples/PHY-5250A-notes/5250A-23-group-theory-se.tex
+++ b/project-examples/PHY-5250A-notes/5250A-23-group-theory-se.tex
@@ -1,14 +1,11 @@
-% \DocumentMetadata (in input file)
+\DocumentMetadata{
+   lang=en,
+   pdfversion=2.0,
+   pdfstandard=ua-2,
+   pdfstandard=a-4f, %  AF not in document catalog dictionary
+   tagging-setup={math/setup=mathml-SE}
+   }
 
-\providecommand\thispdftagsetup{
-\tagpdfsetup{
- math/mathml/structelem,
- math/mathml/luamml=true,
- math/mathml/sources=,
-%  math/mathml/write-dummy
- math/alt/use=false,
- math/mathml/AF=false,
- math/tex/AF=false
-}
-}
+\renewcommand\DocumentMetadata[1]{}   
+
 \input{5250A-23-group-theory}

--- a/project-examples/PHY-5250A-notes/5250A-23-group-theory.tex
+++ b/project-examples/PHY-5250A-notes/5250A-23-group-theory.tex
@@ -3,19 +3,9 @@
    pdfversion=2.0,
    pdfstandard=ua-2,
    pdfstandard=a-4f, %  AF not in document catalog dictionary
-   testphase = {phase-III,math,title}}
+   tagging-setup={math/mathml/luamml/load=false}
+   }
 
-\providecommand\thispdftagsetup{
-\tagpdfsetup{
-% math/mathml/structelem,
- math/mathml/luamml=false,
-% math/mathml/sources=,
-%  math/mathml/write-dummy
- math/alt/use=false,
- math/tex/AF=true
-}
-}
-\thispdftagsetup
 
 \documentclass[12pt]{article}
 

--- a/project-examples/PHY-LaTeX-exam/PHY-exam-17.tex
+++ b/project-examples/PHY-LaTeX-exam/PHY-exam-17.tex
@@ -3,9 +3,8 @@
    pdfversion=1.7,
    pdfstandard=ua-1,
    uncompress,
-   ,
-   testphase = {phase-III,math,title}}
-\tagpdfsetup{math/mathml/sources=, math/alt/use}
+   tagging=on
+   }
 
 \renewcommand\DocumentMetadata[1]{}
 

--- a/project-examples/PHY-LaTeX-exam/PHY-exam-luamml.tex
+++ b/project-examples/PHY-LaTeX-exam/PHY-exam-luamml.tex
@@ -4,17 +4,11 @@
    pdfstandard=ua-2,
    uncompress,
    pdfstandard=a-4f,
-   testphase = {phase-III,math,title}}
+   tagging=on
+   }
 
 
 
 \renewcommand\DocumentMetadata[1]{}
-\tagpdfsetup{
-% math/mathml/structelem,
- math/mathml/luamml=true,
- math/mathml/sources=,
- math/alt/use=false,
- math/tex/AF=false
- }
 
 \input{PHY-exam}

--- a/project-examples/PHY-LaTeX-exam/PHY-exam-se.tex
+++ b/project-examples/PHY-LaTeX-exam/PHY-exam-se.tex
@@ -4,17 +4,7 @@
    pdfstandard=ua-2,
    uncompress,
    pdfstandard=a-4f,
-   testphase = {phase-III,math,title}}
-
-
-
-\renewcommand\DocumentMetadata[1]{}
-\tagpdfsetup{
- math/mathml/structelem,
- math/mathml/luamml=false,
- math/mathml/sources=,
- math/alt/use=false,
- math/tex/AF=false
- }
+   tagging-setup={math/setup=mathml-SE}
+}
 
 \input{PHY-exam}

--- a/project-examples/PHY-LaTeX-exam/PHY-exam.tex
+++ b/project-examples/PHY-LaTeX-exam/PHY-exam.tex
@@ -4,7 +4,8 @@
    pdfstandard=ua-2,
    uncompress,
    pdfstandard=a-4f,
-   testphase = {phase-III,math,title}}
+   tagging-setup={math/mathml/luamml/load=false}
+ }
  % \tagpdfsetup{math/mathml/write-dummy}
  
 \documentclass[a4paper,12pt,twoside]{article}

--- a/project-examples/SilvanusThompson/33283-tagged.tex
+++ b/project-examples/SilvanusThompson/33283-tagged.tex
@@ -1,10 +1,7 @@
 
 \DocumentMetadata{
  lang=en,
- testphase={
-     phase-III
-    ,math,table,title
-     },
+ tagging=on,
  pdfversion=2.0,
  pdfstandard=ua-2,
  pdfstandard=a-4f,

--- a/project-examples/align/align-af.tex
+++ b/project-examples/align/align-af.tex
@@ -2,14 +2,9 @@
 \DocumentMetadata{
   uncompress,
   lang=en,
-  testphase={latest},
-  pdfversion=2.0
+  pdfversion=2.0,
+  tagging=on
  }
 
-
-\tagpdfsetup{
-  math/setup=mathml-AF,
-  root-supplemental-file=latex-align-css.html
-  }
 
 \input{align}

--- a/project-examples/align/align-se.tex
+++ b/project-examples/align/align-se.tex
@@ -2,14 +2,9 @@
 \DocumentMetadata{
   uncompress,
   lang=en,
-  testphase={latest},
-  pdfversion=2.0
+  pdfversion=2.0,
+  tagging-setup={math/setup=mathml-SE}
  }
 
-
-\tagpdfsetup{
-  math/setup=mathml-SE,
-  root-supplemental-file=latex-align-css.html
-  }
 
 \input{align}

--- a/project-examples/amsldoc/amsldoc-luamml.tex
+++ b/project-examples/amsldoc/amsldoc-luamml.tex
@@ -19,10 +19,7 @@
 
 \DocumentMetadata{
  lang=en,
- testphase={
-     phase-III
-    ,math,table,title
-     },
+ tagging=on,
  pdfversion=2.0,
  pdfstandard=ua-2,
  pdfstandard=a-4f,

--- a/project-examples/amsldoc/amsldoc-se.tex
+++ b/project-examples/amsldoc/amsldoc-se.tex
@@ -22,7 +22,7 @@
  pdfversion=2.0,
  pdfstandard=ua-2,
  pdfstandard=a-4f,
- tagging-setup={math/setup=mathml-SE}
+ tagging-setup={math/setup=mathml-SE},
  uncompress
 }
 %\tagpdfsetup{math/mathml/write-dummy}

--- a/project-examples/amsldoc/amsldoc-se.tex
+++ b/project-examples/amsldoc/amsldoc-se.tex
@@ -19,23 +19,14 @@
 
 \DocumentMetadata{
  lang=en,
- testphase={
-     phase-III
-    ,math,table,title
-     },
  pdfversion=2.0,
  pdfstandard=ua-2,
  pdfstandard=a-4f,
+ tagging-setup={math/setup=mathml-SE}
  uncompress
 }
 %\tagpdfsetup{math/mathml/write-dummy}
-\tagpdfsetup{
- math/mathml/structelem,
- math/mathml/luamml=false,
- math/mathml/sources=,
- math/alt/use=false,
- math/tex/AF=false
- }
+
 \documentclass[leqno,titlepage,openany]{amsldoc}
 
 % ======== new ==============%

--- a/project-examples/amsldoc/amsldoc-tagged-17.tex
+++ b/project-examples/amsldoc/amsldoc-tagged-17.tex
@@ -2,17 +2,11 @@
 
 \DocumentMetadata{
  lang=en,
- testphase={
-     phase-III
-    ,math,table,title
-     },
+ tagging=on,
  pdfversion=1.7,
  pdfstandard=ua-1,
- ,
  uncompress
 }
-\tagpdfsetup{math/mathml/sources=, math/alt/use}
-\ifx\pdfvariable\undefined\else \pdfvariable omitcidset=1 \fi
 
 \renewcommand\DocumentMetadata[1]{}
 

--- a/project-examples/amsldoc/amsldoc-tagged.tex
+++ b/project-examples/amsldoc/amsldoc-tagged.tex
@@ -19,7 +19,7 @@
 
 \DocumentMetadata{
  lang=en,
- tagging-setup={math/mathml/luamml/load=false}
+ tagging-setup={math/mathml/luamml/load=false},
  pdfversion=2.0,
  pdfstandard=ua-2,
  pdfstandard=a-4f,

--- a/project-examples/amsldoc/amsldoc-tagged.tex
+++ b/project-examples/amsldoc/amsldoc-tagged.tex
@@ -19,10 +19,7 @@
 
 \DocumentMetadata{
  lang=en,
- testphase={
-     phase-III
-    ,math,table,title
-     },
+ tagging-setup={math/mathml/luamml/load=false}
  pdfversion=2.0,
  pdfstandard=ua-2,
  pdfstandard=a-4f,

--- a/project-examples/arxiv-1/2401.05361v1-luamml.tex
+++ b/project-examples/arxiv-1/2401.05361v1-luamml.tex
@@ -3,13 +3,10 @@
 %%
 \DocumentMetadata{
  lang=en,
- testphase={
-     phase-III
-    ,math,table,title
-     },
  pdfversion=2.0,
  pdfstandard=ua-2,
  pdfstandard=a-4f,
+ tagging=on,
  uncompress
 }
 %\tagpdfsetup{math/mathml/write-dummy}

--- a/project-examples/arxiv-1/2401.05361v1-se.tex
+++ b/project-examples/arxiv-1/2401.05361v1-se.tex
@@ -3,27 +3,16 @@
 %%
 \DocumentMetadata{
  lang=en,
- testphase={
-     phase-III
-    ,math,table,title
-     },
  pdfversion=2.0,
  pdfstandard=ua-2,
  pdfstandard=a-4f,
+ tagging-setup={math/setup=mathml-SE},
  uncompress
 }
 %\tagpdfsetup{math/mathml/write-dummy}
 
 \documentclass[11pt,a4paper]{article}
 
-
-\tagpdfsetup{
- math/mathml/structelem,
- math/mathml/luamml=false,
- math/mathml/sources=,
- math/alt/use=false,
- math/tex/AF=false
- }
 
 %dpc\usepackage[latin1]{inputenc}
 \usepackage{unicode-math}\usepackage{amsmath}

--- a/project-examples/arxiv-1/2401.05361v1-tagged-17.tex
+++ b/project-examples/arxiv-1/2401.05361v1-tagged-17.tex
@@ -3,18 +3,13 @@
 %%
 \DocumentMetadata{
  lang=en,
- testphase={
-     phase-III
-    ,math,table,title
-     },
  pdfversion=1.7,
  pdfstandard=ua-1,
- ,
+ tagging=on,
  uncompress
 }
 %\tagpdfsetup{math/mathml/write-dummy}
 
-\tagpdfsetup{math/mathml/sources=, math/alt/use}
 
 \documentclass[11pt,a4paper]{article}
 %dpc\usepackage[latin1]{inputenc}

--- a/project-examples/arxiv-1/2401.05361v1-tagged.tex
+++ b/project-examples/arxiv-1/2401.05361v1-tagged.tex
@@ -3,13 +3,10 @@
 %%
 \DocumentMetadata{
  lang=en,
- testphase={
-     phase-III
-    ,math,table,title
-     },
  pdfversion=2.0,
  pdfstandard=ua-2,
  pdfstandard=a-4f,
+ tagging-setup={math/mathml/luamml/load=false}
  uncompress
 }
 %\tagpdfsetup{math/mathml/write-dummy}

--- a/project-examples/arxiv-2/2401.09436v1-luamml.tex
+++ b/project-examples/arxiv-2/2401.09436v1-luamml.tex
@@ -3,13 +3,10 @@
 %%
 \DocumentMetadata{
  lang=en,
- testphase={
-     phase-III
-    ,math,table,title
-     },
  pdfversion=2.0,
  pdfstandard=ua-2,
  pdfstandard=a-4f,
+ tagging=on,
  uncompress
  }
 %\tagpdfsetup{math/mathml/write-dummy}

--- a/project-examples/arxiv-2/2401.09436v1-se.tex
+++ b/project-examples/arxiv-2/2401.09436v1-se.tex
@@ -3,13 +3,10 @@
 %%
 \DocumentMetadata{
  lang=en,
- testphase={
-     phase-III
-    ,math,table,title
-     },
  pdfversion=2.0,
  pdfstandard=ua-2,
  pdfstandard=a-4f,
+ tagging-setup={math/setup=mathml-SE},
  uncompress
  }
 \tagpdfsetup{

--- a/project-examples/arxiv-2/2401.09436v1-tagged-17.tex
+++ b/project-examples/arxiv-2/2401.09436v1-tagged-17.tex
@@ -3,18 +3,13 @@
 %%
 \DocumentMetadata{
  lang=en,
- testphase={
-     phase-III
-    ,math,table,title
-     },
  pdfversion=1.7,
  pdfstandard=ua-1,
- ,
+ tagging=on,
  uncompress
  }
 %\tagpdfsetup{math/mathml/write-dummy}
 
-\tagpdfsetup{math/mathml/sources=, math/alt/use}
  
 \documentclass[a4paper,11pt]{article}
 

--- a/project-examples/arxiv-2/2401.09436v1-tagged.tex
+++ b/project-examples/arxiv-2/2401.09436v1-tagged.tex
@@ -3,13 +3,10 @@
 %%
 \DocumentMetadata{
  lang=en,
- testphase={
-     phase-III
-    ,math,table,title
-     },
  pdfversion=2.0,
  pdfstandard=ua-2,
  pdfstandard=a-4f,
+ tagging-setup={math/mathml/luamml/load=false},
  uncompress
  }
 %\tagpdfsetup{math/mathml/write-dummy}

--- a/project-examples/arxiv-3/2401.09965v1-luamml.tex
+++ b/project-examples/arxiv-3/2401.09965v1-luamml.tex
@@ -3,13 +3,10 @@
 %%
 \DocumentMetadata{
  lang=en,
- testphase={
-     phase-III
-    ,math,table,title
-     },
  pdfversion=2.0,
  pdfstandard=ua-2,
  pdfstandard=a-4f,
+ tagging=on,
  uncompress
 }
 %\tagpdfsetup{math/mathml/write-dummy}

--- a/project-examples/arxiv-3/2401.09965v1-se.tex
+++ b/project-examples/arxiv-3/2401.09965v1-se.tex
@@ -3,23 +3,12 @@
 %%
 \DocumentMetadata{
  lang=en,
- testphase={
-     phase-III
-    ,math,table,title
-     },
  pdfversion=2.0,
  pdfstandard=ua-2,
  pdfstandard=a-4f,
+ tagging-setup={math/setup=mathml-SE},
  uncompress
 }
-\tagpdfsetup{
- math/mathml/structelem,
- math/mathml/luamml=false,
- math/mathml/sources=,
- math/alt/use=false,
- math/tex/AF=false
- }
-
 
 \NewCommandCopy\newt\newtheorem
 \documentclass[12pt,reqno]{amsart}

--- a/project-examples/arxiv-3/2401.09965v1-tagged-17.tex
+++ b/project-examples/arxiv-3/2401.09965v1-tagged-17.tex
@@ -3,18 +3,13 @@
 %%
 \DocumentMetadata{
  lang=en,
- testphase={
-     phase-III
-    ,math,table,title
-     },
  pdfversion=1.7,
  pdfstandard=ua-1,
- ,
+ tagging=on,
  uncompress
 }
 %\tagpdfsetup{math/mathml/write-dummy}
 
-\tagpdfsetup{math/mathml/sources=, math/alt/use}
 
 \NewCommandCopy\newt\newtheorem
 \documentclass[12pt,reqno]{amsart}

--- a/project-examples/arxiv-3/2401.09965v1-tagged.tex
+++ b/project-examples/arxiv-3/2401.09965v1-tagged.tex
@@ -3,13 +3,10 @@
 %%
 \DocumentMetadata{
  lang=en,
- testphase={
-     phase-III
-    ,math,table,title
-     },
  pdfversion=2.0,
  pdfstandard=ua-2,
  pdfstandard=a-4f,
+ tagging-setup={math/mathml/luamml/load=false},
  uncompress
 }
 %\tagpdfsetup{math/mathml/write-dummy}

--- a/project-examples/arxiv-4/1910.06709v2-luamml.tex
+++ b/project-examples/arxiv-4/1910.06709v2-luamml.tex
@@ -1,24 +1,15 @@
 
 \DocumentMetadata{
  lang=en,
- testphase={phase-III,math,table,title},
  pdfversion=2.0,
  pdfstandard=ua-2,
  pdfstandard=a-4f,
+ tagging=on,
  uncompress
 }
 \documentclass[11pt]{article}
 \usepackage{fullpage, amsmath}
 
-
-\tagpdfsetup{
-% math/mathml/structelem,
- math/mathml/luamml=true,
- math/mathml/sources=,
-%  math/mathml/write-dummy
- math/alt/use=false,
- math/tex/AF=false
-}
 
 \usepackage{unicode-math}
 \AtBeginDocument{\let\Box\mdlgwhtsquare}

--- a/project-examples/arxiv-4/1910.06709v2-se.tex
+++ b/project-examples/arxiv-4/1910.06709v2-se.tex
@@ -1,24 +1,15 @@
 
 \DocumentMetadata{
  lang=en,
- testphase={phase-III,math,table,title},
  pdfversion=2.0,
  pdfstandard=ua-2,
  pdfstandard=a-4f,
+ tagging-setup={math/setup=mathml-SE},
  uncompress
 }
 \documentclass[11pt]{article}
 \usepackage{fullpage, amsmath}
 
-
-\tagpdfsetup{
- math/mathml/structelem,
-%  math/mathml/luamml=true,
- math/mathml/sources=,
-%  math/mathml/write-dummy
- math/alt/use=false,
- math/tex/AF=false
-}
 
 \usepackage{unicode-math}
 \AtBeginDocument{\let\Box\mdlgwhtsquare}

--- a/project-examples/arxiv-4/1910.06709v2-tagged-17.tex
+++ b/project-examples/arxiv-4/1910.06709v2-tagged-17.tex
@@ -1,23 +1,14 @@
 
 \DocumentMetadata{
  lang=en,
- testphase={phase-III,math,table,title},
  pdfversion=1.7,
  pdfstandard=ua-1,
+ tagging=on,
  uncompress
 }
 \documentclass[11pt]{article}
 \usepackage{fullpage, amsmath}
 
-
-\tagpdfsetup{
-%  math/mathml/structelem,
-%  math/mathml/luamml=true,
-%  math/mathml/sources=,
-%  math/mathml/write-dummy
-%  math/alt/use=false,
-%  math/tex/AF=false
-}
 
 \usepackage{unicode-math}
 \AtBeginDocument{\let\Box\mdlgwhtsquare}

--- a/project-examples/arxiv-4/1910.06709v2-tagged.tex
+++ b/project-examples/arxiv-4/1910.06709v2-tagged.tex
@@ -1,24 +1,15 @@
 
 \DocumentMetadata{
  lang=en,
- testphase={phase-III,math,table,title},
  pdfversion=2.0,
  pdfstandard=ua-2,
  pdfstandard=a-4f,
+ tagging-setup={math/mathml/luamml/load=false},
  uncompress
 }
 \documentclass[11pt]{article}
 \usepackage{fullpage, amsmath}
 
-
-\tagpdfsetup{
-%  math/mathml/structelem,
-%  math/mathml/luamml=true,
-%  math/mathml/sources=,
-%  math/mathml/write-dummy
-%  math/alt/use=false,
-%  math/tex/AF=false
-}
 
 \usepackage{unicode-math}
 \AtBeginDocument{\let\Box\mdlgwhtsquare}

--- a/project-examples/bohr/47464-t-luamml.tex
+++ b/project-examples/bohr/47464-t-luamml.tex
@@ -107,22 +107,18 @@
 %%                                                                  %%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \listfiles
+
 \DocumentMetadata{
  lang=en,
  pdfversion=2.0,
  pdfstandard=ua-2,
  pdfstandard=a-4f,
- testphase=
-   {
-    phase-III, %lists,footnotes,sectioning,
-               %toc,marginpar,bibliography,floats,
-               %graphics ...
-    math,  
-    table, %tabular, tabularx, longtable
-    title  %maketitle
-   }
- }
+ tagging=on
+}
+
+
 %\tagpdfsetup{math/mathml/write-dummy}
+
 \documentclass[12pt]{book}[2005/09/16]
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%% PACKAGES %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/project-examples/bohr/47464-t-se.tex
+++ b/project-examples/bohr/47464-t-se.tex
@@ -107,28 +107,14 @@
 %%                                                                  %%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \listfiles
+
 \DocumentMetadata{
  lang=en,
  pdfversion=2.0,
  pdfstandard=ua-2,
- pdfstandard=a-4f,
- testphase=
-   {
-    phase-III, %lists,footnotes,sectioning,
-               %toc,marginpar,bibliography,floats,
-               %graphics ...
-    math,  
-    table, %tabular, tabularx, longtable
-    title  %maketitle
-   }
- }
-\tagpdfsetup{
- math/mathml/structelem,
- math/mathml/luamml=false,
- math/mathml/sources=,
- math/alt/use=false,
- math/tex/AF=false
- }
+ pdfstandard=a-4,
+ tagging-setup={math/setup=mathml-SE}
+}
 
 \documentclass[12pt]{book}[2005/09/16]
 

--- a/project-examples/bohr/47464-t-tagged-17.tex
+++ b/project-examples/bohr/47464-t-tagged-17.tex
@@ -107,21 +107,14 @@
 %%                                                                  %%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \listfiles
+
 \DocumentMetadata{
  lang=en,
  pdfversion=1.7,
  pdfstandard=ua-1,
- ,
- testphase=
-   {
-    phase-III, %lists,footnotes,sectioning,
-               %toc,marginpar,bibliography,floats,
-               %graphics ...
-    math,  
-    table, %tabular, tabularx, longtable
-    title  %maketitle
-   }
- }
+ tagging=on
+}
+
 
 \documentclass[12pt]{book}[2005/09/16]
 \let\chapter\undefined % UF they do not use chapters ...

--- a/project-examples/bohr/47464-t-tagged.tex
+++ b/project-examples/bohr/47464-t-tagged.tex
@@ -107,22 +107,18 @@
 %%                                                                  %%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \listfiles
+
 \DocumentMetadata{
  lang=en,
  pdfversion=2.0,
  pdfstandard=ua-2,
  pdfstandard=a-4f,
- testphase=
-   {
-    phase-III, %lists,footnotes,sectioning,
-               %toc,marginpar,bibliography,floats,
-               %graphics ...
-    math,  
-    table, %tabular, tabularx, longtable
-    title  %maketitle
-   }
- }
-\tagpdfsetup{math/mathml/write-dummy}
+ tagging-setup={math/mathml/luamml/load=false}
+}
+
+
+%\tagpdfsetup{math/mathml/write-dummy}
+
 \documentclass[12pt]{book}[2005/09/16]
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%% PACKAGES %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/project-examples/calc12book-src/calc12book.tex
+++ b/project-examples/calc12book-src/calc12book.tex
@@ -3,7 +3,7 @@
   pdfversion  = 2.0,
   pdfstandard = ua-2,
   pdfstandard = a-4,
-  testphase   = latest
+  tagging-setup={math/setup=mathml-SE}
 }
 
 

--- a/project-examples/calc12book-src/calc12book.tex
+++ b/project-examples/calc12book-src/calc12book.tex
@@ -7,8 +7,6 @@
 }
 
 
-\tagpdfsetup{math/mathml/structelem, math/mathml/AF=false, math/tex/AF=false, math/mathml/sources=}
-
 \documentclass[paper=letter,fontsize=11pt,headings=big,chapterprefix=false,
 appendixprefix,twoside,titlepage,open=any,numbers=noenddot,
 index=totoc]{scrbook}

--- a/project-examples/example-1/mathml-AF-ex1-17.tex
+++ b/project-examples/example-1/mathml-AF-ex1-17.tex
@@ -7,8 +7,6 @@
  tagging=on
 }
 
-\ifx\pdfvariable\undefined\else \pdfvariable omitcidset=1 \fi
-
 \renewcommand\DocumentMetadata[1]{}
 
 \input{mathml-AF-ex1}

--- a/project-examples/example-1/mathml-AF-ex1-17.tex
+++ b/project-examples/example-1/mathml-AF-ex1-17.tex
@@ -1,13 +1,12 @@
 
 \DocumentMetadata{
  lang=en,
-testphase={phase-III,math,table,title},
  pdfversion=1.7,
  pdfstandard=ua-1,
- ,
- uncompress
+ uncompress,
+ tagging=on
 }
-\tagpdfsetup{math/mathml/sources=, math/alt/use}
+
 \ifx\pdfvariable\undefined\else \pdfvariable omitcidset=1 \fi
 
 \renewcommand\DocumentMetadata[1]{}

--- a/project-examples/example-1/mathml-AF-ex1-luamml.tex
+++ b/project-examples/example-1/mathml-AF-ex1-luamml.tex
@@ -1,11 +1,11 @@
 
 \DocumentMetadata{
  lang=en,
-testphase={phase-III,math,table,title},
  pdfversion=2.0,
  pdfstandard=ua-2,
  pdfstandard=a-4f,
- uncompress
+ uncompress,
+ tagging=on
 }
 
 

--- a/project-examples/example-1/mathml-AF-ex1-se.tex
+++ b/project-examples/example-1/mathml-AF-ex1-se.tex
@@ -1,24 +1,17 @@
 
 \DocumentMetadata{
  lang=en,
-testphase={phase-III,math,table,title},
  pdfversion=2.0,
  pdfstandard=ua-2,
- pdfstandard=a-4f,
- uncompress
+ pdfstandard=a-4,
+ uncompress,
+ tagging-setup={math/setup=mathml-SE}
 }
 
 
 %\tagpdfsetup{math/mathml/write-dummy}
 \documentclass{article}
 
-\tagpdfsetup{
- math/mathml/structelem,
- math/mathml/luamml=false,
- math/mathml/sources=,
- math/alt/use=false,
- math/tex/AF=false
- }
 \usepackage{unicode-math}
 \setmainfont{STIX Two Text}
 \setmathfont{STIX Two Math}

--- a/project-examples/example-1/mathml-AF-ex1.tex
+++ b/project-examples/example-1/mathml-AF-ex1.tex
@@ -1,11 +1,11 @@
 
 \DocumentMetadata{
  lang=en,
-testphase={phase-III,math,table,title},
  pdfversion=2.0,
  pdfstandard=ua-2,
  pdfstandard=a-4f,
- uncompress
+ uncompress,
+ tagging-setup={math/mathml/luamml/load=false}
 }
 
 

--- a/project-examples/example-2/mathml-AF-ex2-17.tex
+++ b/project-examples/example-2/mathml-AF-ex2-17.tex
@@ -7,8 +7,6 @@
  tagging=on
 }
 
-\ifx\pdfvariable\undefined\else \pdfvariable omitcidset=1 \fi
-
 \renewcommand\DocumentMetadata[1]{}
 
 \input{mathml-AF-ex2}

--- a/project-examples/example-2/mathml-AF-ex2-17.tex
+++ b/project-examples/example-2/mathml-AF-ex2-17.tex
@@ -1,15 +1,12 @@
+
 \DocumentMetadata{
  lang=en,
- testphase={
-     phase-III
-    ,math,table,title
-     },
  pdfversion=1.7,
  pdfstandard=ua-1,
- ,
- uncompress
+ uncompress,
+ tagging=on
 }
-\tagpdfsetup{math/mathml/sources=, math/alt/use}
+
 \ifx\pdfvariable\undefined\else \pdfvariable omitcidset=1 \fi
 
 \renewcommand\DocumentMetadata[1]{}

--- a/project-examples/example-2/mathml-AF-ex2-luamml.tex
+++ b/project-examples/example-2/mathml-AF-ex2-luamml.tex
@@ -1,13 +1,10 @@
 \DocumentMetadata{
  lang=en,
- testphase={
-     phase-III
-    ,math,table,title
-     },
  pdfversion=2.0,
  pdfstandard=ua-2,
  pdfstandard=a-4f,
- uncompress
+ uncompress,
+ tagging=on
 }
 %\tagpdfsetup{math/mathml/write-dummy}
 \documentclass{article}

--- a/project-examples/example-2/mathml-AF-ex2-se.tex
+++ b/project-examples/example-2/mathml-AF-ex2-se.tex
@@ -1,21 +1,11 @@
 \DocumentMetadata{
  lang=en,
- testphase={
-     phase-III
-    ,math,table,title
-     },
  pdfversion=2.0,
  pdfstandard=ua-2,
  pdfstandard=a-4f,
- uncompress
+ uncompress,
+ tagging-setup={math/setup=mathml-SE}
 }
-\tagpdfsetup{
- math/mathml/structelem,
- math/mathml/luamml=false,
- math/mathml/sources=,
- math/alt/use=false,
- math/tex/AF=false
- }
 
 \documentclass{article}
 

--- a/project-examples/example-2/mathml-AF-ex2.tex
+++ b/project-examples/example-2/mathml-AF-ex2.tex
@@ -1,13 +1,10 @@
 \DocumentMetadata{
  lang=en,
- testphase={
-     phase-III
-    ,math,table,title
-     },
  pdfversion=2.0,
  pdfstandard=ua-2,
  pdfstandard=a-4f,
- uncompress
+ uncompress,
+ tagging-setup={math/mathml/luamml/load=false}
 }
 %\tagpdfsetup{math/mathml/write-dummy}
 \documentclass{article}

--- a/project-examples/example-3/Sample-AF-Math-LaTeX-17.tex
+++ b/project-examples/example-3/Sample-AF-Math-LaTeX-17.tex
@@ -7,8 +7,6 @@
  tagging=on
 }
 
-\ifx\pdfvariable\undefined\else \pdfvariable omitcidset=1 \fi
-
 \renewcommand\DocumentMetadata[1]{}
 
 \input{Sample-AF-Math-LaTeX}

--- a/project-examples/example-3/Sample-AF-Math-LaTeX-17.tex
+++ b/project-examples/example-3/Sample-AF-Math-LaTeX-17.tex
@@ -1,18 +1,12 @@
 
-% !TEX TS-program = lualatex-dev
-
 \DocumentMetadata{
  lang=en,
- testphase={
-     phase-III
-    ,math,table,title
-     },
  pdfversion=1.7,
  pdfstandard=ua-1,
- ,
- uncompress
+ uncompress,
+ tagging=on
 }
-\tagpdfsetup{math/mathml/sources=, math/alt/use}
+
 \ifx\pdfvariable\undefined\else \pdfvariable omitcidset=1 \fi
 
 \renewcommand\DocumentMetadata[1]{}

--- a/project-examples/example-3/Sample-AF-Math-LaTeX-luamml.tex
+++ b/project-examples/example-3/Sample-AF-Math-LaTeX-luamml.tex
@@ -1,9 +1,13 @@
-\tagpdfsetup{
-% math/mathml/structelem,
- math/mathml/luamml=true,
- math/alt/use=false,
- math/tex/AF=false
- }
+\DocumentMetadata{
+ lang=en,
+ pdfversion=2.0,
+ pdfstandard=ua-2,
+ pdfstandard=a-4f,
+ uncompress,
+ tagging=on
+}
 
+% hide existing \DocumentMetadata
+\renewcommand\DocumentMetadata[1]{}
 \input{Sample-AF-Math-LaTeX}
 

--- a/project-examples/example-3/Sample-AF-Math-LaTeX-se.tex
+++ b/project-examples/example-3/Sample-AF-Math-LaTeX-se.tex
@@ -1,9 +1,14 @@
-\tagpdfsetup{
- math/mathml/structelem,
-% math/mathml/luamml=true,
- math/alt/use=false,
- math/tex/AF=false
- }
 
+\DocumentMetadata{
+ lang=en,
+ pdfversion=2.0,
+ pdfstandard=ua-2,
+ pdfstandard=a-4,
+ uncompress,
+ tagging-setup={math/setup=mathml-SE}
+}
+
+% hide existing \DocumentMetadata
+\renewcommand\DocumentMetadata[1]{}
 \input{Sample-AF-Math-LaTeX}
 

--- a/project-examples/example-3/Sample-AF-Math-LaTeX.tex
+++ b/project-examples/example-3/Sample-AF-Math-LaTeX.tex
@@ -1,16 +1,11 @@
 
-% !TEX TS-program = lualatex-dev
-
 \DocumentMetadata{
  lang=en,
- testphase={
-     phase-III
-    ,math,table,title
-     },
  pdfversion=2.0,
  pdfstandard=ua-2,
  pdfstandard=a-4f,
- uncompress
+ uncompress,
+ tagging-setup={math/mathml/luamml/load=false}
 }
 %\tagpdfsetup{math/mathml/write-dummy}
 \documentclass{article}

--- a/project-examples/macbeth/macbeth-tagged-17.tex
+++ b/project-examples/macbeth/macbeth-tagged-17.tex
@@ -7,17 +7,12 @@
  lang=en,
  pdfversion=1.7,
  pdfstandard=ua-1,
- ,
- testphase=
-   {
-    phase-III, %lists,footnotes,sectioning,
-               %toc,marginpar,bibliography,floats,
-               %graphics ...
-    math,  
-    table, %tabular, tabularx, longtable
-    title  %maketitle
-   }
- }
+ tagging-setup = {
+  add-new-tag=Speaker/Strong,
+  add-new-tag=SceneDescription/Span,
+  role/user-NS=plays
+  }
+}
 
 \renewcommand\DocumentMetadata[1]{}
 

--- a/project-examples/macbeth/macbeth-tagged.tex
+++ b/project-examples/macbeth/macbeth-tagged.tex
@@ -8,24 +8,12 @@
  pdfversion=2.0,
  pdfstandard=ua-2,
  pdfstandard=a-4,
- testphase=
-   {
-    phase-III, %lists,footnotes,sectioning,
-               %toc,marginpar,bibliography,floats,
-               %graphics ...
-    math,  
-    table, %tabular, tabularx, longtable
-    title  %maketitle
-   }
- }
-
-\tagpdfsetup
- {
+ tagging-setup = {
   add-new-tag=Speaker/Strong,
   add-new-tag=SceneDescription/Span,
-  role/user-NS=plays,
-  math/mathml/luamml/load=false
- }
+  role/user-NS=plays
+  }
+}
 
 
 \documentclass{book}

--- a/project-examples/max-moritz/pg17161-tagged-17.tex
+++ b/project-examples/max-moritz/pg17161-tagged-17.tex
@@ -2,7 +2,7 @@
   
 \DocumentMetadata{
  lang=en,
- lang=de-DE  
+ lang=de-DE,
  pdfversion=1.7,
  pdfstandard=ua-1,
  tagging=on

--- a/project-examples/max-moritz/pg17161-tagged-17.tex
+++ b/project-examples/max-moritz/pg17161-tagged-17.tex
@@ -2,21 +2,11 @@
   
 \DocumentMetadata{
  lang=en,
+ lang=de-DE  
  pdfversion=1.7,
  pdfstandard=ua-1,
- ,
- testphase=
-   {
-    phase-III, %lists,footnotes,sectioning,
-               %toc,marginpar,bibliography,floats,
-               %graphics ...
-    table, %tabular, tabularx, longtable
-    title  %maketitle
-   },
- lang=de-DE  
+ tagging=on
  }
-
-\ifx\pdfvariable\undefined\else \pdfvariable omitcidset=1 \fi
 
 \renewcommand\DocumentMetadata[1]{}
 

--- a/project-examples/max-moritz/pg17161-tagged.tex
+++ b/project-examples/max-moritz/pg17161-tagged.tex
@@ -2,18 +2,11 @@
   
 \DocumentMetadata{
  lang=en,
+ lang=de-DE, 
  pdfversion=2.0,
  pdfstandard=ua-2,
  pdfstandard=a-4,
- testphase=
-   {
-    phase-III, %lists,footnotes,sectioning,
-               %toc,marginpar,bibliography,floats,
-               %graphics ...
-    table, %tabular, tabularx, longtable
-    title  %maketitle
-   },
- lang=de-DE  
+ tagging=on
  }
 \AddToHookWithArguments{env/otherlanguage/begin}{\tagpdfsetup{text/lang=\BCPdata{language}}} 
   \documentclass[a4paper,12pt]{article}

--- a/project-examples/nested-1/nested-1-luamml.tex
+++ b/project-examples/nested-1/nested-1-luamml.tex
@@ -1,5 +1,12 @@
-
-\newcommand\thistagpdf{
+\DocumentMetadata{
+ lang=en,
+ tagging=on,
+ pdfversion=2.0,
+ pdfstandard=ua-2,
+ pdfstandard=a-4f,
+ uncompress
 }
+
+\renewcommand\DocumentMetadata[1]{}
 
 \input{nested-1}

--- a/project-examples/nested-1/nested-1-se.tex
+++ b/project-examples/nested-1/nested-1-se.tex
@@ -1,12 +1,12 @@
+\DocumentMetadata{
+ lang=en,
+ tagging-setup={math/setup=mathml-SE},
+ pdfversion=2.0,
+ pdfstandard=ua-2,
+ pdfstandard=a-4f,
+ uncompress
+}
 
-\newcommand\thistagpdf{ 
-  \tagpdfsetup{
- math/mathml/structelem,
- math/mathml/luamml=false,
- math/mathml/sources=,
- math/alt/use=false,
- math/tex/AF=false
-}
-}
+\renewcommand\DocumentMetadata[1]{}
 
 \input{nested-1}

--- a/project-examples/nested-1/nested-1.tex
+++ b/project-examples/nested-1/nested-1.tex
@@ -1,10 +1,7 @@
 
 \DocumentMetadata{
  lang=en,
- testphase={
-     phase-III
-    ,math,table,title
-     },
+ tagging-setup={math/mathml/luamml/load=false},
  pdfversion=2.0,
  pdfstandard=ua-2,
  pdfstandard=a-4f,
@@ -13,10 +10,6 @@
 \documentclass{article}
 \usepackage{unicode-math}
 
-\providecommand\thistagpdf{%
-%\tagpdfsetup{math/mathml/write-dummy}
-}
-\thistagpdf
 
 \usepackage{hyperref}
 \begin{document}

--- a/project-examples/pdfa-art/pdfa-art-17.tex
+++ b/project-examples/pdfa-art/pdfa-art-17.tex
@@ -3,20 +3,9 @@
  lang=en,
  pdfversion=1.7,
  pdfstandard=ua-1,
- ,
- testphase=
-   {
-    phase-III, %lists,footnotes,sectioning,
-               %toc,marginpar,bibliography,floats,
-               %graphics ...
-    math,  
-    table, %tabular, tabularx, longtable
-    title  %maketitle
-   },
+ tagging=on,
  uncompress  
  }
-\tagpdfsetup{math/mathml/sources=, math/alt/use}
-\ifx\pdfvariable\undefined\else \pdfvariable omitcidset=1 \fi
 
 \renewcommand\DocumentMetadata[1]{}
 

--- a/project-examples/pdfa-art/pdfa-art.tex
+++ b/project-examples/pdfa-art/pdfa-art.tex
@@ -4,15 +4,7 @@
  pdfversion=2.0,
  pdfstandard=ua-2,
  pdfstandard=a-4,
- testphase=
-   {
-    phase-III, %lists,footnotes,sectioning,
-               %toc,marginpar,bibliography,floats,
-               %graphics ...
-    math,  
-    table, %tabular, tabularx, longtable
-    title  %maketitle
-   },
+ tagging=on,
  uncompress  
  }
 

--- a/project-examples/phoneme/phoneme.tex
+++ b/project-examples/phoneme/phoneme.tex
@@ -1,4 +1,4 @@
-\DocumentMetadata{uncompress,testphase=latest,pdfversion=2.0}
+\DocumentMetadata{uncompress,tagging=on,pdfversion=2.0}
 \documentclass[]{article}
 \begin{document}
 some text \tagstructbegin{tag=Span,phoneme=[ˈlaːtɛx]}\tagmcbegin{}LaTeX\tagstructend\tagmcbegin{} more text

--- a/project-examples/tagpdf/tagpdf-17.tex
+++ b/project-examples/tagpdf/tagpdf-17.tex
@@ -9,7 +9,7 @@
 
 \DocumentMetadata
  {
-   testphase={phase-III,title,table},
+   tagging=on,
    pdfversion=1.7,lang=en-UK,,pdfstandard=ua-1,
    pdfstandard=a-3u,
    %uncompress

--- a/project-examples/tagpdf/tagpdf.tex
+++ b/project-examples/tagpdf/tagpdf.tex
@@ -10,7 +10,7 @@
 \DocumentMetadata
  {
    % comment the following line to compile an untagged documentation:
-   testphase={phase-III,title,table},
+   tagging=on,
    pdfversion=2.0,lang=en-UK,pdfstandard=a-4,pdfstandard=ua-2
    %uncompress
  }


### PR DESCRIPTION

* This mostly just replaces `testphase=(phase-III,title,math}` and `\tahpdfsetup{...} by
`tagging-setup={...}`

* Some warnings that may or may not have been there before

 `arxiv-3/2401.09965v1-se.log`, `arxiv-4/1910.06709v2-se.log`, `bohr/47464-t-se.log`

  `Package tagpdf Warning: Parent-Child 'mtext/mathml' --> 'Link/pdf2'.`

   links in mathml....

* I broke `tagpdf` 

  ```
  tagpdf/tagpdf-17.log:Runaway argument?
  tagpdf/tagpdf.log:Runaway argument?
  ```

* and `amsldoc` all versions but `almsldoc-tagged.log`

  ```
  ! LaTeX Error: Control sequence \g__tag_struct_756_prop already defined.
  ! LaTeX Error: Control sequence \g__tag_struct_kids_756_seq already defined.
  ! Limit controls must follow a math operator.
  <argument> ...s _{A}, \qquad \varliminf \nolimits 
                                                  _{n\to \infty }
  ====>grabbed math=macro:->A_\infty + \pi A_0 \sim \mathbf {A}_{\boldsymbol {\in
  fty }} \boldsymbol {+} \boldsymbol {\pi } \mathbf {A}_{\boldsymbol {0}} \sim \p
  mb {A}_{\pmb {\infty }} \pmb {+}\pmb {\pi } \pmb {A}_{\pmb {0}}
  ! Undefined control sequence.
  <argument> \l_@@_tmpa_box 
  ! Undefined control sequence.
  \pmb@ ...ise \pmbraise@ \box_use:N \l_@@_tmpa_box 
                                                  \kern \dimen@ \mkern .4mu\...
  ```

(at least the amsldoc ones give same error in `main` using current code so not affected by this PR)