### PR TITLE
add status for box packages

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -228,13 +228,12 @@
 - name: adjcalc
   ctan-pkg: adjustbox
   type: package
-  status: unknown
+  status: compatible
   included-in: [arxiv1]
   priority: 5
   issues:
   tests: false
-  tasks: needs tests
-  updated: 2024-08-01
+  updated: 2025-04-05
 
 - name: adjmulticol
   type: package
@@ -247,13 +246,18 @@
 
 - name: adjustbox
   type: package
-  status: unknown
+  status: currently-incompatible
   included-in: [tlc3, arxiv1]
   priority: 2
+  comments: "`varwidth` and `stack` keys rely on currently-incompatible varwidth package.
+            Does not register `alt`, `artifact`, or `actualtext` keys for `\adjincludegraphics`.
+            `\adjustbox` creates empty tags."
   issues:
-  tests: false
-  tasks: needs tests
-  updated: 2024-07-13
+  external-issues: ["https://github.com/MartinScharrer/adjustbox/issues/4"]
+  package-repository: "https://github.com/MartinScharrer/adjustbox"
+  tests: true
+  tasks: more tests needed
+  updated: 2025-04-05
 
 - name: afterpage
   type: package
@@ -2872,6 +2876,7 @@
   status: unknown
   included-in: [arxiv001]
   priority: 7
+  package-repository: "https://github.com/MartinScharrer/collcell"
   issues:
   tests: false
   tasks: needs tests
@@ -2879,13 +2884,14 @@
 
 - name: collectbox
   type: package
-  status: unknown
+  status: partially-compatible
   included-in: [arxiv1]
   priority: 5
+  package-repository: "https://github.com/MartinScharrer/collectbox"
+  comments: "Limited by current tagging of boxes."
   issues:
-  tests: false
-  tasks: needs tests
-  updated: 2024-07-18
+  tests: true
+  updated: 2025-04-05
 
 - name: collref
   type: package
@@ -3513,13 +3519,15 @@
 
 - name: easyfig
   type: package
-  status: unknown
+  status: currently-incompatible
   included-in:
   priority: 9
+  package-repository: "https://github.com/MartinScharrer/easyfig"
+  comments: "Depends on currently-incompatible adjustbox."
   issues:
   tests: false
   tasks: needs tests
-  updated: 2024-07-18
+  updated: 2025-04-06
 
 - name: easylist
   type: package
@@ -5124,13 +5132,15 @@
 
 - name: gincltex
   type: package
-  status: unknown
+  status: currently-incompatible
   included-in:
   priority: 9
+  package-repository: "https://github.com/MartinScharrer/gincltex"
   issues:
+  comments: "Depends on currently-incompatible adjustbox."
   tests: false
   tasks: needs tests
-  updated: 2024-07-18
+  updated: 2025-04-06
 
 - name: gindex
   type: package
@@ -9121,13 +9131,15 @@
 
 - name: realboxes
   type: package
-  status: unknown
+  status: partially-compatible
   included-in: [arxiv001]
   priority: 7
+  package-repository: "https://github.com/MartinScharrer/realboxes"
+  comments: "Depends on partially-compatible collectbox. `\Parbox` produces parent-child
+            warnings. Graphics and dashbox macros not tagged correctly."
   issues:
-  tests: false
-  tasks: needs tests
-  updated: 2024-07-18
+  tests: true
+  updated: 2025-04-06
 
 - name: realscripts
   type: package
@@ -10065,13 +10077,15 @@
 
 - name: storebox
   type: package
-  status: unknown
+  status: currently-incompatible
   included-in:
   priority: 9
+  package-repository: "https://github.com/MartinScharrer/storebox"
+  comments: "Depends on partially-compatible collectbox. Loses all spaces in tags.
+            Requires luatex85 with lualatex."
   issues:
-  tests: false
-  tasks: needs tests
-  updated: 2024-07-18
+  tests: true
+  updated: 2025-04-06
 
 - name: stringenc
   type: package
@@ -11008,13 +11022,13 @@
 - name: trimclip
   ctan-pkg: adjustbox
   type: package
-  status: unknown
+  status: partially-compatible
   included-in: [arxiv1]
   priority: 5
+  comments: "Depends on partially-compatible collectbox. `\clipbox` adds empty tags."
   issues:
-  tests: false
-  tasks: needs tests
-  updated: 2024-08-01
+  tests: true
+  updated: 2025-04-05
 
 - name: trimspaces
   type: package
@@ -12331,6 +12345,7 @@
   status: currently-incompatible
   included-in: [arxiv01]
   priority: 6
+  package-repository: "https://github.com/MartinScharrer/standalone"
   issues:
   tests: true
   comments: "Content is lost at pdf level due to being boxed."

--- a/tagging-status/testfiles/adjustbox/adjustbox-01.tex
+++ b/tagging-status/testfiles/adjustbox/adjustbox-01.tex
@@ -1,0 +1,21 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase=latest
+  }
+\documentclass{article}
+\usepackage{adjustbox}
+
+\def\examplecontent{\includegraphics[width=2cm,alt=Example image]{example-image}}
+
+\begin{document}
+
+\adjustbox{}{\examplecontent}
+
+\adjustbox{scale=0.5}{\examplecontent}
+
+\adjincludegraphics[width=2cm,alt=Example image]{example-image}
+
+\end{document}

--- a/tagging-status/testfiles/collectbox/collectbox-01.tex
+++ b/tagging-status/testfiles/collectbox/collectbox-01.tex
@@ -1,0 +1,36 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase=latest
+  }
+\documentclass{article}
+\usepackage{collectbox}
+
+\newsavebox\mybox
+
+\newcommand*{\foobar}{%
+  \collectboxcheckenv{foobar}%
+  \collectbox*{\textit}%
+  }
+
+\begin{document}
+
+\collectbox{\textbf{\BOXCONTENT}}{Stuff}
+
+\collectbox*{\textbf}{Stuff}
+
+\collectbox[ABC]{\textbf{\BOXCONTENT}}[DEF]{Stuff}
+
+\collectboxto{\mybox}{XYZ}{More stuff}
+
+\usebox\mybox
+
+\foobar{Blub}
+
+\begin{foobar}
+Blub blub
+\end{foobar}
+
+\end{document}

--- a/tagging-status/testfiles/realboxes/realboxes-01.tex
+++ b/tagging-status/testfiles/realboxes/realboxes-01.tex
@@ -1,0 +1,54 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase=latest
+  }
+\documentclass{article}
+\usepackage[all]{realboxes}
+
+\def\examplecontent{ABC xyz}
+
+\newsavebox\mybox
+
+\begin{document}
+
+\examplecontent
+
+\Mbox{\examplecontent}
+
+\Makebox{\examplecontent}
+
+\Fbox{\examplecontent}
+
+\Framebox{\examplecontent}
+
+\Frame{\examplecontent}
+
+\Centerline{\examplecontent}
+
+\Rightline{\examplecontent}
+
+\Parbox{1cm}{\examplecontent} % parent-child warnings
+
+\Sbox{\mybox}{\examplecontent}
+
+\Colorbox{green}{\examplecontent}
+
+\Fcolorbox{blue}{green}{\examplecontent}
+
+\Rotatebox{30}{\examplecontent}
+
+\Scalebox{2}{\examplecontent}
+
+\Resizebox{2cm}{2cm}{\examplecontent}
+
+\Dbox{\examplecontent}
+
+\Dashbox{\examplecontent}
+
+\Lbox{\examplecontent}
+
+%\Dlbox{\examplecontent} % errors unrelated to tagging
+\end{document}

--- a/tagging-status/testfiles/storebox/storebox-01.tex
+++ b/tagging-status/testfiles/storebox/storebox-01.tex
@@ -1,0 +1,36 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase=latest
+  }
+\documentclass{article}
+\usepackage{storebox}
+\usepackage{luatex85}
+
+\newstorebox{\mybox}
+\begin{document}
+
+\storebox{\mybox}{\verb+Supports verbatim #$\empty+}
+
+\usestorebox{\mybox}
+\usestorebox{\mybox}
+
+\storebox\mybox\bgroup
+Can also be split
+\verb+\empty+
+\egroup
+
+\usestorebox{\mybox}
+\usestorebox{\mybox}
+
+\begin{storebox}{\mybox}
+ Or used as environment
+ (then will ignore leading and trailing spaces)
+\end{storebox}
+
+\usestorebox{\mybox}
+\usestorebox{\mybox}
+
+\end{document}

--- a/tagging-status/testfiles/trimclip/trimclip-01.tex
+++ b/tagging-status/testfiles/trimclip/trimclip-01.tex
@@ -1,0 +1,41 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase=latest
+  }
+\documentclass{article}
+\usepackage{trimclip}
+
+\def\examplecontent{\includegraphics[width=2cm,alt=Example image]{example-image}}
+
+\begin{document}
+
+\examplecontent
+
+\trimbox{1cm}{\examplecontent}
+
+\trimbox*{5pt 0pt 3em 2em}{\examplecontent}
+
+\begin{trimbox}{1cm}
+\examplecontent
+\end{trimbox}
+
+\clipbox{1cm}{\examplecontent}
+
+\clipbox*{5pt 0pt 3em 2em}{\examplecontent}
+
+\begin{clipbox}{1cm}
+\examplecontent
+\end{clipbox}
+
+\marginbox{1cm}{\examplecontent}
+
+\marginbox*{5pt 0pt 3em 2em}{\examplecontent}
+
+\begin{marginbox}{1cm}
+\examplecontent
+\end{marginbox}
+
+\end{document}


### PR DESCRIPTION
Lists `adjcalc` as compatible since it's just a package for calculating lengths.

Lists `adjustbox` as currently-incompatible since some keys rely on varwidth, it doesn't register the tagging-necessary graphics keys, and the tagging for boxes in general is not great at the moment.

Lists `collectbox` as partially-compatible since sometimes spaces are lost.

Lists `easyfig` and `gincltex` as currently-incompatible since they're built on top of `adjustbox`.

Lists `realboxes` as partially-compatible since mostly it look okay, but `\Parbox` produces parent-child warnings and the graphics and dashbox macros produce wrong tagging.

Lists `storebox` as currently-incompatible since it loses all spaces in the tags.

Lists `trimclip` as partially-compatible since it depends on collectbox and `\clipbox` produces some extra empty tags.