### PR TITLE
update aliascnt status

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -334,13 +334,14 @@
 
 - name: aliascnt
   type: package
-  status: unknown
+  status: partially-compatible
   included-in: [arxiv01]
   priority: 6
-  issues:
-  tests: false
-  tasks: needs tests
-  updated: 2024-07-18
+  issues: [229]
+  comments: "Actual function is not affected but one of its main uses, creating
+            sibling theorems, does not work with redefined `\\newtheorem`."
+  tests: true
+  updated: 2025-04-06
 
 - name: aligned-overset
   type: package
@@ -10661,7 +10662,7 @@
   status: currently-incompatible
   included-in: [tlc3, arxiv01]
   priority: 2
-  issues:
+  issues: [229]
   tests: true
   comments: "Numbering with sibling key is wrong."
   updated: 2024-08-08

--- a/tagging-status/testfiles/aliascnt/aliascnt-01.tex
+++ b/tagging-status/testfiles/aliascnt/aliascnt-01.tex
@@ -1,0 +1,47 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase=latest
+  }
+\documentclass{article}
+
+\usepackage{aliascnt}
+\usepackage{hyperref}
+
+\newtheorem{theorem}{Theorem}
+\newaliascnt{lemma}{theorem}
+\newtheorem{lemma}[lemma]{Lemma}
+\aliascntresetthe{lemma}
+
+% compare with
+%\newtheorem{theorem}{Theorem}
+%\newtheorem{lemma}[theorem]{Lemma}
+
+\providecommand{\theoremautorefname}{Theorem}
+\providecommand{\lemmaautorefname}{Lemma}
+
+\begin{document}
+
+\begin{theorem}\label{thm}
+Some text
+\end{theorem}
+
+\begin{lemma}\label{lem}
+Some more text
+\end{lemma}
+
+\begin{theorem}
+Some text
+\end{theorem}
+
+\begin{lemma}
+Some more text
+\end{lemma}
+
+\autoref{thm}
+
+\autoref{lem}
+
+\end{document}


### PR DESCRIPTION
Lists aliascnt as partially-compatible because while its mechanism is not affected by the tagging code, one of its main documented uses, sibling theorems, does not work with the tagging code `\newtheorem`. It does work with the redefined amsthm `\newtheorem`, though, since it uses traditional LaTeX counters.

Links #229 to the aliascnt and thmtools entries.