### PR TITLE
update babel listings in tagging-status.yml

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -986,7 +986,7 @@
   updated: 2024-09-01
 
 - name: babel/afrikaans
-  ctan-pkg: babel
+  ctan-pkg: babel-dutch
   type: package
   status: unknown
   included-in: [tlc3]
@@ -998,7 +998,7 @@
   updated: 2024-09-01
 
 - name: babel/australian
-  ctan-pkg: babel
+  ctan-pkg: babel-english
   type: package
   status: unknown
   included-in: [tlc3]
@@ -1010,7 +1010,7 @@
   updated: 2024-09-01
 
 - name: babel/albanian
-  ctan-pkg: babel
+  ctan-pkg: babel-albanian
   type: package
   status: unknown
   included-in: [tlc3]
@@ -1022,7 +1022,7 @@
   updated: 2024-09-01
 
 - name: babel/austrian
-  ctan-pkg: babel
+  ctan-pkg: babel-german
   type: package
   status: unknown
   included-in: [tlc3]
@@ -1034,7 +1034,7 @@
   updated: 2024-09-01
 
 - name: babel/azerbaijani
-  ctan-pkg: babel
+  ctan-pkg: babel-azerbaijani
   type: package
   status: unknown
   included-in: [tlc3]
@@ -1046,7 +1046,7 @@
   updated: 2024-09-01
 
 - name: babel/basque
-  ctan-pkg: babel
+  ctan-pkg: babel-basque
   type: package
   status: unknown
   included-in: [tlc3]
@@ -1058,7 +1058,7 @@
   updated: 2024-09-01
 
 - name: babel/belarusian
-  ctan-pkg: babel
+  ctan-pkg: babel-belarusian
   type: package
   status: unknown
   included-in: [tlc3]
@@ -1070,7 +1070,7 @@
   updated: 2024-09-01
 
 - name: babel/bosnian
-  ctan-pkg: babel
+  ctan-pkg: babel-bosnian
   type: package
   status: unknown
   included-in: [tlc3]
@@ -1082,7 +1082,7 @@
   updated: 2024-09-01
 
 - name: babel/brazilian
-  ctan-pkg: babel
+  ctan-pkg: babel-portuges
   type: package
   status: unknown
   included-in: [tlc3]
@@ -1094,7 +1094,7 @@
   updated: 2024-09-01
 
 - name: babel/breton
-  ctan-pkg: babel
+  ctan-pkg: babel-breton
   type: package
   status: unknown
   included-in: [tlc3]
@@ -1106,7 +1106,7 @@
   updated: 2024-09-01
 
 - name: babel/bulgarian
-  ctan-pkg: babel
+  ctan-pkg: babel-bulgarian
   type: package
   status: unknown
   included-in: [tlc3]
@@ -1118,7 +1118,7 @@
   updated: 2024-09-01
 
 - name: babel/catalan
-  ctan-pkg: babel
+  ctan-pkg: babel-catalan
   type: package
   status: unknown
   included-in: [tlc3]
@@ -1130,7 +1130,7 @@
   updated: 2024-09-01
 
 - name: babel/croatian
-  ctan-pkg: babel
+  ctan-pkg: babel-croatian
   type: package
   status: unknown
   included-in: [tlc3]
@@ -1142,7 +1142,7 @@
   updated: 2024-09-01
 
 - name: babel/czech
-  ctan-pkg: babel
+  ctan-pkg: babel-czech
   type: package
   status: unknown
   included-in: [tlc3]
@@ -1154,7 +1154,7 @@
   updated: 2024-09-01
 
 - name: babel/danish
-  ctan-pkg: babel
+  ctan-pkg: babel-danish
   type: package
   status: unknown
   included-in: [tlc3]
@@ -1166,7 +1166,7 @@
   updated: 2024-09-01
 
 - name: babel/dutch
-  ctan-pkg: babel
+  ctan-pkg: babel-dutch
   type: package
   status: unknown
   included-in: [tlc3]
@@ -1178,7 +1178,7 @@
   updated: 2024-09-01
 
 - name: babel/english
-  ctan-pkg: babel
+  ctan-pkg: babel-english
   type: package
   status: unknown
   included-in: [tlc3]
@@ -1190,7 +1190,7 @@
   updated: 2024-09-01
 
 - name: babel/esperanto
-  ctan-pkg: babel
+  ctan-pkg: babel-esperanto
   type: package
   status: unknown
   included-in: [tlc3]
@@ -1202,7 +1202,7 @@
   updated: 2024-09-01
 
 - name: babel/estonian
-  ctan-pkg: babel
+  ctan-pkg: babel-estonian
   type: package
   status: unknown
   included-in: [tlc3]
@@ -1214,7 +1214,7 @@
   updated: 2024-09-01
 
 - name: babel/finnish
-  ctan-pkg: babel
+  ctan-pkg: babel-finnish
   type: package
   status: unknown
   included-in: [tlc3]
@@ -1226,7 +1226,7 @@
   updated: 2024-09-01
 
 - name: babel/french
-  ctan-pkg: babel
+  ctan-pkg: babel-french
   type: package
   status: currently-incompatible
   included-in: [tlc3]
@@ -1238,7 +1238,7 @@
   updated: 2024-09-01
 
 - name: babel/friulan
-  ctan-pkg: babel
+  ctan-pkg: babel-friulan
   type: package
   status: unknown
   included-in: [tlc3]
@@ -1250,7 +1250,7 @@
   updated: 2024-09-01
 
 - name: babel/galician
-  ctan-pkg: babel
+  ctan-pkg: babel-galician
   type: package
   status: unknown
   included-in: [tlc3]
@@ -1261,8 +1261,20 @@
   tasks: needs tests
   updated: 2024-09-01
 
+- name: babel/georgian
+  ctan-pkg: babel-georgian
+  type: package
+  status: unknown
+  included-in: [tlc3]
+  priority: 2
+  comments:
+  issues:
+  tests: false
+  tasks: needs tests
+  updated: 2025-04-07
+
 - name: babel/german
-  ctan-pkg: babel
+  ctan-pkg: babel-german
   type: package
   status: unknown
   included-in: [tlc3]
@@ -1274,7 +1286,7 @@
   updated: 2024-09-01
 
 - name: babel/greek
-  ctan-pkg: babel
+  ctan-pkg: babel-greek
   type: package
   status: unknown
   included-in: [tlc3]
@@ -1286,7 +1298,7 @@
   updated: 2024-09-01
 
 - name: babel/hebrew
-  ctan-pkg: babel
+  ctan-pkg: babel-hebrew
   type: package
   status: unknown
   included-in: [tlc3]
@@ -1298,7 +1310,7 @@
   updated: 2024-09-01
 
 - name: babel/icelandic
-  ctan-pkg: babel
+  ctan-pkg: babel-icelandic
   type: package
   status: unknown
   included-in: [tlc3]
@@ -1310,7 +1322,7 @@
   updated: 2024-09-01
 
 - name: babel/indonesian
-  ctan-pkg: babel
+  ctan-pkg: babel-indonesian
   type: package
   status: unknown
   included-in: [tlc3]
@@ -1322,7 +1334,7 @@
   updated: 2024-09-01
 
 - name: babel/interlingua
-  ctan-pkg: babel
+  ctan-pkg: babel-interlingua
   type: package
   status: unknown
   included-in: [tlc3]
@@ -1334,7 +1346,7 @@
   updated: 2024-09-01
 
 - name: babel/irish
-  ctan-pkg: babel
+  ctan-pkg: babel-irish
   type: package
   status: unknown
   included-in: [tlc3]
@@ -1345,8 +1357,20 @@
   tasks: needs tests
   updated: 2024-09-01
 
+- name: babel/japanese
+  ctan-pkg: babel-japanese
+  type: package
+  status: unknown
+  included-in: [tlc3]
+  priority: 2
+  comments:
+  issues:
+  tests: false
+  tasks: needs tests
+  updated: 2025-04-07
+
 - name: babel/kurmanji
-  ctan-pkg: babel
+  ctan-pkg: babel-kurmanji
   type: package
   status: unknown
   included-in: [tlc3]
@@ -1358,7 +1382,7 @@
   updated: 2024-09-01
 
 - name: babel/latin
-  ctan-pkg: babel
+  ctan-pkg: babel-latin
   type: package
   status: unknown
   included-in: [tlc3]
@@ -1370,7 +1394,7 @@
   updated: 2024-09-01
 
 - name: babel/latvian
-  ctan-pkg: babel
+  ctan-pkg: babel-latvian
   type: package
   status: unknown
   included-in: [tlc3]
@@ -1382,7 +1406,7 @@
   updated: 2024-09-01
 
 - name: babel/lithuanian
-  ctan-pkg: babel
+  ctan-pkg: babel-lithuanian
   type: package
   status: unknown
   included-in: [tlc3]
@@ -1394,7 +1418,7 @@
   updated: 2024-09-01
 
 - name: babel/lowersorbian
-  ctan-pkg: babel
+  ctan-pkg: babel-sorbian
   type: package
   status: unknown
   included-in: [tlc3]
@@ -1406,7 +1430,7 @@
   updated: 2024-09-01
 
 - name: babel/macedonian
-  ctan-pkg: babel
+  ctan-pkg: babel-macedonian
   type: package
   status: unknown
   included-in: [tlc3]
@@ -1418,7 +1442,7 @@
   updated: 2024-09-01
 
 - name: babel/malay
-  ctan-pkg: babel
+  ctan-pkg: babel-malay
   type: package
   status: unknown
   included-in: [tlc3]
@@ -1430,7 +1454,7 @@
   updated: 2024-09-01
 
 - name: babel/magyar
-  ctan-pkg: babel
+  ctan-pkg: babel-hungarian
   type: package
   status: unknown
   included-in: [tlc3]
@@ -1441,8 +1465,20 @@
   tasks: needs tests
   updated: 2024-09-01
 
+- name: babel/mongolian
+  ctan-pkg: mongolian-babel
+  type: package
+  status: unknown
+  included-in: [tlc3]
+  priority: 2
+  comments:
+  issues:
+  tests: false
+  tasks: needs tests
+  updated: 2025-04-07
+
 - name: babel/naustrian
-  ctan-pkg: babel
+  ctan-pkg: babel-german
   type: package
   status: unknown
   included-in: [tlc3]
@@ -1454,7 +1490,7 @@
   updated: 2024-09-01
 
 - name: babel/ngerman
-  ctan-pkg: babel
+  ctan-pkg: babel-german
   type: package
   status: unknown
   included-in: [tlc3]
@@ -1466,7 +1502,7 @@
   updated: 2024-09-01
 
 - name: babel/norsk
-  ctan-pkg: babel
+  ctan-pkg: babel-norsk
   type: package
   status: unknown
   included-in: [tlc3]
@@ -1478,7 +1514,7 @@
   updated: 2024-09-01
 
 - name: babel/nynorsk
-  ctan-pkg: babel
+  ctan-pkg: babel-norsk
   type: package
   status: unknown
   included-in: [tlc3]
@@ -1490,7 +1526,7 @@
   updated: 2024-09-01
 
 - name: babel/occitan
-  ctan-pkg: babel
+  ctan-pkg: babel-occitan
   type: package
   status: unknown
   included-in: [tlc3]
@@ -1501,8 +1537,20 @@
   tasks: needs tests
   updated: 2024-09-01
 
+- name: babel/piedmontese
+  ctan-pkg: babel-piedmontese
+  type: package
+  status: unknown
+  included-in: [tlc3]
+  priority: 2
+  comments:
+  issues:
+  tests: false
+  tasks: needs tests
+  updated: 2025-04-07
+
 - name: babel/polish
-  ctan-pkg: babel
+  ctan-pkg: babel-polish
   type: package
   status: unknown
   included-in: [tlc3]
@@ -1514,7 +1562,7 @@
   updated: 2024-09-01
 
 - name: babel/polutonikogreek
-  ctan-pkg: babel
+  ctan-pkg: babel-greek
   type: package
   status: unknown
   included-in: [tlc3]
@@ -1526,7 +1574,7 @@
   updated: 2024-09-01
 
 - name: babel/portuguese
-  ctan-pkg: babel
+  ctan-pkg: babel-portuges
   type: package
   status: unknown
   included-in: [tlc3]
@@ -1538,7 +1586,7 @@
   updated: 2024-09-01
 
 - name: babel/romanian
-  ctan-pkg: babel
+  ctan-pkg: babel-romanian
   type: package
   status: unknown
   included-in: [tlc3]
@@ -1550,7 +1598,7 @@
   updated: 2024-09-01
 
 - name: babel/romansh
-  ctan-pkg: babel
+  ctan-pkg: babel-romansh
   type: package
   status: unknown
   included-in: [tlc3]
@@ -1562,7 +1610,7 @@
   updated: 2024-09-01
 
 - name: babel/russian
-  ctan-pkg: babel
+  ctan-pkg: babel-russian
   type: package
   status: unknown
   included-in: [tlc3]
@@ -1574,7 +1622,7 @@
   updated: 2024-09-01
 
 - name: babel/samin
-  ctan-pkg: babel
+  ctan-pkg: babel-samin
   type: package
   status: unknown
   included-in: [tlc3]
@@ -1586,7 +1634,7 @@
   updated: 2024-09-01
 
 - name: babel/scottish
-  ctan-pkg: babel
+  ctan-pkg: babel-scottish
   type: package
   status: unknown
   included-in: [tlc3]
@@ -1598,7 +1646,7 @@
   updated: 2024-09-01
 
 - name: babel/serbian
-  ctan-pkg: babel
+  ctan-pkg: babel-serbian
   type: package
   status: unknown
   included-in: [tlc3]
@@ -1610,7 +1658,7 @@
   updated: 2024-09-01
 
 - name: babel/serbianc
-  ctan-pkg: babel
+  ctan-pkg: babel-serbianc
   type: package
   status: unknown
   included-in: [tlc3]
@@ -1622,7 +1670,7 @@
   updated: 2024-09-01
 
 - name: babel/slovak
-  ctan-pkg: babel
+  ctan-pkg: babel-slovak
   type: package
   status: unknown
   included-in: [tlc3]
@@ -1634,7 +1682,7 @@
   updated: 2024-09-01
 
 - name: babel/slovene
-  ctan-pkg: babel
+  ctan-pkg: babel-slovenian
   type: package
   status: unknown
   included-in: [tlc3]
@@ -1646,7 +1694,7 @@
   updated: 2024-09-01
 
 - name: babel/spanish
-  ctan-pkg: babel
+  ctan-pkg: babel-spanish
   type: package
   status: currently-incompatible
   included-in: [tlc3]
@@ -1658,7 +1706,7 @@
   updated: 2024-09-01
 
 - name: babel/swedish
-  ctan-pkg: babel
+  ctan-pkg: babel-swedish
   type: package
   status: unknown
   included-in: [tlc3]
@@ -1669,8 +1717,20 @@
   tasks: needs tests
   updated: 2024-09-01
 
+- name: babel/thai
+  ctan-pkg: babel-thai
+  type: package
+  status: unknown
+  included-in: [tlc3]
+  priority: 2
+  comments:
+  issues:
+  tests: false
+  tasks: needs tests
+  updated: 2025-04-07
+
 - name: babel/turkish
-  ctan-pkg: babel
+  ctan-pkg: babel-turkish
   type: package
   status: unknown
   included-in: [tlc3]
@@ -1682,7 +1742,7 @@
   updated: 2024-09-01
 
 - name: babel/turkmen
-  ctan-pkg: babel
+  ctan-pkg: turkmen
   type: package
   status: unknown
   included-in: [tlc3]
@@ -1694,7 +1754,7 @@
   updated: 2024-09-01
 
 - name: babel/ukrainian
-  ctan-pkg: babel
+  ctan-pkg: babel-ukrainian
   type: package
   status: unknown
   included-in: [tlc3]
@@ -1706,7 +1766,7 @@
   updated: 2024-09-01
 
 - name: babel/uppersorbian
-  ctan-pkg: babel
+  ctan-pkg: babel-sorbian
   type: package
   status: unknown
   included-in: [tlc3]
@@ -1718,7 +1778,7 @@
   updated: 2024-09-01
 
 - name: babel/UKenglish
-  ctan-pkg: babel
+  ctan-pkg: babel-english
   type: package
   status: unknown
   included-in: [tlc3]
@@ -1730,7 +1790,7 @@
   updated: 2024-09-01
 
 - name: babel/USenglish
-  ctan-pkg: babel
+  ctan-pkg: babel-english
   type: package
   status: unknown
   included-in: [tlc3]
@@ -1742,7 +1802,7 @@
   updated: 2024-09-01
 
 - name: babel/vietnamese
-  ctan-pkg: babel
+  ctan-pkg: babel-vietnamese
   type: package
   status: unknown
   included-in: [tlc3]
@@ -1754,7 +1814,7 @@
   updated: 2024-09-01
 
 - name: babel/welsh
-  ctan-pkg: babel
+  ctan-pkg: babel-welsh
   type: package
   status: unknown
   included-in: [tlc3]


### PR DESCRIPTION
Updates the `ctan-pkg` entries for the babel listings. Also adds georgian, japanese, mongolian, piedmontese, and thai. These are all documented in the babel manual.

For test files, the entry names may have to be changed from `babel/<language>` to something else since the testfile folder name can't contain a slash (at least on my computer). Unless it's smart enough to recognize a subfolder `dutch` in the testfile folder `babel`, I didn't try.