### PR TITLE
update tagging-status; add test files

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -6934,13 +6934,13 @@
 
 - name: mathpazo
   type: package
-  status: partially-compatible
+  status: compatible
   included-in: [tlc3, arxiv01]
   priority: 2
-  comments: "Text collapses with pdflatex due to a pdftex engine bug."
+  comments: "A pdftex engine bug has been fixed."
   issues: [837]
   tests: true
-  updated: 2025-05-12
+  updated: 2025-05-18
 
 - name: mathpple
   type: package

--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -7600,12 +7600,14 @@
 
 - name: needspace
   type: package
-  status: compatible
+  status: currently-incompatible
   included-in: [tlc3, arxiv01]
   priority: 2
   issues:
+  package-repository: "https://github.com/LaTeX-Package-Repositories/herries-press"
+  external-issues: "https://github.com/LaTeX-Package-Repositories/herries-press/issues/54"
   tests: true
-  updated: 2024-08-03
+  updated: 2025-05-12
 
 - name: newapa
   type: package

--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -6934,12 +6934,13 @@
 
 - name: mathpazo
   type: package
-  status: compatible
+  status: partially-compatible
   included-in: [tlc3, arxiv01]
   priority: 2
-  issues:
-  tests: false
-  updated: 2024-07-15
+  comments: "Text collapses with pdflatex due to a pdftex engine bug."
+  issues: [837]
+  tests: true
+  updated: 2025-05-12
 
 - name: mathpple
   type: package

--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -540,7 +540,7 @@
   included-in: [tlc3, arxiv10]
   priority: 2
   supported-through: [phase-III,firstaid]
-  issues: [83,733,736]
+  issues: [83,733,736,759,790,792,835]
   tests: true
   updated: 2024-10-16
 
@@ -10725,8 +10725,12 @@
   status: currently-incompatible
   included-in: [tlc3, arxiv10]
   priority: 2
+  supported-through: [phase-III,tikz]
+  comments: tikz testphase module defines `alt`, `actualtext`, and `artifact` tikz keys.
+  issues: [30]
   references: [1]
-  updated: 2024-07-06
+  test: true
+  updated: 2025-05-08
 
 - name: tikz-cd
   type: package
@@ -10734,7 +10738,8 @@
   included-in: [tlc3, arxiv1]
   priority: 2
   issues: [30]
-  updated: 2024-07-06
+  tests: true
+  updated: 2025-05-08
 
 - name: tikzducks
   type: package
@@ -12221,6 +12226,16 @@
              [bible example](https://github.com/latex3/tagging-project/blob/main/project-examples/ASV/bible.tex)"
   tests: false
   updated: 2024-07-05
+
+- name: minimal
+  type: class
+  status: currently-incompatible
+  included-in:
+  priority:
+  comments: "The minimal class is not useful even for MWE's. Don't use it."
+  issues: [284]
+  tests: true
+  updated: 2025-05-08
 
 - name: mitthesis
   type: class

--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -3948,14 +3948,14 @@
 
 - name: esvect
   type: package
-  status: compatible
+  status: currently-incompatible
   included-in: [arxiv01]
   priority: 6
   supported-through: [phase-III,math]
   comments: "Use of math tagging currently requires support from external tools."
-  issues:
+  issues: [836]
   tests: true
-  updated: 2024-08-02
+  updated: 2025-05-12
 
 - name: etaremune
   type: package

--- a/tagging-status/testfiles/esvect/esvect-01.tex
+++ b/tagging-status/testfiles/esvect/esvect-01.tex
@@ -3,10 +3,11 @@
     lang=en-US,
     pdfversion=2.0,
     pdfstandard=ua-2,
-    testphase={phase-III,math,title,table,firstaid},
+    testphase=latest,
   }
 \documentclass{article}
 \usepackage{esvect}
+\usepackage{unicode-math}
 
 \title{esvect tagging test}
 

--- a/tagging-status/testfiles/mathpazo/mathpazo-01.tex
+++ b/tagging-status/testfiles/mathpazo/mathpazo-01.tex
@@ -1,0 +1,35 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase=latest,
+  }
+\documentclass{article}
+\usepackage{mathpazo}
+
+\title{mathpazo tagging test}
+
+\begin{document}
+{\Large Some intro text}
+
+{\tiny tiny text}
+
+{\scriptsize scriptsize text}
+
+{\footnotesize footnotesize text}
+
+{\small small text}
+
+{\normalsize Some normal size text}
+
+{\large Some large text}
+
+{\Large Some Large text}
+
+{\LARGE Some LARGE text}
+
+{\huge Some huge text}
+
+{\Huge Some Huge text}
+\end{document}

--- a/tagging-status/testfiles/minimal/minimal-01.tex
+++ b/tagging-status/testfiles/minimal/minimal-01.tex
@@ -1,0 +1,11 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase=latest,
+  }
+\documentclass{minimal}
+\begin{document}
+blub
+\end{document}

--- a/tagging-status/testfiles/needspace/needspace-02.tex
+++ b/tagging-status/testfiles/needspace/needspace-02.tex
@@ -1,0 +1,19 @@
+\DocumentMetadata{
+    pdfstandard = ua-2,
+    lang = de-AT,
+    pdfversion = 2.0,
+    testphase = latest,
+}
+\documentclass{article}
+\usepackage[margin=3.5cm, showframe]{geometry} 
+\usepackage{needspace}
+\usepackage{kantlipsum}
+
+\begin{document}
+    \kant[11-14]
+    \begin{itemize}
+        \item first item
+    \end{itemize}
+    \needspace{5\baselineskip}
+    \kant[62-65]
+\end{document}

--- a/tagging-status/testfiles/tikz-cd/tikz-cd-01.tex
+++ b/tagging-status/testfiles/tikz-cd/tikz-cd-01.tex
@@ -1,0 +1,25 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase=latest,
+  }
+\documentclass{article}
+
+\usepackage{unicode-math}
+\usepackage{tikz-cd}
+
+\begin{document}
+
+% this errors
+\[\begin{tikzcd}
+  A \& B
+\end{tikzcd}\]
+
+% this does not; not sure about the tagging
+\[\begin{tikzcd}[ampersand replacement=\&,]
+  A \& B
+\end{tikzcd}\]
+
+\end{document}

--- a/tagging-status/testfiles/tikz/tikz-01.tex
+++ b/tagging-status/testfiles/tikz/tikz-01.tex
@@ -1,0 +1,23 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase=latest,
+  }
+\documentclass{article}
+
+\usepackage{unicode-math}
+\usepackage{tikz}
+\usetikzlibrary{matrix}
+
+\begin{document}
+
+\begin{tikzpicture}
+\matrix[matrix of math nodes]
+  {
+    A & B \\
+  };
+\end{tikzpicture}
+
+\end{document}

--- a/tagging-status/testfiles/tikz/tikz-02.tex
+++ b/tagging-status/testfiles/tikz/tikz-02.tex
@@ -1,0 +1,35 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    testphase=latest,
+  }
+\documentclass{article}
+
+\usepackage{unicode-math}
+\usepackage{tikz}
+
+\begin{document}
+
+\begin{tikzpicture}[alt=some axes]
+\draw (-1.5,0) -- (1.5,0);
+\draw (0,-1.5) -- (0,1.5);
+\end{tikzpicture}
+
+\begin{tikzpicture}[actualtext=just a test]
+\filldraw [gray] (0,0) circle [radius=2pt]
+(1,1) circle [radius=2pt]
+(2,1) circle [radius=2pt]
+(2,0) circle [radius=2pt];
+\draw (0,0) .. controls (1,1) and (2,1) .. (2,0);
+\end{tikzpicture}
+
+\begin{tikzpicture}[artifact]
+\draw (-1.5,0) -- (1.5,0);
+\draw (0,-1.5) -- (0,1.5);
+\draw (-1,0) .. controls (-1,0.555) and (-0.555,1) .. (0,1)
+.. controls (0.555,1) and (1,0.555) .. (1,0);
+\end{tikzpicture}
+
+\end{document}


### PR DESCRIPTION
Updates the tagging-status entries for amsthm, tikz, and tikz-cd. I left the status of tikz as currently-incompatible instead of partially-compatible because of #30 and because it's a huge package that surely has other incompatibilities. Let me know if that should change.

Lists the minimal class as incompatible.

Adds test files for tikz and tikz-cd.

Updates the status for needspace to reflect https://github.com/LaTeX-Package-Repositories/herries-press/issues/54.

Lists esvect as currently incompatible due to #836.

