### PR TITLE
Morepkg

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -6885,10 +6885,13 @@
   status: unknown
   included-in:
   priority: 9
+  supported-through: [phase-III,package]
+  package-repository: "https://github.com/dohyunkim/luatexko"
+  comments: "Package provides tagging support for `\\ruby`, `\\dotemph`, `\\uline`, and other underline-type commands."
   issues:
-  tests: false
-  tasks: needs tests
-  updated: 2024-07-18
+  tests: true
+  tasks: Tests need to be checked.
+  updated: 2025-06-08
 
 - name: luatodonotes
   type: package

--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -2237,6 +2237,15 @@
   tests: true
   updated: 2024-08-16
 
+- name: bonum-otf
+  type: package
+  status: compatible
+  included-in:
+  priority: 9
+  issues:
+  tests: false
+  updated: 2025-06-07
+
 - name: booklet
   type: package
   status: currently-incompatible
@@ -6910,12 +6919,14 @@
 
 - name: lucidabr
   type: package
-  status: compatible
+  status: partially-compatible
   included-in: [tlc3]
   priority: 2
+  supported-through: [phase-III,math]
+  comments: "Incompatible with unicode-math. No luamml support."
   issues:
   tests: false
-  updated: 2024-07-15
+  updated: 2025-06-07
 
 - name: luciole
   type: package
@@ -7184,6 +7195,7 @@
   status: partially-compatible
   included-in: [tlc3, arxiv01]
   priority: 2
+  supported-through: [phase-III,math]
   comments: "A pdftex engine bug has been fixed.
              Incompatible with unicode-math. No luamml support."
   issues: [837]
@@ -7417,7 +7429,7 @@
   status: unknown
   included-in: [arxiv01]
   priority: 6
-  issues:
+  issues: [793]
   tests: false
   tasks: needs tests
   updated: 2024-07-18
@@ -9089,6 +9101,15 @@
   issues:
   tests: false
   updated: 2024-07-21
+
+- name: plex-otf
+  type: package
+  status: compatible
+  included-in:
+  priority: 9
+  issues:
+  tests: false
+  updated: 2025-06-07
 
 - name: plex-sans
   ctan-pkg: plex

--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -4074,10 +4074,10 @@
   status: partially-compatible
   included-in: [arxiv1]
   priority: 5
-  issues:
+  issues: [898]
   tests: true
   comments: "Content of `\\AddToShipoutPictureBG` should always be Artifact."
-  updated: 2024-08-05
+  updated: 2025-06-09
 
 - name: esstixbb
   type: package
@@ -7634,13 +7634,13 @@
 
 - name: multicol
   type: package
-  status: partially-compatible
+  status: compatible
   included-in: [tlc3, arxiv5]
   priority: 2
   issues: [705]
-  tasks: test column rules
-  comments: "Full-sized floats currently do not work with tagging."
-  updated: 2024-09-12
+  tasks:
+  comments:
+  updated: 2025-06-09
 
 - name: multicolrule
   type: package
@@ -9615,12 +9615,12 @@
 
 - name: rotating
   type: package
-  status: currently-incompatible
+  status: compatible
   included-in: [tlc3, arxiv5]
   priority: 2
-  issues: [112]
+  issues: [112,751]
   tests: true
-  updated: 2024-07-11
+  updated: 2025-06-09
 
 - name: rotchiffre
   type: package
@@ -12198,10 +12198,11 @@
   priority: 2
   supported-through: [phase-III,math]
   comments: "In text mode, no tagging occurs for `\\xymatrix`.
-             No luamml support."
-  issues:
+             No luamml support. Requires luatex85 with luatex.
+             unicode-math must be loaded after xy."
+  issues: [899]
   tests: true
-  updated: 2025-05-28
+  updated: 2025-06-09
 
 #------------------------ YYY ----------------------------
 

--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -2106,13 +2106,14 @@
 
 - name: bigdelim
   type: package
-  status: unknown
+  status: currently-incompatible
   included-in: [tlc3, arxiv01]
   priority: 2
   issues:
+  comments: "Relies on incompatible multirow."
   tests: false
   tasks: needs tests
-  updated: 2024-07-14
+  updated: 2025-06-09
 
 - name: bigfoot
   type: package
@@ -2146,13 +2147,12 @@
 
 - name: bigstrut
   type: package
-  status: unknown
+  status: compatible
   included-in: [tlc3, arxiv01]
   priority: 2
   issues:
-  tests: false
-  tasks: needs tests
-  updated: 2024-07-14
+  tests: true
+  updated: 2025-06-09
 
 - name: biolinum
   ctan-pkg: libertine
@@ -3391,9 +3391,9 @@
   included-in: [tlc3, arxiv10]
   priority: 2
   comments: "`d` columns are set as text not math, which is arguably correct, but needs some further evaluation."
-  issues:
+  issues: [896]
   tests: true
-  updated: 2024-07-08
+  updated: 2025-06-09
 
 - name: decorule
   type: package
@@ -7711,13 +7711,12 @@
 
 - name: multirow
   type: package
-  status: unknown
+  status: currently-incompatible
   included-in: [tlc3, arxiv10]
   priority: 2
-  issues:
-  tests: false
-  tasks: needs tests
-  updated: 2024-07-15
+  issues: [894]
+  tests: true
+  updated: 2025-06-09
 
 - name: multitoc
   type: package
@@ -8067,10 +8066,10 @@
   status: currently-incompatible
   included-in: [arxiv5]
   priority: 4
-  issues:
+  issues: [897]
   comments: "Text-mode fractions are implemented as a sequence of formulas."
   tests: true
-  updated: 2024-07-29
+  updated: 2025-06-09
 
 - name: niceframe
   type: package

--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -10357,9 +10357,9 @@
   status: currently-incompatible
   included-in: [tlc3, arxiv1]
   priority: 2
-  issues:
+  issues: [900]
   tests: true
-  updated: 2024-08-04
+  updated: 2025-06-10
 
 - name: stickstootext
   ctan-pkg: stickstoo

--- a/tagging-status/testfiles/bigstrut/bigstrut-01.tex
+++ b/tagging-status/testfiles/bigstrut/bigstrut-01.tex
@@ -1,0 +1,23 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on,
+  }
+\documentclass{article}
+
+\usepackage{bigstrut}
+
+\title{bigstrut tagging test}
+
+\begin{document}
+
+\setlength{\bigstrutjot}{7pt}
+\begin{tabular}{cc}
+\hline
+AAA & bbb \bigstrut \\
+\hline
+\end{tabular}
+
+\end{document}

--- a/tagging-status/testfiles/dcolumn/dcolumn-01.tex
+++ b/tagging-status/testfiles/dcolumn/dcolumn-01.tex
@@ -1,11 +1,13 @@
-\DocumentMetadata{
-  lang=en-US,
-  pdfversion=2.0,
-  pdfstandard=ua-2,
-  tagging=on
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on
   }
- 
 \documentclass{article}
+
+\UseName{sys_if_engine_opentype:T}{\usepackage{unicode-math}}
 \usepackage{dcolumn}
 
 \newcolumntype{d}[1]{D{.}{\cdot}{#1}}
@@ -16,8 +18,6 @@
 
 \begin{document}
 
-% can't contain vertical rules
-% but this is also true without dcolumn
 \begin{center}
 \begin{tabular}{d{-1}d{2}.,l}
 1.2   & 1.2   &1.2    &1,2    & a\\

--- a/tagging-status/testfiles/luatexko/luatexko-01.tex
+++ b/tagging-status/testfiles/luatexko/luatexko-01.tex
@@ -37,6 +37,8 @@
   CharacterWidth=Full,
 ]
 
+\title{luatexko tagging test}
+
 \begin{document}
 패키지 옵션
 

--- a/tagging-status/testfiles/luatexko/luatexko-01.tex
+++ b/tagging-status/testfiles/luatexko/luatexko-01.tex
@@ -1,0 +1,81 @@
+\DocumentMetadata
+  {
+    lang=ko,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on
+  }
+\documentclass{article}
+
+\usepackage{unicode-math}
+\usepackage{luatexko}
+
+\defaultfontfeatures+{Renderer=HarfBuzz}
+
+% https://fonts.google.com/noto/specimen/Noto+Serif+KR
+\setmainhangulfont{Noto Serif KR}[
+  Script=Hangul,
+  Language=Korean,
+  ]
+% https://fonts.google.com/noto/specimen/Noto+Sans+KR
+\setmathhangulfont{Noto Sans KR}[
+  Script=Hangul,
+  Language=Korean,
+  ]
+\newhangulfontfamily\verticalhangulfont{Noto Sans KR}[
+  Renderer=Node,
+  Script=Hangul,
+  Language=Korean,
+  UprightFont=* Light,
+  BoldFont=* Bold,
+  InterLatinCJK=.125em,
+  Vertical=Alternates,
+  RawFeature=vertical,
+  CompressPunctuations,
+  InterCharStretch=1pt,
+  CharRaise=1pt,
+  CharacterWidth=Full,
+]
+
+\begin{document}
+패키지 옵션
+
+$가^{나^다}=\sum_i^\infty a_i$
+
+\dotemph{드러냄표}
+
+\ruby{漢字}{한자}
+
+\xxruby{漢字}{한자}
+
+\uline{밑줄을 그을 수 있다}
+
+\sout{취소선을 그을 수 있다}
+
+\uuline{밑줄을 두 줄 긋는다}
+
+\xout{빗금으로 취소할 수 있다}
+
+\uwave{물결표로 밑줄을 삼는다}
+
+\dashuline{대시로 밑줄을 삼는다}
+
+\dotuline{밑줄을 점선으로 긋는다}
+
+\hellipsis
+
+\begin{vertical}{20em}
+\verticalhangulfont
+世솅〮宗조ᇰ御ᅌᅥᆼ〮製졩〮訓훈〮民민正져ᇰ〮音ᅙᅳᆷ
+\end{vertical}
+
+\begin{verticaltypesetting}
+\verticalhangulfont
+世솅〮宗조ᇰ御ᅌᅥᆼ〮製졩〮訓훈〮民민正져ᇰ〮音ᅙᅳᆷ
+\begin{horizontal}{20em}
+\normalfont
+世솅〮宗조ᇰ御ᅌᅥᆼ〮製졩〮訓훈〮民민正져ᇰ〮音ᅙᅳᆷ
+\end{horizontal}
+\end{verticaltypesetting}
+
+\end{document}

--- a/tagging-status/testfiles/multicol/multicol-01.tex
+++ b/tagging-status/testfiles/multicol/multicol-01.tex
@@ -1,0 +1,26 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on
+  }
+\documentclass{article}
+
+\usepackage{multicol}
+\usepackage{kantlipsum}
+
+\title{multicol tagging test - 1}
+
+\begin{document}
+
+\begin{multicols}{2}
+\kant[1-2]
+\begin{table*}
+a large table
+\caption{Some caption}
+\end{table*}
+\kant[3-4]
+\end{multicols}
+
+\end{document}

--- a/tagging-status/testfiles/multicol/multicol-02.tex
+++ b/tagging-status/testfiles/multicol/multicol-02.tex
@@ -1,0 +1,24 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on
+  }
+\documentclass{article}
+
+\usepackage{multicol}
+\usepackage{kantlipsum}
+
+\title{multicol tagging test - 2}
+
+\begin{document}
+
+\setlength{\columnseprule}{1pt}
+\begin{multicols}{2}[\section{Some section}]
+\kant[1-2]
+
+some text\footnote{some footnote}
+\end{multicols}
+
+\end{document}

--- a/tagging-status/testfiles/multirow/multirow-01.tex
+++ b/tagging-status/testfiles/multirow/multirow-01.tex
@@ -1,0 +1,25 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on,
+  }
+\documentclass{article}
+\usepackage{multirow}
+
+\title{multirow tagging test}
+
+\begin{document}
+
+\begin{tabular}{cc}
+\multicolumn{2}{c}{AAA} \\
+C & D
+\end{tabular}
+
+\begin{tabular}{cc}
+\multirow{2}{*}{AAA} & B \\
+& D
+\end{tabular}
+
+\end{document}

--- a/tagging-status/testfiles/nicefrac/nicefrac-01.tex
+++ b/tagging-status/testfiles/nicefrac/nicefrac-01.tex
@@ -7,6 +7,7 @@
   }
 \documentclass{article}
 
+\UseName{sys_if_engine_opentype:T}{\usepackage{unicode-math}}
 \usepackage{nicefrac}
 
 \title{nicefrac tagging test}

--- a/tagging-status/testfiles/xy/xy-01.tex
+++ b/tagging-status/testfiles/xy/xy-01.tex
@@ -7,6 +7,8 @@
   }
 \documentclass{article}
 
+\UseName{sys_if_engine_luatex:T}{\usepackage{luatex85}} % needed with luatex
+\UseName{sys_if_engine_unicode:T}{\usepackage{unicode-math}}
 \usepackage[all]{xy}
 
 \title{xy tagging test}


### PR DESCRIPTION
Adds tests for multirow and changes status to currently-incompatible. Same for bigdelim which loads multirow.

Lists bigstrut as compatible with a test.

Lists the unicode font packages bonum-otf and plex-otf as compatible.

Adds a test for luatexko since the package author recently added tagging support for several of the package's commands. I didn't change the status because I'm not sure if the tagging is correct. It also doesn't help that I don't know Korean :-) At least with ngpdf, none of the text decorations show up, but that could be an ngpdf or browser issue. There are also parent-child warnings when the `horizontal` environment is nested in an environment for vertical typesetting.

Lists lucidabr as partially-compatible since it uses 8-bit math fonts.

Lists multicol as compatible and adds two tests.

Lists rotating as compatible since support was added.

Links several issues to entries.