### PR TITLE
Status updates

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -12494,13 +12494,13 @@
 
 - name: letter
   type: class
-  status: unknown
+  status: partially-compatible
   included-in:
   priority: 2
-  issues:
-  tests: false
-  tasks: needs tests
-  updated: 2024-07-06
+  issues: [912]
+  tests: true
+  comments: "Tagging is not ideal."
+  updated: 2025-06-12
 
 - name: llncs
   type: class

--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -250,8 +250,8 @@
   included-in: [tlc3, arxiv1]
   priority: 2
   comments: "`varwidth` and `stack` keys rely on currently-incompatible varwidth package.
-            Does not register `alt`, `artifact`, or `actualtext` keys for `\adjincludegraphics`.
-            `\adjustbox` creates empty tags."
+            Does not register `alt`, `artifact`, or `actualtext` keys for `\\adjincludegraphics`.
+            `\\adjustbox` creates empty tags."
   issues:
   external-issues: ["https://github.com/MartinScharrer/adjustbox/issues/4"]
   package-repository: "https://github.com/MartinScharrer/adjustbox"
@@ -799,7 +799,7 @@
   status: compatible
   included-in: [tlc3, arxiv01]
   priority: 2
-  comments: This is an obsolete package. The hooks it defines are available directly from the LaTeX kernel when using the `\AddToHook` interface.
+  comments: "This is an obsolete package. The hooks it defines are available directly from the LaTeX kernel when using the `\\AddToHook` interface."
   issues:
   tests: false
   updated: 2024-07-14
@@ -1990,7 +1990,7 @@
   priority: 2
   comments: "Requires hyperref."
   references: [2]
-  issues: [18]
+  issues: [18,902]
   external-issues: ["https://github.com/plk/biblatex/issues/1366"]
   tasks: needs tests
   updated: 2024-07-07
@@ -2913,10 +2913,11 @@
   included-in: [tlc3, arxiv1]
   priority: 2
   supported-through: [phase-III,firstaid]
-  comments: "Partially supported in the firstaid module, but open issue with hyperref (workaround suggested)"
+  comments: "Must be loaded after amsmath."
   issues: [2]
   tests: true
-  updated: 2024-07-08
+  tasks: More tests needed
+  updated: 2025-06-10
 
 - name: clrstrip
   type: package
@@ -3920,7 +3921,9 @@
   status: partially-compatible
   included-in: [tlc3, arxiv5]
   priority: 2
-  comments: The package itself can't be loaded right now. However, the tagging code supports (most of) the document-level  syntax of `enumitem`, so that one can use, for example, `\begin{itemize}[...]` out of the box.
+  comments: "The package itself can't be loaded right now. However, the tagging code
+             supports (most of) the document-level  syntax of `enumitem`, so that one
+             can use, for example, `\\begin{itemize}[...]` out of the box."
   tasks: Check which keys are not yet supported and what else is missing.
   references: [1]
   issues: [61]
@@ -4624,7 +4627,7 @@
   status: currently-incompatible
   included-in: [arxiv01]
   priority: 6
-  comments: "redefines \\@xfloat"
+  comments: "Redefines \\@xfloat."
   issues: [209]
   tests: true
   updated: 2024-07-19
@@ -4739,7 +4742,7 @@
   included-in: [arxiv001]
   priority: 7
   issues: [888]
-  comments: Redefines `\\@makecol`.
+  comments: "Redefines `\\@makecol`."
   tests: true
   tasks: Revisit once OR is altered.
   updated: 2024-08-01
@@ -4768,13 +4771,13 @@
 - name: fontawesome6
   type: package
   status: partially-compatible
-  included-in: [tlc3, arxiv001]
-  priority: 2
+  included-in:
+  priority: 9
   issues:
   tests: true
   comments: "Symbols missing ToUnicode with pdftex.
              Fully compatible with luatex."
-  updated: 2025-06-03
+  updated: 2025-06-10
 
 - name: fontaxes
   type: package
@@ -4877,9 +4880,9 @@
   included-in: [arxiv001]
   priority: 7
   comments: "Footnote tagging is correct but breaks footnotes in `\\maketitle`."
-  issues:
+  issues: [908]
   tests: true
-  updated: 2024-07-21
+  updated: 2025-06-10
 
 - name: forest
   type: package
@@ -5650,14 +5653,13 @@
 
 - name: hypbmsec
   type: package
-  status: partially-compatible
+  status: compatible
   included-in: [arxiv001]
   priority: 7
   issues:
-  comments: Currently compatible, but once the new template interface for headings is in place this might stop working
-  tasks: Recheck after latex-lab-sections has been updated
+  comments:
   tests: true
-  updated: 2024-08-07
+  updated: 2025-06-10
 
 - name: hypcap
   type: package
@@ -7357,13 +7359,14 @@
 
 - name: menukeys
   type: package
-  status: unknown
+  status: partially-compatible
   included-in: [arxiv001]
   priority: 7
-  issues:
-  tests: false
-  tasks: needs tests
-  updated: 2024-07-18
+  issues: [907]
+  comments: "None of the formatting is represented at the tag level; spaces between
+             keywords are lost."
+  tests: true
+  updated: 2025-06-10
 
 - name: merriweather
   type: package
@@ -7480,13 +7483,13 @@
 
 - name: minibox
   type: package
-  status: unknown
+  status: currently-incompatible
   included-in: [arxiv001]
   priority: 7
-  issues:
-  tests: false
-  tasks: needs tests
-  updated: 2024-07-18
+  issues: [905]
+  comments: "Tags `\\minibox`es as tables."
+  tests: true
+  updated: 2025-06-10
 
 - name: minitoc
   type: package
@@ -7606,9 +7609,9 @@
   included-in: [tlc3, arxiv001]
   priority: 4
   comments: "Errors with `debug` option."
-  issues:
+  issues: [906]
   tests: true
-  updated: 2024-07-24
+  updated: 2025-06-10
 
 - name: multiaudience
   type: package
@@ -7666,6 +7669,7 @@
   updated: 2024-08-06
 
 - name: multienum
+  ctan-pkg: multenum
   type: package
   status: currently-incompatible
   included-in: [arxiv001]
@@ -9016,9 +9020,9 @@
   status: currently-incompatible
   included-in: [arxiv001]
   priority: 7
-  issues:
+  issues: [904]
   tests: true
-  updated: 2024-08-15
+  updated: 2025-06-10
 
 - name: picins
   type: package
@@ -9432,7 +9436,7 @@
   included-in: [arxiv001]
   priority: 7
   package-repository: "https://github.com/MartinScharrer/realboxes"
-  comments: "Depends on partially-compatible collectbox. `\Parbox` produces parent-child
+  comments: "Depends on partially-compatible collectbox. `\\Parbox` produces parent-child
             warnings. Graphics and dashbox macros not tagged correctly."
   issues:
   tests: true
@@ -10633,7 +10637,7 @@
   status: currently-incompatible
   included-in: [tlc3, arxiv01]
   priority: 2
-  issues:
+  issues: [903]
   tests: true
   comments: Inserts empty `equation*` tags.
   updated: 2024-08-02

--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -4728,13 +4728,13 @@
 
 - name: fnpct
   type: package
-  status: partially-compatible
+  status: compatible
   included-in: [tlc3, arxiv001]
   priority: 2
   issues:
-  comments: "`ranges` option does not work with hyperref."
+  comments:
   tests: true
-  updated: 2024-07-31
+  updated: 2025-06-11
 
 - name: fnpos
   type: package

--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -2268,14 +2268,14 @@
 
 - name: booktabs
   type: package
-  status: partially-compatible
+  status: compatible
   included-in: [tlc3, arxiv10]
   priority: 2
   supported-through: [phase-III,firstaid,table]
-  comments: requires the firstaid module which contains a fix.
+  comments: "Requires the firstaid module which contains a fix."
   issues: [69]
   tests: true
-  updated: 2024-07-08
+  updated: 2025-06-13
 
 - name: boxedminipage
   type: package
@@ -9285,11 +9285,11 @@
   included-in: [tlc3, arxiv1]
   priority: 2
   comments: "Compatibility is only with lualatex; dvips cannot properly support PDF/UA.
-            Offers `alt`, `actualtext`, `artifact`, and `correct-BBox` keys.
-            Not tagged as figures."
-  issues:
+            Offers `alt`, `actualtext`, `artifact`, and `correct-BBox` keys,
+            however these seem not to work. Not tagged as figures."
+  issues: [913]
   tests: true
-  updated: 2024-11-19
+  updated: 2025-06-13
 
 - name: px-ds
   ctan-pkg: pxtxalfa
@@ -9299,7 +9299,8 @@
   priority: 9
   issues:
   tests: false
-  updated: 2024-08-05
+  comments: "No luamml support."
+  updated: 2025-06-13
 
 - name: pxpic
   type: package
@@ -9319,7 +9320,8 @@
   priority: 9
   issues:
   tests: false
-  updated: 2024-08-05
+  comments: "No luamml support."
+  updated: 2025-06-13
 
 - name: pxtx-frak
   ctan-pkg: pxtxalfa
@@ -9329,7 +9331,8 @@
   priority: 9
   issues:
   tests: false
-  updated: 2024-08-05
+  comments: "No luamml support."
+  updated: 2025-06-13
 
 - name: pyluatex
   type: package

--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -12552,8 +12552,9 @@
   priority: 2
   comments: "Some code showing the needed adjustments can be found in the
              [bible example](https://github.com/latex3/tagging-project/blob/main/project-examples/ASV/bible.tex)."
+  issues: [910]
   tests: false
-  updated: 2024-07-05
+  updated: 2025-06-11
 
 - name: minimal
   type: class

--- a/tagging-status/testfiles/booktabs/booktabs-01.tex
+++ b/tagging-status/testfiles/booktabs/booktabs-01.tex
@@ -3,7 +3,7 @@
     lang=en-US,
     pdfversion=2.0,
     pdfstandard=ua-2,
-    tagging=on
+    tagging=on,
   }
 \documentclass{article}
 
@@ -15,26 +15,34 @@
 \begin{document}
 \begin{tabular}{r}
 aaa\\
-\midrule %works
+\midrule
 bbb
 \end{tabular}    
 
 \begin{tabular}{r}
 aaa\\
- \cmidrule{1-1} %fails
+ \cmidrule{1-1}
 bbb
 \end{tabular}    
 
 \begin{longtable}{r}
 aaaa\\
- \midrule %fails
+ \midrule
 bbbb
 \end{longtable}
 
-\begin{tabular}{r}
-aaa\\
-\multispan 1 xxx \cr %fails
-bbb
+\begin{tabular}{rc}
+\toprule[10pt]
+Some text & A\\
+\midrule[4pt]
+More text & B\\
+\addlinespace[1cm]
+Even more text & C\\
+\cmidrule{1-1}\morecmidrules\cmidrule{1-1}
+And more \\
+\specialrule{3pt}{3mm}{1mm}
+Blub & foo \\
+\bottomrule[0.5pt]
 \end{tabular}    
 
 \end{document}

--- a/tagging-status/testfiles/cleveref/cleveref-01.tex
+++ b/tagging-status/testfiles/cleveref/cleveref-01.tex
@@ -5,9 +5,12 @@
     pdfstandard=ua-2,
     tagging=on
   }
-
 \documentclass[a4paper,10pt]{article}
 
+\UseName{sys_if_engine_opentype:TF}
+  {\usepackage{unicode-math}}
+  {\usepackage{amsmath}}
+% ^ need to load amsmath before cleveref
 \usepackage{varioref}
 %\usepackage{hyperref}
 \usepackage{cleveref}

--- a/tagging-status/testfiles/cleveref/cleveref-02.tex
+++ b/tagging-status/testfiles/cleveref/cleveref-02.tex
@@ -7,13 +7,21 @@
   }
 \documentclass{book}
 
-\usepackage{amsmath}
-
+\UseName{sys_if_engine_opentype:TF}
+  {\usepackage{unicode-math}}
+  {\usepackage{amsmath}}
 \usepackage{hyperref}
 \usepackage{cleveref}
 
 \title{cleveref tagging test - 2}
 
 \begin{document}
+
+\begin{align}
+A &= B \label{foo} \\
+C &= D
+\end{align}
+
+\cref{foo}
 
 \end{document}

--- a/tagging-status/testfiles/fnpct/fnpct-01.tex
+++ b/tagging-status/testfiles/fnpct/fnpct-01.tex
@@ -7,6 +7,7 @@
   }
 \documentclass{article}
 \usepackage{fnpct}
+\usepackage{hyperref}
 
 \title{fnpct tagging test}
 

--- a/tagging-status/testfiles/letter/letter-01.tex
+++ b/tagging-status/testfiles/letter/letter-01.tex
@@ -1,0 +1,43 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on,
+  }
+\documentclass{letter}
+\usepackage{hyperref}
+\signature{Joe Bloggs}
+\address{21 Bridge Street \\ Smallville \\ Dunwich DU3 4WE}
+\begin{document}
+
+\begin{letter}{Director \\ Doe \& Co \\ 35 Anthony Road
+\\ Newport \\ Ipswich IP3 5RT}
+\opening{Dear Sir or Madam:}
+
+I am writing to you on behalf of the Wikipedia project (http://www.wikipedia.org/),
+an endeavour to build a fully-fledged multilingual encyclopaedia in an entirely
+open manner, to ask for permission to use your copyrighted material.
+
+\ldots 
+
+That said, allow me to reiterate that your material will be used to the noble end of
+providing a free collection of knowledge for everyone; naturally enough, only if you
+agree. If that is the case, could you kindly fill in the attached form and post it
+back to me? We shall greatly appreciate it.
+
+Thank you for your time and consideration.
+
+I look forward to your reply.
+
+\closing{Yours Faithfully,}
+
+\ps
+
+P.S. You can find the full text of GFDL license at
+\url{http://www.gnu.org/copyleft/fdl.html}.
+
+\encl{Copyright permission form}
+
+\end{letter}
+\end{document}

--- a/tagging-status/testfiles/luamplib/luamplib-01.tex
+++ b/tagging-status/testfiles/luamplib/luamplib-01.tex
@@ -19,6 +19,12 @@ draw (0,0)--(100,0)--(100,100)--(0,100)--cycle;
 endfig;
 \end{mplibcode}
 
+\begin{mplibcode}[actualtext=just a test]
+beginfig(1);
+draw (0,0)--(100,0)--(100,100)--(0,100)--cycle;
+endfig;
+\end{mplibcode}
+
 \begin{mplibcode}[artifact]
 beginfig(1);
 draw (0,0)--(100,0)--(100,100)--(0,100)--cycle;

--- a/tagging-status/testfiles/menukeys/menukeys-01.tex
+++ b/tagging-status/testfiles/menukeys/menukeys-01.tex
@@ -1,0 +1,23 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on
+  }
+\documentclass{article}
+\usepackage{menukeys}
+
+\title{menukeys tagging test}
+
+\begin{document}
+
+To set the unit of the rulers go to \menu{Extras > Settings > Rulers}
+and choose between millimeters, inches and pixels. The shortcut
+to view the rulers is \keys{cmd + R}. Pressing these keys again
+will hide the rulers.
+The standard path for saving your document is \directory{Macintosh HD/
+Users/Your Name/Documents} but you can change it at \menu{Extras >
+Settings > Saving} by clicking \menu{Change save path}.
+
+\end{document}

--- a/tagging-status/testfiles/minibox/minibox-01.tex
+++ b/tagging-status/testfiles/minibox/minibox-01.tex
@@ -1,0 +1,27 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on
+  }
+\documentclass{article}
+
+\usepackage{minibox}
+
+\title{minibox tagging test}
+
+\def\sample{abcd\\efg\\h}
+
+\begin{document}
+
+\minibox{\sample}
+
+% compare with
+\parbox{2cm}{\sample}
+
+\minibox[frame,rule=1pt,pad=0pt]{\sample}
+
+text\minibox[frame,c,b]{\sample}
+
+\end{document}

--- a/tagging-status/testfiles/mparhack/mparhack-01.tex
+++ b/tagging-status/testfiles/mparhack/mparhack-01.tex
@@ -5,7 +5,6 @@
     pdfstandard=ua-2,
     tagging=on
   }
-
 \documentclass[twoside]{article}
 \usepackage{mparhack} % errors with [debug]
 


### PR DESCRIPTION
Updates booktabs to compatible and improves the test file.

Updates the comment for cleveref since that issue seems fixed.

Changes fnpct to compatible because the issue it had with hyperref seems fixed.

Changes hypbmsec to compatible since it seems fine after the latex-lab-sec update the entry mentions.

Lists menukeys and letter as partially-compatible and minibox as currently-incompatible, see linked issues.

Several issues are linked to their entries.