### PR TITLE
Disable GitHub Pages site and replace with site under latex-project.org

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -8,7 +8,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
   id-token: write
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
@@ -49,5 +48,3 @@ jobs:
         uses: zauguin/custom-pages@trunk
         with:
           server: https://deploy.latex-project.org
-      - name: Deploy to GitHub Pages
-        uses: actions/deploy-pages@v4

--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,6 @@
 title: LaTeX Tagging Project
+baseurl: ""
+url: "https://tagging-project.latex-project.org/"
 
 exclude:
  - project-examples


### PR DESCRIPTION
Currently the page created by this repository is reachable under https://latex3.github.io/tagging-project/ and under https://tagging-project.latex-project.org/. This leads to issues since the links assume that the base URL is https://latex3.github.io/tagging-project/, so some links are leading to unexpected locations when viewed under https://tagging-project.latex-project.org/.

My suggestion is to change the configuration to fully use the https://tagging-project.latex-project.org/ URL and stop deploying to https://latex3.github.io/tagging-project/. Alternatively we could also do the opposite and remove the https://tagging-project.latex-project.org/ version again.