### PR TITLE
add babel status for simple languages

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -1001,38 +1001,38 @@
 - name: babel-afrikaans
   ctan-pkg: babel-dutch
   type: library
-  status: unknown
+  status: compatible
   included-in: [tlc3]
   priority: 2
   comments:
   issues:
   tests: false
-  tasks: needs tests
-  updated: 2024-09-01
+  tasks:
+  updated: 2025-08-17
 
 - name: babel-australian
   ctan-pkg: babel-english
   type: library
-  status: unknown
+  status: compatible
   included-in: [tlc3]
   priority: 2
-  comments: See babel-english
+  comments: See babel-english.
   issues:
   tests: false
   tasks: 
-  updated: 2024-09-01
+  updated: 2025-08-17
 
 - name: babel-albanian
   ctan-pkg: babel-albanian
   type: library
-  status: unknown
+  status: compatible
   included-in: [tlc3]
   priority: 2
   comments:
   issues:
   tests: false
-  tasks: needs tests
-  updated: 2024-09-01
+  tasks:
+  updated: 2025-08-17
 
 - name: babel-austrian
   ctan-pkg: babel-german
@@ -1061,14 +1061,14 @@
 - name: babel-basque
   ctan-pkg: babel-basque
   type: library
-  status: unknown
+  status: compatible
   included-in: [tlc3]
   priority: 2
   comments:
   issues:
   tests: false
-  tasks: needs tests
-  updated: 2024-09-01
+  tasks:
+  updated: 2025-08-17
 
 - name: babel-belarusian
   ctan-pkg: babel-belarusian
@@ -1085,26 +1085,26 @@
 - name: babel-bosnian
   ctan-pkg: babel-bosnian
   type: library
-  status: unknown
+  status: compatible
   included-in: [tlc3]
   priority: 2
   comments:
   issues:
   tests: false
-  tasks: needs tests
-  updated: 2024-09-01
+  tasks:
+  updated: 2025-08-17
 
 - name: babel-brazilian
   ctan-pkg: babel-portuges
   type: library
-  status: unknown
+  status: compatible
   included-in: [tlc3]
   priority: 2
   comments: See babel-portuguese
   issues:
   tests: false
   tasks:
-  updated: 2024-09-01
+  updated: 2025-08-17
 
 - name: babel-breton
   ctan-pkg: babel-breton
@@ -1145,14 +1145,14 @@
 - name: babel-croatian
   ctan-pkg: babel-croatian
   type: library
-  status: unknown
+  status: compatible
   included-in: [tlc3]
   priority: 2
   comments:
   issues:
   tests: false
-  tasks: needs tests
-  updated: 2024-09-01
+  tasks:
+  updated: 2025-08-17
 
 - name: babel-czech
   ctan-pkg: babel-czech
@@ -1169,38 +1169,38 @@
 - name: babel-danish
   ctan-pkg: babel-danish
   type: library
-  status: unknown
+  status: compatible
   included-in: [tlc3]
   priority: 2
   comments:
   issues:
   tests: false
-  tasks: needs tests
-  updated: 2024-09-01
+  tasks:
+  updated: 2025-08-17
 
 - name: babel-dutch
   ctan-pkg: babel-dutch
   type: library
-  status: unknown
+  status: compatible
   included-in: [tlc3]
   priority: 2
   comments:
   issues:
   tests: false
-  tasks: needs tests
-  updated: 2024-09-01
+  tasks:
+  updated: 2025-08-17
 
 - name: babel-english
   ctan-pkg: babel-english
   type: library
-  status: unknown
+  status: compatible
   included-in: [tlc3]
   priority: 2
   comments:
   issues:
   tests: false
-  tasks: needs tests
-  updated: 2024-09-01
+  tasks:
+  updated: 2025-08-17
 
 - name: babel-esperanto
   ctan-pkg: babel-esperanto
@@ -1208,10 +1208,10 @@
   status: partially-compatible
   included-in: [tlc3]
   priority: 2
-  comments: "Shorthand `^h` does not correctly map to Unicode."
+  comments: "Shorthand `^h` does not correctly map to Unicode with pdflatex."
   issues: [752]
   tests: unknown
-  updated: 2025-06-06
+  updated: 2025-08-17
 
 - name: babel-estonian
   ctan-pkg: babel-estonian
@@ -1228,14 +1228,14 @@
 - name: babel-finnish
   ctan-pkg: babel-finnish
   type: library
-  status: unknown
+  status: compatible
   included-in: [tlc3]
   priority: 2
   comments:
   issues:
   tests: false
-  tasks: needs tests
-  updated: 2024-09-01
+  tasks:
+  updated: 2025-08-17
 
 - name: babel-french
   ctan-pkg: babel-french
@@ -1252,14 +1252,14 @@
 - name: babel-friulan
   ctan-pkg: babel-friulan
   type: library
-  status: unknown
+  status: compatible
   included-in: [tlc3]
   priority: 2
   comments:
   issues:
   tests: false
-  tasks: needs tests
-  updated: 2024-09-01
+  tasks:
+  updated: 2025-08-17
 
 - name: babel-galician
   ctan-pkg: babel-galician
@@ -1336,38 +1336,38 @@
 - name: babel-indonesian
   ctan-pkg: babel-indonesian
   type: library
-  status: unknown
+  status: compatible
   included-in: [tlc3]
   priority: 2
   comments:
   issues:
   tests: false
-  tasks: needs tests
-  updated: 2024-09-01
+  tasks:
+  updated: 2025-08-17
 
 - name: babel-interlingua
   ctan-pkg: babel-interlingua
   type: library
-  status: unknown
+  status: compatible
   included-in: [tlc3]
   priority: 2
   comments:
   issues:
   tests: false
-  tasks: needs tests
-  updated: 2024-09-01
+  tasks:
+  updated: 2025-08-17
 
 - name: babel-irish
   ctan-pkg: babel-irish
   type: library
-  status: unknown
+  status: compatible
   included-in: [tlc3]
   priority: 2
   comments:
   issues:
   tests: false
-  tasks: needs tests
-  updated: 2024-09-01
+  tasks:
+  updated: 2025-08-17
 
 - name: babel-japanese
   ctan-pkg: babel-japanese
@@ -1432,14 +1432,14 @@
 - name: babel-lowersorbian
   ctan-pkg: babel-sorbian
   type: library
-  status: unknown
+  status: compatible
   included-in: [tlc3]
   priority: 2
   comments:
   issues:
   tests: false
-  tasks: needs tests
-  updated: 2024-09-01
+  tasks:
+  updated: 2025-08-17
 
 - name: babel-macedonian
   ctan-pkg: babel-macedonian
@@ -1456,14 +1456,14 @@
 - name: babel-malay
   ctan-pkg: babel-malay
   type: library
-  status: unknown
+  status: compatible
   included-in: [tlc3]
   priority: 2
   comments:
   issues:
   tests: false
-  tasks: needs tests
-  updated: 2024-09-01
+  tasks:
+  updated: 2025-08-17
 
 - name: babel-magyar
   ctan-pkg: babel-hungarian
@@ -1516,26 +1516,26 @@
 - name: babel-norsk
   ctan-pkg: babel-norsk
   type: library
-  status: unknown
+  status: compatible
   included-in: [tlc3]
   priority: 2
-  comments: See babel-nynorsk
+  comments: See babel-nynorsk.
   issues:
   tests: false
   tasks:
-  updated: 2024-09-01
+  updated: 2025-08-17
 
 - name: babel-nynorsk
   ctan-pkg: babel-norsk
   type: library
-  status: unknown
+  status: compatible
   included-in: [tlc3]
   priority: 2
   comments:
   issues:
   tests: false
-  tasks: needs tests
-  updated: 2024-09-01
+  tasks:
+  updated: 2025-08-17
 
 - name: babel-occitan
   ctan-pkg: babel-occitan
@@ -1564,14 +1564,14 @@
 - name: babel-polish
   ctan-pkg: babel-polish
   type: library
-  status: unknown
+  status: compatible
   included-in: [tlc3]
   priority: 2
   comments:
   issues:
   tests: false
-  tasks: needs tests
-  updated: 2024-09-01
+  tasks:
+  updated: 2025-08-17
 
 - name: babel-polutonikogreek
   ctan-pkg: babel-greek
@@ -1588,38 +1588,38 @@
 - name: babel-portuguese
   ctan-pkg: babel-portuges
   type: library
-  status: unknown
+  status: compatible
   included-in: [tlc3]
   priority: 2
   comments:
   issues:
   tests: false
-  tasks: needs tests
-  updated: 2024-09-01
+  tasks:
+  updated: 2025-08-17
 
 - name: babel-romanian
   ctan-pkg: babel-romanian
   type: library
-  status: unknown
+  status: compatible
   included-in: [tlc3]
   priority: 2
   comments:
   issues:
   tests: false
-  tasks: needs tests
-  updated: 2024-09-01
+  tasks:
+  updated: 2025-08-17
 
 - name: babel-romansh
   ctan-pkg: babel-romansh
   type: library
-  status: unknown
+  status: compatible
   included-in: [tlc3]
   priority: 2
   comments:
   issues:
   tests: false
-  tasks: needs tests
-  updated: 2024-09-01
+  tasks:
+  updated: 2025-08-17
 
 - name: babel-russian
   ctan-pkg: babel-russian
@@ -1636,26 +1636,26 @@
 - name: babel-samin
   ctan-pkg: babel-samin
   type: library
-  status: unknown
+  status: compatible
   included-in: [tlc3]
   priority: 2
   comments:
   issues:
   tests: false
-  tasks: needs tests
-  updated: 2024-09-01
+  tasks:
+  updated: 2025-08-17
 
 - name: babel-scottish
   ctan-pkg: babel-scottish
   type: library
-  status: unknown
+  status: compatible
   included-in: [tlc3]
   priority: 2
   comments:
   issues:
   tests: false
-  tasks: needs tests
-  updated: 2024-09-01
+  tasks:
+  updated: 2025-08-17
 
 - name: babel-serbian
   ctan-pkg: babel-serbian
@@ -1696,14 +1696,14 @@
 - name: babel-slovene
   ctan-pkg: babel-slovenian
   type: library
-  status: unknown
+  status: compatible
   included-in: [tlc3]
   priority: 2
   comments:
   issues:
   tests: false
-  tasks: needs tests
-  updated: 2024-09-01
+  tasks:
+  updated: 2025-08-17
 
 - name: babel-spanish
   ctan-pkg: babel-spanish
@@ -1720,14 +1720,14 @@
 - name: babel-swedish
   ctan-pkg: babel-swedish
   type: library
-  status: unknown
+  status: compatible
   included-in: [tlc3]
   priority: 2
   comments:
   issues:
   tests: false
-  tasks: needs tests
-  updated: 2024-09-01
+  tasks:
+  updated: 2025-08-17
 
 - name: babel-thai
   ctan-pkg: babel-thai
@@ -1756,14 +1756,14 @@
 - name: babel-turkmen
   ctan-pkg: turkmen
   type: library
-  status: unknown
+  status: compatible
   included-in: [tlc3]
   priority: 2
   comments:
   issues:
   tests: false
-  tasks: needs tests
-  updated: 2024-09-01
+  tasks:
+  updated: 2025-08-17
 
 - name: babel-ukrainian
   ctan-pkg: babel-ukrainian
@@ -1780,38 +1780,38 @@
 - name: babel-uppersorbian
   ctan-pkg: babel-sorbian
   type: library
-  status: unknown
+  status: compatible
   included-in: [tlc3]
   priority: 2
   comments:
   issues:
   tests: false
-  tasks: needs tests
-  updated: 2024-09-01
+  tasks:
+  updated: 2025-08-17
 
 - name: babel-UKenglish
   ctan-pkg: babel-english
   type: library
-  status: unknown
+  status: compatible
   included-in: [tlc3]
   priority: 2
-  comments: See babel-english
+  comments: See babel-english.
   issues:
   tests: false
   tasks: 
-  updated: 2024-09-01
+  updated: 2025-08-17
 
 - name: babel-USenglish
   ctan-pkg: babel-english
   type: library
-  status: unknown
+  status: compatible
   included-in: [tlc3]
   priority: 2
-  comments: See babel-english
+  comments: See babel-english.
   issues:
   tests: false
   tasks: 
-  updated: 2024-09-01
+  updated: 2025-08-17
 
 - name: babel-vietnamese
   ctan-pkg: babel-vietnamese
@@ -1828,14 +1828,14 @@
 - name: babel-welsh
   ctan-pkg: babel-welsh
   type: library
-  status: unknown
+  status: compatible
   included-in: [tlc3]
   priority: 2
   comments:
   issues:
   tests: false
-  tasks: needs tests
-  updated: 2024-09-01
+  tasks:
+  updated: 2025-08-17
 
 - name: babelbib
   type: package


### PR DESCRIPTION
This marks as compatible the babel languages that do little more than set up translations and possibly some shorthands with `"`. I did not add tests.