### PR TITLE
update descriptions of tagging-status tables

### DIFF
--- a/tagging-status/full.md
+++ b/tagging-status/full.md
@@ -25,7 +25,7 @@ This file shows the status of **{{t-s | size }}** LaTeX [Packages](#packages) an
 with respect to PDF tagging. `phase-III` is generally needed and not explicitly shown.
 
 This is the full list of data in the [YAML file](https://github.com/latex3/tagging-project/blob/main/_data/tagging-status.yml).
-Revert to the [filtered tables of compatible or higher priority classes and packages](./).
+Revert to the [display of main properties](./).
 
 The values in the *Status* column have the following meaning:
 

--- a/tagging-status/index.md
+++ b/tagging-status/index.md
@@ -36,13 +36,13 @@ The values in the *Status* column have the following meaning:
 - `no-support` This package or class or class is incompatible with the tagging code and we do *not* believe that it will ever be supported. (**{{t-s | where: "status", "no-support" | size }}** entries across all tables)
 - `unknown` The status of this package or class is not known, because there aren't reliable tests yet. Help with testing to determine the real status is very much appreciated. (**{{t-s | where: "status", "unknown" | size }}** entries across all tables)
 
-To use packages or classes together with the tagging code it is (nearly) always necessary to load at least `phase-III`of the tagging code, i.e., `testphase=phase-III` in `\DocumentMetadata`. To save space in the tables, this is not explicitly mentioned below. However, if a package or class requires other settings there is an explicit remark in the comments column, e.g., `Tagging support: phase-III, table` which means you have to specify `testphase={phase-III,table}`. If **package** is mentioned at this point it means that the package itself provides the necessary tagging support and not one of the modules in `latex-lab`. If known, **package** will link to the repository used by the package maintainer for tagging support.
+To use packages or classes together with the tagging code it is (nearly) always necessary to enable tagging with  `\DocumentMetadata{tagging=on}`. However, if a package or class requires other settings there is an explicit remark in the comments column. If **package** is mentioned at this point it means that the package itself provides the necessary tagging support and not one of the modules in `latex-lab`. If known, **package** will link to the repository used by the package maintainer for tagging support.
 
 
 To add or edit the entries in the tables, please make a pull request to change the YAML file
 [tagging-status.yml](https://github.com/latex3/tagging-project/blob/main/_data/tagging-status.yml).
 
-The table shown here omits some entries for packages that are incompatible or have unknown status, and for which support is not expected within the current project. A view of the [full data in the yaml](full) file  is also available.
+The table shown here omits some of the data stored for each package. A view of the [full data in the yaml](full) file  is also available.
 
 If you encounter a problem with a package or class for which there is no issue in the [issue tracker](https://github.com/latex3/tagging-project/issues) yet, please add an issue in the tracker first (including a small example what goes wrong) or start a discussion  in the [discussion view](https://github.com/latex3/tagging-project/discussions) if that seems more appropriate. Later on it can still be added to the tables.
 


### PR DESCRIPTION
This PR adjusts the description of how to enable tagging (replacing `testphase=...` by `tagging=on`) and adjusts the description of the main and "full" tables to say that they show different fields from the yaml (and not say that the main list only shows higher priority packages)
