### PR TITLE
remove config-broken from build.lua

### DIFF
--- a/tagging-status/build.lua
+++ b/tagging-status/build.lua
@@ -9,7 +9,6 @@ checkconfigs = {
   'config-partial',
   'config-incompatible',
   'build',
-  'config-broken',
   'config-unknown',
 }
 checkruns = 3

--- a/tagging-status/config-broken.lua
+++ b/tagging-status/config-broken.lua
@@ -1,1 +1,0 @@
-testfiledir = "testfiles-broken"


### PR DESCRIPTION
Deletes `config-broken.lua` and removes it from `checkconfigs` in the main `build.lua`. For some reason the github CI is still not running all the tests (and still running the config-broken tests) but that's out of my wheelhouse.