### PR TITLE
Add entries for ltj classes

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -12577,6 +12577,7 @@
   ctan-pkg: luatexja
   type: class
   status: currently-incompatible
+  luatex-only: true
   included-in:
   priority: 9
   issues: [713]
@@ -12588,6 +12589,7 @@
   ctan-pkg: luatexja
   type: class
   status: currently-incompatible
+  luatex-only: true
   included-in:
   priority: 9
   issues: [713]
@@ -12599,6 +12601,7 @@
   ctan-pkg: luatexja
   type: class
   status: currently-incompatible
+  luatex-only: true
   included-in:
   priority: 9
   issues: [713]
@@ -12610,6 +12613,7 @@
   ctan-pkg: luatexja
   type: class
   status: currently-incompatible
+  luatex-only: true
   included-in:
   priority: 9
   issues: [713]
@@ -12621,6 +12625,7 @@
   ctan-pkg: luatexja
   type: class
   status: currently-incompatible
+  luatex-only: true
   included-in:
   priority: 9
   issues: [713]
@@ -12632,6 +12637,7 @@
   ctan-pkg: luatexja
   type: class
   status: currently-incompatible
+  luatex-only: true
   included-in:
   priority: 9
   issues: [713]
@@ -12643,6 +12649,7 @@
   ctan-pkg: luatexja
   type: class
   status: currently-incompatible
+  luatex-only: true
   included-in:
   priority: 9
   issues: [713]
@@ -12654,6 +12661,7 @@
   ctan-pkg: luatexja
   type: class
   status: currently-incompatible
+  luatex-only: true
   included-in:
   priority: 9
   issues: [713]
@@ -12665,6 +12673,7 @@
   ctan-pkg: luatexja
   type: class
   status: currently-incompatible
+  luatex-only: true
   included-in:
   priority: 9
   issues: [713]


### PR DESCRIPTION
Since the luatexja class tests were split into their own directories, I suppose it makes sense to have separate entries.