### PR TITLE
add some tests

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -9446,10 +9446,9 @@
   priority: 2
   package-repository: "https://gitlab.com/TeXhackse/ragged2e"
   external-issues: "https://gitlab.com/TeXhackse/ragged2e/-/issues/9"
-  issues:
-  tests: false
-  tasks: needs tests
-  updated: 2024-07-15
+  issues: [1070]
+  tests: true
+  updated: 2025-11-19
 
 - name: raleway
   type: package
@@ -9487,9 +9486,9 @@
   included-in: [tlc3]
   priority: 2
   issues: [457]
-  tests: false
-  tasks: needs tests
-  updated: 2024-11-18
+  tests: true
+  luatex-only: true
+  updated: 2025-11-19
 
 - name: refcheck
   type: package
@@ -9566,13 +9565,12 @@
 
 - name: repltext
   type: package
-  status: unchecked
+  status: currently-incompatible
   included-in:
   priority: 9
-  issues:
-  tests: false
-  tasks: needs tests
-  updated: 2024-07-18
+  issues: [1071]
+  tests: true
+  updated: 2025-11-19
 
 - name: rerunfilecheck
   type: package
@@ -9914,13 +9912,13 @@
 
 - name: selinput
   type: package
-  status: unchecked
+  status: partially-compatible
   included-in: [arxiv001]
   priority: 7
   issues:
+  comments: "Only works with pdftex. Should not be necessary in new documents."
   tests: false
-  tasks: needs tests
-  updated: 2024-07-18
+  updated: 2025-11-19
 
 - name: selnolig
   type: package

--- a/tagging-status/testfiles-incompatible/repltext/repltext-01-BAD.pdftex.struct.xml
+++ b/tagging-status/testfiles-incompatible/repltext/repltext-01-BAD.pdftex.struct.xml
@@ -1,0 +1,21 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.02"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.05"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.06"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>original-
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-incompatible/repltext/repltext-01-BAD.struct.xml
+++ b/tagging-status/testfiles-incompatible/repltext/repltext-01-BAD.struct.xml
@@ -1,0 +1,21 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.02"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.05"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.06"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>original-
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-incompatible/repltext/repltext-01-BAD.tex
+++ b/tagging-status/testfiles-incompatible/repltext/repltext-01-BAD.tex
@@ -1,0 +1,17 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on
+  }
+\documentclass{article}
+\usepackage{repltext}
+
+\title{repltext tagging test}
+
+\begin{document}
+
+\repltext{replacement}{original}
+
+\end{document}

--- a/tagging-status/testfiles-partial-luatex/realscripts/realscripts-01.struct.xml
+++ b/tagging-status/testfiles-partial-luatex/realscripts/realscripts-01.struct.xml
@@ -1,0 +1,60 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.005"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.006"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Text¹²³⁴⁵⁶⁷⁸⁹¹⁰ᵃᵇᶜᵈᵉᶠ
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.007"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.008"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Text₁₂₃₄₅₆₇₈₉₁₀ₐbcdₑf
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.009"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.010"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Text12345678910abcdef
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.011"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.012"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Text12345678910abcdef
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-partial-luatex/realscripts/realscripts-01.tex
+++ b/tagging-status/testfiles-partial-luatex/realscripts/realscripts-01.tex
@@ -1,0 +1,26 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on
+  }
+\documentclass{article}
+\usepackage{fontspec}
+\setmainfont{Libertinus Serif}
+\usepackage{realscripts}
+
+\title{realscripts tagging test}
+
+\begin{document}
+
+Text\textsuperscript{12345678910abcdef}
+
+Text\textsubscript{12345678910abcdef}
+
+% original behavior
+Text\textsuperscript*{12345678910abcdef}
+
+Text\textsubscript*{12345678910abcdef}
+
+\end{document}

--- a/tagging-status/testfiles-partial/ragged2e/ragged2e-01-BAD.pdftex.struct.xml
+++ b/tagging-status/testfiles-partial/ragged2e/ragged2e-01-BAD.pdftex.struct.xml
@@ -1,0 +1,59 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.005"
+      rolemaps-to="Part"
+     >
+    <list xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.006"
+       xmlns:List="http://iso.org/pdf/ssn/List"
+       List:ListNumbering="Unordered"
+       rolemaps-to="L"
+      >
+     <LI xmlns="http://iso.org/pdf2/ssn"
+        id="ID.007"
+       >
+      <Lbl xmlns="http://iso.org/pdf2/ssn"
+         id="ID.008"
+        >
+       <?MarkedContent page="1" ?>
+      </Lbl>
+      <LBody xmlns="http://iso.org/pdf2/ssn"
+         id="ID.009"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.010"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.011"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="1" ?>Some text in an environment
+        </text>
+       </text-unit>
+      </LBody>
+     </LI>
+    </list>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.012"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.013"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Center"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Compare with normal center environment
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-partial/ragged2e/ragged2e-01-BAD.struct.xml
+++ b/tagging-status/testfiles-partial/ragged2e/ragged2e-01-BAD.struct.xml
@@ -1,0 +1,58 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.005"
+      rolemaps-to="Part"
+     >
+    <list xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.006"
+       xmlns:List="http://iso.org/pdf/ssn/List"
+       List:ListNumbering="Unordered"
+       rolemaps-to="L"
+      >
+     <LI xmlns="http://iso.org/pdf2/ssn"
+        id="ID.007"
+       >
+      <Lbl xmlns="http://iso.org/pdf2/ssn"
+         id="ID.008"
+        >
+      </Lbl>
+      <LBody xmlns="http://iso.org/pdf2/ssn"
+         id="ID.009"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.010"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.011"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="1" ?>Some text in an environment
+        </text>
+       </text-unit>
+      </LBody>
+     </LI>
+    </list>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.012"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.013"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Center"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Compare with normal center environment
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-partial/ragged2e/ragged2e-01-BAD.tex
+++ b/tagging-status/testfiles-partial/ragged2e/ragged2e-01-BAD.tex
@@ -1,0 +1,23 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on
+  }
+\documentclass{article}
+\usepackage{ragged2e}
+
+\title{ragged2e tagging test}
+
+\begin{document}
+
+\begin{Center}
+Some text in an environment
+\end{Center}
+
+\begin{center}
+Compare with normal center environment
+\end{center}
+
+\end{document}


### PR DESCRIPTION
Lists ragged2e as partially-compatible, realscripts as partially-compatible, and repltext as currently-incompatible and adds tests for each.

Lists selinput as partially-compatible because its mechanism does not seem to have negative effects but it only works with pdftex and should not be needed with new documents.