### PR TITLE
add more tests

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -406,13 +406,13 @@
 
 - name: amsaddr
   type: package
-  status: unchecked
+  status: currently-incompatible
   included-in: [arxiv01]
   priority: 6
   issues:
-  tests: false
-  tasks: needs tests
-  updated: 2024-08-01
+  tests: true
+  comments: "`\\maketitle` tagging is not correct."
+  updated: 2025-11-20
 
 - name: amsbsy
   type: package
@@ -479,13 +479,13 @@
 
 - name: amsmidx
   type: package
-  status: unchecked
+  status: partially-compatible
   included-in: 
   priority: 9
-  issues:
-  tests: false
-  tasks: needs tests
-  updated: 2024-08-01
+  issues: [1079]
+  tests: true
+  comments: "Meant for use with amsbook which is currently incompatible."
+  updated: 2025-11-20
 
 - name: amsopn
   type: package
@@ -637,13 +637,14 @@
 
 - name: arabi
   type: package
-  status: unchecked
+  status: no-support
   included-in: [tlc3]
   priority: 2
   issues:
   tests: false
-  tasks: needs tests
-  updated: 2024-07-13
+  comments: "Obsolete. Use luatex with arabluatex or babel; see the babel
+             [guide](https://latex3.github.io/babel/guides/locale-arabic.html)."
+  updated: 2025-11-20
 
 - name: arabicfront
   type: package
@@ -1984,9 +1985,9 @@
   references: [2]
   issues: [18,902]
   external-issues: ["https://github.com/plk/biblatex/issues/1366"]
-  tests: false
-  tasks: needs tests
-  updated: 2024-07-07
+  tests: true
+  tasks: needs more tests
+  updated: 2025-11-20
 
 - name: biblatex-chicago
   type: package
@@ -2824,23 +2825,23 @@
 
 - name: circledsteps
   type: package
-  status: unchecked
+  status: partially-compatible
   included-in: [arxiv001]
   priority: 7
   issues:
-  tests: false
-  tasks: needs tests
-  updated: 2024-07-18
+  tests: true
+  comments: "Missing TextDecoration attributes. No luamml support in math mode."
+  updated: 2025-11-20
 
 - name: circledtext
   type: package
-  status: unchecked
+  status: partially-compatible
   included-in:
   priority: 9
   issues:
-  tests: false
-  tasks: needs tests
-  updated: 2024-07-18
+  tests: true
+  comments: "Missing TextDecoration attributes."
+  updated: 2025-11-20
 
 - name: cistercian
   type: package
@@ -2959,13 +2960,12 @@
 
 - name: codehigh
   type: package
-  status: unchecked
+  status: currently-incompatible
   included-in:
   priority: 9
-  issues:
-  tests: false
-  tasks: needs tests
-  updated: 2024-07-18
+  issues: [1080]
+  tests: true
+  updated: 2025-11-20
 
 - name: coelacanth
   type: package

--- a/tagging-status/testfiles-incompatible/amsaddr/amsaddr-01-BAD.pdftex.struct.xml
+++ b/tagging-status/testfiles-incompatible/amsaddr/amsaddr-01-BAD.pdftex.struct.xml
@@ -1,0 +1,113 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <footnote xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.005"
+      rolemaps-to="FENote"
+     >
+    <footnotelabel xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.008"
+       rolemaps-to="Lbl"
+      >
+     <?MarkedContent page="1" ?>
+    </footnotelabel>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.006"
+       rolemaps-to="Part"
+      >
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.007"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextAlign="Justify"
+        rolemaps-to="P"
+       >
+      <?MarkedContent page="1" ?>
+      <?MarkedContent page="1" ?>
+      <?MarkedContent page="1" ?>E-mail addresses:someone@something.com.
+      <?MarkedContent page="1" ?>
+     </text>
+    </text-unit>
+   </footnote>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.009"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.010"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Center"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>AMSADDR TAGGING TEST – 01
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.011"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.012"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Center"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>SOME AUTHOR
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.013"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.014"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Center"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Some address
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.015"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.016"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Center"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>ANOTHER AUTHOR
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.017"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.018"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Center"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Another address
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.019"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.020"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Some text
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-incompatible/amsaddr/amsaddr-01-BAD.struct.xml
+++ b/tagging-status/testfiles-incompatible/amsaddr/amsaddr-01-BAD.struct.xml
@@ -1,0 +1,109 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <footnote xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.005"
+      rolemaps-to="FENote"
+     >
+    <footnotelabel xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.008"
+       rolemaps-to="Lbl"
+      >
+    </footnotelabel>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.006"
+       rolemaps-to="Part"
+      >
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.007"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextAlign="Justify"
+        rolemaps-to="P"
+       >
+      <?MarkedContent page="1" ?>E-mail addresses: someone@something.com.
+     </text>
+    </text-unit>
+   </footnote>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.009"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.010"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Center"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>AMSADDR TAGGING TEST – 01
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.011"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.012"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Center"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>SOME AUTHOR
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.013"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.014"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Center"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Some address
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.015"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.016"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Center"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>ANOTHER AUTHOR
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.017"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.018"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Center"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Another address
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.019"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.020"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Some text
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-incompatible/amsaddr/amsaddr-01-BAD.tex
+++ b/tagging-status/testfiles-incompatible/amsaddr/amsaddr-01-BAD.tex
@@ -1,0 +1,28 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on,
+  }
+\documentclass{amsart}
+\ifdefined\Uchar
+  \usepackage{unicode-math}
+\fi
+\usepackage{amsaddr}
+
+\title{amsaddr tagging test -- 01}
+
+\author{Some author}
+\address{Some address}
+
+\author{Another author}
+\address{Another address}
+
+\email{someone@something.com}
+
+\begin{document}
+\maketitle
+
+Some text
+\end{document}

--- a/tagging-status/testfiles-incompatible/amsaddr/amsaddr-02-BAD.pdftex.struct.xml
+++ b/tagging-status/testfiles-incompatible/amsaddr/amsaddr-02-BAD.pdftex.struct.xml
@@ -1,0 +1,134 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <footnote xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.005"
+      rolemaps-to="FENote"
+     >
+    <footnotelabel xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.008"
+       rolemaps-to="Lbl"
+      >
+     <?MarkedContent page="1" ?>
+    </footnotelabel>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.006"
+       rolemaps-to="Part"
+      >
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.007"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextAlign="Justify"
+        rolemaps-to="P"
+       >
+      <?MarkedContent page="1" ?>
+      <?MarkedContent page="1" ?>
+      <?MarkedContent page="1" ?>Some address
+     </text>
+    </text-unit>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.009"
+       rolemaps-to="Part"
+      >
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.010"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextAlign="Justify"
+        rolemaps-to="P"
+       >
+      <?MarkedContent page="1" ?>Another address
+      <?MarkedContent page="1" ?>
+     </text>
+    </text-unit>
+   </footnote>
+   <footnote xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.011"
+      rolemaps-to="FENote"
+     >
+    <footnotelabel xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.014"
+       rolemaps-to="Lbl"
+      >
+     <?MarkedContent page="1" ?>
+    </footnotelabel>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.012"
+       rolemaps-to="Part"
+      >
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.013"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextAlign="Justify"
+        rolemaps-to="P"
+       >
+      <?MarkedContent page="1" ?>
+      <?MarkedContent page="1" ?>
+      <?MarkedContent page="1" ?>E-mail addresses:someone@something.com.
+      <?MarkedContent page="1" ?>
+     </text>
+    </text-unit>
+   </footnote>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.015"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.016"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Center"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>AMSADDR TAGGING TEST – 02
+    </text>
+    <list xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.017"
+       xmlns:List="http://iso.org/pdf/ssn/List"
+       List:ListNumbering="Unordered"
+       rolemaps-to="L"
+      >
+     <LI xmlns="http://iso.org/pdf2/ssn"
+        id="ID.018"
+       >
+      <Lbl xmlns="http://iso.org/pdf2/ssn"
+         id="ID.019"
+        >
+       <?MarkedContent page="1" ?>
+      </Lbl>
+      <LBody xmlns="http://iso.org/pdf2/ssn"
+         id="ID.020"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.021"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.022"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Center"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="1" ?>SOME AUTHOR AND ANOTHER AUTHOR
+        </text>
+       </text-unit>
+      </LBody>
+     </LI>
+    </list>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.023"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.024"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Some text
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-incompatible/amsaddr/amsaddr-02-BAD.struct.xml
+++ b/tagging-status/testfiles-incompatible/amsaddr/amsaddr-02-BAD.struct.xml
@@ -1,0 +1,125 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <footnote xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.005"
+      rolemaps-to="FENote"
+     >
+    <footnotelabel xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.008"
+       rolemaps-to="Lbl"
+      >
+    </footnotelabel>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.006"
+       rolemaps-to="Part"
+      >
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.007"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextAlign="Justify"
+        rolemaps-to="P"
+       >
+      <?MarkedContent page="1" ?>Some address
+     </text>
+    </text-unit>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.009"
+       rolemaps-to="Part"
+      >
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.010"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextAlign="Justify"
+        rolemaps-to="P"
+       >
+      <?MarkedContent page="1" ?>Another address
+     </text>
+    </text-unit>
+   </footnote>
+   <footnote xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.011"
+      rolemaps-to="FENote"
+     >
+    <footnotelabel xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.014"
+       rolemaps-to="Lbl"
+      >
+    </footnotelabel>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.012"
+       rolemaps-to="Part"
+      >
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.013"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextAlign="Justify"
+        rolemaps-to="P"
+       >
+      <?MarkedContent page="1" ?>E-mail addresses: someone@something.com.
+     </text>
+    </text-unit>
+   </footnote>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.015"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.016"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Center"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>AMSADDR TAGGING TEST – 02
+    </text>
+    <list xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.017"
+       xmlns:List="http://iso.org/pdf/ssn/List"
+       List:ListNumbering="Unordered"
+       rolemaps-to="L"
+      >
+     <LI xmlns="http://iso.org/pdf2/ssn"
+        id="ID.018"
+       >
+      <Lbl xmlns="http://iso.org/pdf2/ssn"
+         id="ID.019"
+        >
+      </Lbl>
+      <LBody xmlns="http://iso.org/pdf2/ssn"
+         id="ID.020"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.021"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.022"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Center"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="1" ?>SOME AUTHOR AND ANOTHER AUTHOR
+        </text>
+       </text-unit>
+      </LBody>
+     </LI>
+    </list>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.023"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.024"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Some text
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-incompatible/amsaddr/amsaddr-02-BAD.tex
+++ b/tagging-status/testfiles-incompatible/amsaddr/amsaddr-02-BAD.tex
@@ -1,0 +1,28 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on,
+  }
+\documentclass{amsart}
+\ifdefined\Uchar
+  \usepackage{unicode-math}
+\fi
+\usepackage[foot]{amsaddr}
+
+\title{amsaddr tagging test -- 02}
+
+\author{Some author}
+\address{Some address}
+
+\author{Another author}
+\address{Another address}
+
+\email{someone@something.com}
+
+\begin{document}
+\maketitle
+
+Some text
+\end{document}

--- a/tagging-status/testfiles-incompatible/codehigh/codehigh-01-BAD.pdftex.struct.xml
+++ b/tagging-status/testfiles-incompatible/codehigh/codehigh-01-BAD.pdftex.struct.xml
@@ -1,0 +1,421 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.005"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.006"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+    </text>
+    <Div xmlns="http://iso.org/pdf2/ssn"
+       id="ID.007"
+      >
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.008"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.009"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Justify"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>% -*- coding: utf-8 -*-
+      </text>
+     </text-unit>
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.010"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.011"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Justify"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>\documentclass{article}
+      </text>
+     </text-unit>
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.012"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.013"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Justify"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>\usepackage[a4paper,margin=2cm]{geometry}
+      </text>
+     </text-unit>
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.014"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.015"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Justify"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>\usepackage{codehigh}
+      </text>
+     </text-unit>
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.016"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.017"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Justify"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>\usepackage{hyperref}
+      </text>
+     </text-unit>
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.018"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.019"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Justify"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>\newcommand*{\myversion}{2021C}
+      </text>
+     </text-unit>
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.020"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.021"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Justify"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>\newcommand*{\mydate}{Version \myversion\(\the\year-\mylpad\month-\mylpad\day)}
+      </text>
+     </text-unit>
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.022"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.023"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Justify"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>\newcommand*{\mylpad}[1]{\ifnum#1&lt;10 0\the#1\else\the#1\fi}
+      </text>
+     </text-unit>
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.024"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.025"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Justify"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>\setlength{\abc}{1}
+      </text>
+     </text-unit>
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.026"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.027"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Justify"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>\begin{document}
+      </text>
+     </text-unit>
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.028"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.029"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Justify"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>% some comment
+      </text>
+     </text-unit>
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.030"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.031"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Justify"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>\section{Section Name}
+      </text>
+     </text-unit>
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.032"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.033"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Justify"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>\subsection*{Subsection Name}
+      </text>
+     </text-unit>
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.034"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.035"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Justify"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>Math $a+b$.
+      </text>
+     </text-unit>
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.036"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.037"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Justify"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>\end{document}
+      </text>
+     </text-unit>
+    </Div>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.038"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.039"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.040"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>% this original file has been renamed to samples.tex and describesthe
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.041"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.042"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>% short quotes that can be used in test files
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.043"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.044"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>\starttext
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.045"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.046"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>see \type {samples.tex}
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.047"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.048"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>\blank
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.049"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.050"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>\startluacode
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.051"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.052"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>context("see \\type {samples.tex}")
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.053"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.054"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>\stopluacode
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.055"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.056"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>\blank
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.057"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.058"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>\startMPcode
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.059"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.060"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>draw textext("see \type {samples.tex}") ;
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.061"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.062"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>draw boundingbox currentpicture enlarged 2pt ;
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.063"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.064"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>\stopMPcode
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.065"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.066"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>\stoptext
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.067"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.068"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-incompatible/codehigh/codehigh-01-BAD.struct.xml
+++ b/tagging-status/testfiles-incompatible/codehigh/codehigh-01-BAD.struct.xml
@@ -1,0 +1,421 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.005"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.006"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+    </text>
+    <Div xmlns="http://iso.org/pdf2/ssn"
+       id="ID.007"
+      >
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.008"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.009"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Justify"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>% -*- coding: utf-8 -*-
+      </text>
+     </text-unit>
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.010"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.011"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Justify"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>\documentclass{article}
+      </text>
+     </text-unit>
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.012"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.013"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Justify"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>\usepackage[a4paper,margin=2cm]{geometry}
+      </text>
+     </text-unit>
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.014"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.015"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Justify"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>\usepackage{codehigh}
+      </text>
+     </text-unit>
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.016"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.017"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Justify"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>\usepackage{hyperref}
+      </text>
+     </text-unit>
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.018"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.019"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Justify"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>\newcommand*{\myversion}{2021C}
+      </text>
+     </text-unit>
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.020"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.021"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Justify"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>\newcommand*{\mydate}{Version \myversion\ (\the\year-\mylpad\month-\mylpad\day)}
+      </text>
+     </text-unit>
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.022"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.023"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Justify"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>\newcommand*{\mylpad}[1]{\ifnum#1&lt;10 0\the#1\else\the#1\fi}
+      </text>
+     </text-unit>
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.024"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.025"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Justify"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>\setlength{\abc}{1}
+      </text>
+     </text-unit>
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.026"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.027"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Justify"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>\begin{document}
+      </text>
+     </text-unit>
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.028"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.029"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Justify"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>% some comment
+      </text>
+     </text-unit>
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.030"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.031"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Justify"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>\section{Section Name}
+      </text>
+     </text-unit>
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.032"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.033"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Justify"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>\subsection*{Subsection Name}
+      </text>
+     </text-unit>
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.034"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.035"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Justify"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>Math $a+b$.
+      </text>
+     </text-unit>
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.036"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.037"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Justify"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>\end{document}
+      </text>
+     </text-unit>
+    </Div>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.038"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.039"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.040"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>% this original file has been renamed to samples.tex and describes the
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.041"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.042"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>% short quotes that can be used in test files
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.043"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.044"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>\starttext
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.045"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.046"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>see \type{samples.tex}
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.047"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.048"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>\blank
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.049"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.050"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>\startluacode
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.051"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.052"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?> context("see \\type{samples.tex}")
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.053"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.054"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>\stopluacode
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.055"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.056"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>\blank
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.057"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.058"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>\startMPcode
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.059"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.060"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?> draw textext("see \type{samples.tex}") ;
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.061"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.062"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?> draw boundingbox currentpicture enlarged 2pt ;
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.063"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.064"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>\stopMPcode
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.065"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.066"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>\stoptext
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.067"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.068"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-incompatible/codehigh/codehigh-01-BAD.tex
+++ b/tagging-status/testfiles-incompatible/codehigh/codehigh-01-BAD.tex
@@ -1,0 +1,47 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on
+  }
+\begin{filecontents}{sample.tex}
+\cs_new_protected:Npn \__codehigh_typeset_demo:
+  {
+    \__codehigh_build_code:
+    \__codehigh_build_demo:
+    \dim_set:Nn \l_tmpa_dim { \box_wd:N \g__codehigh_code_box }
+    \dim_set:Nn \l_tmpb_dim { \box_wd:N \g__codehigh_demo_box }
+    \par\addvspace{0.5em}\noindent
+    % more code
+  }
+\end{filecontents}
+\documentclass{article}
+
+\usepackage{codehigh}
+
+\title{codehigh tagging test -- 01}
+
+\begin{document}
+
+\begin{codehigh}
+% -*- coding: utf-8 -*-
+\documentclass{article}
+\usepackage[a4paper,margin=2cm]{geometry}
+\usepackage{codehigh}
+\usepackage{hyperref}
+\newcommand*{\myversion}{2021C}
+\newcommand*{\mydate}{Version \myversion\ (\the\year-\mylpad\month-\mylpad\day)}
+\newcommand*{\mylpad}[1]{\ifnum#1<10 0\the#1\else\the#1\fi}
+\setlength{\abc}{1}
+\begin{document}
+% some comment
+\section{Section Name}
+\subsection*{Subsection Name}
+Math $a+b$.
+\end{document}
+\end{codehigh}
+
+\dochighinput[language=latex/latex3]{sample.tex}
+
+\end{document}

--- a/tagging-status/testfiles-incompatible/codehigh/codehigh-02-BAD.pdftex.struct.xml
+++ b/tagging-status/testfiles-incompatible/codehigh/codehigh-02-BAD.pdftex.struct.xml
@@ -1,0 +1,168 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+  </Document>
+  <Div xmlns="http://iso.org/pdf2/ssn"
+     id="ID.005"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.006"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.007"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>\begin{tabular}{lc}
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.008"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.009"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>A &amp; B \\
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.010"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.011"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>C &amp; D
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.012"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.013"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>\end{tabular}
+    </text>
+   </text-unit>
+  </Div>
+  <text xmlns="https://www.latex-project.org/ns/dflt"
+     id="ID.014"
+     rolemaps-to="P"
+    >
+  </text>
+  <Div xmlns="http://iso.org/pdf2/ssn"
+     id="ID.015"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.016"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.017"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+    </text>
+    <Table xmlns="http://iso.org/pdf2/ssn"
+       id="ID.018"
+      >
+     <TR xmlns="http://iso.org/pdf2/ssn"
+        id="ID.019"
+       >
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.020"
+        >
+       <?MarkedContent page="1" ?>A
+      </TD>
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.021"
+        >
+       <?MarkedContent page="1" ?>B
+      </TD>
+     </TR>
+     <TR xmlns="http://iso.org/pdf2/ssn"
+        id="ID.022"
+       >
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.023"
+        >
+       <?MarkedContent page="1" ?>C
+      </TD>
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.024"
+        >
+       <?MarkedContent page="1" ?>D
+      </TD>
+     </TR>
+    </Table>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.025"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+    </text>
+   </text-unit>
+  </Div>
+  <text xmlns="https://www.latex-project.org/ns/dflt"
+     id="ID.026"
+     rolemaps-to="P"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.027"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.028"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>\begin{tabular}{lc}A &amp; B \\C &amp; D\end{tabular}ABCD
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.029"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.030"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Justify"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>\begin{tabular}{lc}A &amp; B \\C &amp; D\end{tabular}
+      </text>
+     </text-unit>
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.031"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.032"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Justify"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>ABCD
+      </text>
+     </text-unit>
+    </text>
+   </text-unit>
+  </text>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-incompatible/codehigh/codehigh-02-BAD.struct.xml
+++ b/tagging-status/testfiles-incompatible/codehigh/codehigh-02-BAD.struct.xml
@@ -1,0 +1,142 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+  </Document>
+  <Div xmlns="http://iso.org/pdf2/ssn"
+     id="ID.005"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.006"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.007"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>\begin{tabular}{lc}
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.008"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.009"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>A &amp; B \\
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.010"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.011"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>C &amp; D
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.012"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.013"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>\end{tabular}
+    </text>
+   </text-unit>
+  </Div>
+  <text xmlns="https://www.latex-project.org/ns/dflt"
+     id="ID.014"
+     rolemaps-to="P"
+    >
+  </text>
+  <Div xmlns="http://iso.org/pdf2/ssn"
+     id="ID.015"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.016"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.017"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+    </text>
+    <Table xmlns="http://iso.org/pdf2/ssn"
+       id="ID.018"
+      >
+     <TR xmlns="http://iso.org/pdf2/ssn"
+        id="ID.019"
+       >
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.020"
+        >
+       <?MarkedContent page="1" ?>A
+      </TD>
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.021"
+        >
+       <?MarkedContent page="1" ?>B
+      </TD>
+     </TR>
+     <TR xmlns="http://iso.org/pdf2/ssn"
+        id="ID.022"
+       >
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.023"
+        >
+       <?MarkedContent page="1" ?>C
+      </TD>
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.024"
+        >
+       <?MarkedContent page="1" ?>D
+      </TD>
+     </TR>
+    </Table>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.025"
+       rolemaps-to="P"
+      >
+    </text>
+   </text-unit>
+  </Div>
+  <text xmlns="https://www.latex-project.org/ns/dflt"
+     id="ID.026"
+     rolemaps-to="P"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.027"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.028"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+    </text>
+   </text-unit>
+  </text>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-incompatible/codehigh/codehigh-02-BAD.tex
+++ b/tagging-status/testfiles-incompatible/codehigh/codehigh-02-BAD.tex
@@ -1,0 +1,23 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on
+  }
+\documentclass{article}
+
+\usepackage{codehigh}
+
+\title{codehigh tagging test -- 02}
+
+\begin{document}
+
+\begin{demohigh}[language=latex/table]
+\begin{tabular}{lc}
+A & B \\
+C & D
+\end{tabular}
+\end{demohigh}
+
+\end{document}

--- a/tagging-status/testfiles-partial-mathml/circledsteps/circledsteps-01-BAD.pdftex.struct.xml
+++ b/tagging-status/testfiles-partial-mathml/circledsteps/circledsteps-01-BAD.pdftex.struct.xml
@@ -1,0 +1,76 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.005"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.006"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>This is normal text:1 is on the baseline,2is on top.
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.007"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.008"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>This is more evident if you have descenders, like p:p andp.
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.009"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.010"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>You can set options as optional arguments, likeR org.
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.011"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.012"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Math mode is detected too:A and
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.013"
+        title="math"
+        af="mathml-1.xml tag-AFfile1.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-1.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mtext> �� </mtext> <msup> <mrow/> <mtext> �� </mtext> </msup> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile1.tex" xmlns="">
+       $\Circled {A}^{\Circled {A}}$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>AA
+     </Formula>
+     <?MarkedContent page="1" ?>.
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-partial-mathml/circledsteps/circledsteps-01-BAD.struct.xml
+++ b/tagging-status/testfiles-partial-mathml/circledsteps/circledsteps-01-BAD.struct.xml
@@ -1,0 +1,76 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.005"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.006"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>This is normal text: 1 is on the baseline, 2 is on top.
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.007"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.008"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>This is more evident if you have descenders, like p: p and p.
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.009"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.010"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>You can set options as optional arguments, like R or g.
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.011"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.012"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Math mode is detected too: A and 
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.013"
+        title="math"
+        af="mathml-1.xml tag-AFfile1.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-1.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mtext> �� </mtext> <msup> <mrow/> <mtext> �� </mtext> </msup> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile1.tex" xmlns="">
+       $\Circled {A}^{\Circled {A}}$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>𝐴𝐴
+     </Formula>
+     <?MarkedContent page="1" ?>.
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-partial-mathml/circledsteps/circledsteps-01-BAD.tex
+++ b/tagging-status/testfiles-partial-mathml/circledsteps/circledsteps-01-BAD.tex
@@ -1,0 +1,31 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on
+  }
+\documentclass{article}
+\ifdefined\Uchar
+  \usepackage{unicode-math}
+\fi
+\usepackage{circledsteps}
+
+\title{circledsteps tagging test}
+
+\begin{document}
+
+This is normal text: \Circled{1} is on the
+baseline, \CircledTop{2} is on top.
+
+This is more evident if you have descenders,
+like p: \Circled{p} and \CircledTop{p}.
+
+You can set options as optional arguments,
+like \Circled[inner color=red]{R} or
+\CircledTop[outer color=green]{g}.
+
+Math mode is detected too: \Circled{A}
+and $\Circled{A}^{\Circled{A}}$.
+
+\end{document}

--- a/tagging-status/testfiles-partial/amsmidx/amsmidx-tasks-01-BAD.pdftex.struct.xml
+++ b/tagging-status/testfiles-partial/amsmidx/amsmidx-tasks-01-BAD.pdftex.struct.xml
@@ -1,0 +1,106 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.005"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.006"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Text, text.
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.007"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.008"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Text. End of text.
+    </text>
+   </text-unit>
+   <Sect xmlns="http://iso.org/pdf2/ssn"
+      id="ID.009"
+     >
+    <chapter xmlns="https://www.latex-project.org/ns/book"
+       id="ID.010"
+       title="The Books index"
+       rolemaps-to="H1"
+      >
+     <Span xmlns="http://iso.org/pdf2/ssn"
+        id="ID.011"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextAlign="Center"
+       >
+      <?MarkedContent page="3" ?>The Books index
+     </Span>
+     <Span xmlns="http://iso.org/pdf2/ssn"
+        id="ID.012"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextAlign="Center"
+       >
+      <?MarkedContent page="3" ?>
+     </Span>
+     <Div xmlns="http://iso.org/pdf2/ssn"
+        id="ID.013"
+       >
+      <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.014"
+         rolemaps-to="Part"
+        >
+       <text xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.015"
+          xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+          Layout:TextAlign="Center"
+          rolemaps-to="P"
+         >
+        <?MarkedContent page="3" ?>A comment before the books index
+       </text>
+      </text-unit>
+     </Div>
+     <Span xmlns="http://iso.org/pdf2/ssn"
+        id="ID.016"
+       >
+      <?MarkedContent page="3" ?>
+     </Span>
+    </chapter>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.017"
+       rolemaps-to="Part"
+      >
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.018"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextAlign="Start"
+        rolemaps-to="P"
+       >
+      <?MarkedContent page="3" ?>b1, 1
+     </text>
+    </text-unit>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.019"
+       rolemaps-to="Part"
+      >
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.020"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextAlign="Start"
+        rolemaps-to="P"
+       >
+      <?MarkedContent page="3" ?>b2, 1
+     </text>
+    </text-unit>
+   </Sect>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-partial/amsmidx/amsmidx-tasks-01-BAD.struct.xml
+++ b/tagging-status/testfiles-partial/amsmidx/amsmidx-tasks-01-BAD.struct.xml
@@ -1,0 +1,104 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.005"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.006"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Text, text.
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.007"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.008"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Text. End of text.
+    </text>
+   </text-unit>
+   <Sect xmlns="http://iso.org/pdf2/ssn"
+      id="ID.009"
+     >
+    <chapter xmlns="https://www.latex-project.org/ns/book"
+       id="ID.010"
+       title="The Books index"
+       rolemaps-to="H1"
+      >
+     <Span xmlns="http://iso.org/pdf2/ssn"
+        id="ID.011"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextAlign="Center"
+       >
+      <?MarkedContent page="3" ?>The Books index
+     </Span>
+     <Span xmlns="http://iso.org/pdf2/ssn"
+        id="ID.012"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextAlign="Center"
+       >
+     </Span>
+     <Div xmlns="http://iso.org/pdf2/ssn"
+        id="ID.013"
+       >
+      <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.014"
+         rolemaps-to="Part"
+        >
+       <text xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.015"
+          xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+          Layout:TextAlign="Center"
+          rolemaps-to="P"
+         >
+        <?MarkedContent page="3" ?>A comment before the books index
+       </text>
+      </text-unit>
+     </Div>
+     <Span xmlns="http://iso.org/pdf2/ssn"
+        id="ID.016"
+       >
+     </Span>
+    </chapter>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.017"
+       rolemaps-to="Part"
+      >
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.018"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextAlign="Start"
+        rolemaps-to="P"
+       >
+      <?MarkedContent page="3" ?>b1, 1
+     </text>
+    </text-unit>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.019"
+       rolemaps-to="Part"
+      >
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.020"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextAlign="Start"
+        rolemaps-to="P"
+       >
+      <?MarkedContent page="3" ?>b2, 1
+     </text>
+    </text-unit>
+   </Sect>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-partial/amsmidx/amsmidx-tasks-01-BAD.tex
+++ b/tagging-status/testfiles-partial/amsmidx/amsmidx-tasks-01-BAD.tex
@@ -1,0 +1,26 @@
+%tasks: makeindex books
+%tasks: makeindex author
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on
+  }
+\documentclass{amsbook}
+
+\usepackage{amsmidx}
+\makeindex{books}
+\makeindex{authors}
+
+\title{amsmidx tagging test}
+
+\begin{document}
+Text\index{books}{b1}, text\index{authors}{a1}.
+
+Text\index{books}{b2}\index{authors}{a2}. End of text.
+
+\indexcomment{A comment before the books index}
+\Printindex{books}{The Books index}
+\Printindex{authors}{The Authors index}
+\end{document}

--- a/tagging-status/testfiles-partial/biblatex/biblatex-biber-01-BAD.pdftex.struct.xml
+++ b/tagging-status/testfiles-partial/biblatex/biblatex-biber-01-BAD.pdftex.struct.xml
@@ -1,0 +1,248 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.005"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.006"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Knuth,
+     <Reference xmlns="http://iso.org/pdf/ssn"
+        id="ID.007"
+       >
+       <?References objects="1" ?>
+      <?MarkedContent page="1" ?>
+      <Link xmlns="http://iso.org/pdf2/ssn"
+         id="ID.008"
+        >
+       <?MarkedContent page="1" ?>
+       <Em xmlns="http://iso.org/pdf2/ssn"
+          id="ID.009"
+         >
+        <?MarkedContent page="1" ?>Computers &amp; Typesetting
+       </Em>
+       <?MarkedContent page="1" ?>
+       <?ReferencedObject type="Annot" page="1" ?>
+      </Link>
+      <?MarkedContent page="1" ?>
+     </Reference>
+     <?MarkedContent page="1" ?>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.010"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.011"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Goossens, Mittelbach, and Samarin,
+     <Reference xmlns="http://iso.org/pdf/ssn"
+        id="ID.012"
+       >
+       <?References objects="2" ?>
+      <?MarkedContent page="1" ?>
+      <Link xmlns="http://iso.org/pdf2/ssn"
+         id="ID.013"
+        >
+       <?MarkedContent page="1" ?>
+       <Em xmlns="http://iso.org/pdf2/ssn"
+          id="ID.014"
+         >
+        <?MarkedContent page="1" ?>LaTeX Companion
+       </Em>
+       <?MarkedContent page="1" ?>
+       <?ReferencedObject type="Annot" page="1" ?>
+      </Link>
+      <?MarkedContent page="1" ?>
+     </Reference>
+     <?MarkedContent page="1" ?>
+    </text>
+   </text-unit>
+   <Sect xmlns="http://iso.org/pdf2/ssn"
+      id="ID.015"
+     >
+    <section xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.016"
+       title="\refname "
+       rolemaps-to="H1"
+      >
+     <?MarkedContent page="1" ?>References
+    </section>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.017"
+       rolemaps-to="Part"
+      >
+     <list xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.018"
+        xmlns:List="http://iso.org/pdf/ssn/List"
+        List:ListNumbering="Unordered"
+        rolemaps-to="L"
+       >
+      <LI xmlns="http://iso.org/pdf2/ssn"
+         id="ID.019"
+        >
+       <Lbl xmlns="http://iso.org/pdf2/ssn"
+          id="ID.020"
+         >
+        <?MarkedContent page="1" ?>
+       </Lbl>
+       <LBody xmlns="http://iso.org/pdf2/ssn"
+          id="ID.021"
+         >
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.022"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.023"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>Goossens et al.: LaTeX Companion companion
+         </text>
+        </text-unit>
+       </LBody>
+      </LI>
+      <LI xmlns="http://iso.org/pdf2/ssn"
+         id="ID.024"
+         referenced-as="2"
+        >
+       <Lbl xmlns="http://iso.org/pdf2/ssn"
+          id="ID.025"
+         >
+        <?MarkedContent page="1" ?>
+       </Lbl>
+       <LBody xmlns="http://iso.org/pdf2/ssn"
+          id="ID.026"
+         >
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.027"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.028"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>Michel Goossens, Frank Mittelbach, and Alexander Samarin.
+          <Em xmlns="http://iso.org/pdf2/ssn"
+             id="ID.029"
+            >
+           <?MarkedContent page="1" ?>The LaTeX Com-panion
+          </Em>
+          <?MarkedContent page="1" ?>. 1st ed. Reading, Mass.: Addison-Wesley, 1994. 528 pp.
+         </text>
+        </text-unit>
+       </LBody>
+      </LI>
+      <LI xmlns="http://iso.org/pdf2/ssn"
+         id="ID.030"
+        >
+       <Lbl xmlns="http://iso.org/pdf2/ssn"
+          id="ID.031"
+         >
+        <!-- Referenced marked content sequence not found -->
+        <?MarkedContent page="1" ?>[missing]
+       </Lbl>
+       <LBody xmlns="http://iso.org/pdf2/ssn"
+          id="ID.032"
+         >
+       </LBody>
+      </LI>
+     </list>
+    </text-unit>
+    <LI xmlns="http://iso.org/pdf2/ssn"
+       id="ID.033"
+      >
+     <Lbl xmlns="http://iso.org/pdf2/ssn"
+        id="ID.034"
+       >
+      <!-- Referenced marked content sequence not found -->
+      <?MarkedContent page="1" ?>[missing]
+     </Lbl>
+     <LBody xmlns="http://iso.org/pdf2/ssn"
+        id="ID.035"
+       >
+      <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.036"
+         rolemaps-to="Part"
+        >
+       <text xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.037"
+          xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+          Layout:TextAlign="Justify"
+          rolemaps-to="P"
+         >
+        <!-- Referenced marked content sequence not found -->
+        <?MarkedContent page="1" ?>[missing]
+       </text>
+      </text-unit>
+     </LBody>
+    </LI>
+    <LI xmlns="http://iso.org/pdf2/ssn"
+       id="ID.038"
+       referenced-as="1"
+      >
+     <Lbl xmlns="http://iso.org/pdf2/ssn"
+        id="ID.039"
+       >
+      <!-- Referenced marked content sequence not found -->
+      <?MarkedContent page="1" ?>[missing]
+     </Lbl>
+     <LBody xmlns="http://iso.org/pdf2/ssn"
+        id="ID.040"
+       >
+      <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.041"
+         rolemaps-to="Part"
+        >
+       <text xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.042"
+          xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+          Layout:TextAlign="Justify"
+          rolemaps-to="P"
+         >
+        <!-- Referenced marked content sequence not found -->
+        <?MarkedContent page="1" ?>[missing]
+        <Em xmlns="http://iso.org/pdf2/ssn"
+           id="ID.043"
+          >
+         <!-- Referenced marked content sequence not found -->
+         <?MarkedContent page="1" ?>[missing]
+        </Em>
+        <!-- Referenced marked content sequence not found -->
+        <?MarkedContent page="1" ?>[missing]
+       </text>
+      </text-unit>
+     </LBody>
+    </LI>
+    <LI xmlns="http://iso.org/pdf2/ssn"
+       id="ID.044"
+      >
+     <Lbl xmlns="http://iso.org/pdf2/ssn"
+        id="ID.045"
+       >
+      <?MarkedContent page="1" ?>
+     </Lbl>
+     <LBody xmlns="http://iso.org/pdf2/ssn"
+        id="ID.046"
+       >
+     </LBody>
+    </LI>
+   </Sect>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-partial/biblatex/biblatex-biber-01-BAD.struct.xml
+++ b/tagging-status/testfiles-partial/biblatex/biblatex-biber-01-BAD.struct.xml
@@ -1,0 +1,238 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.005"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.006"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Knuth, 
+     <Reference xmlns="http://iso.org/pdf/ssn"
+        id="ID.007"
+       >
+       <?References objects="1" ?>
+      <Link xmlns="http://iso.org/pdf2/ssn"
+         id="ID.008"
+        >
+       <?MarkedContent page="1" ?>
+       <Em xmlns="http://iso.org/pdf2/ssn"
+          id="ID.009"
+         >
+        <?MarkedContent page="1" ?>Computers &amp; Typesetting
+       </Em>
+       <?MarkedContent page="1" ?>
+       <?ReferencedObject type="Annot" page="1" ?>
+      </Link>
+     </Reference>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.010"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.011"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Goossens, Mittelbach, and Samarin, 
+     <Reference xmlns="http://iso.org/pdf/ssn"
+        id="ID.012"
+       >
+       <?References objects="2" ?>
+      <Link xmlns="http://iso.org/pdf2/ssn"
+         id="ID.013"
+        >
+       <?MarkedContent page="1" ?>
+       <Em xmlns="http://iso.org/pdf2/ssn"
+          id="ID.014"
+         >
+        <?MarkedContent page="1" ?>LaTeX Companion
+       </Em>
+       <?MarkedContent page="1" ?>
+       <?ReferencedObject type="Annot" page="1" ?>
+      </Link>
+     </Reference>
+    </text>
+   </text-unit>
+   <Sect xmlns="http://iso.org/pdf2/ssn"
+      id="ID.015"
+     >
+    <section xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.016"
+       title="\refname "
+       rolemaps-to="H1"
+      >
+     <?MarkedContent page="1" ?>References
+    </section>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.017"
+       rolemaps-to="Part"
+      >
+     <list xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.018"
+        xmlns:List="http://iso.org/pdf/ssn/List"
+        List:ListNumbering="Unordered"
+        rolemaps-to="L"
+       >
+      <LI xmlns="http://iso.org/pdf2/ssn"
+         id="ID.019"
+        >
+       <Lbl xmlns="http://iso.org/pdf2/ssn"
+          id="ID.020"
+         >
+        <?MarkedContent page="1" ?>
+       </Lbl>
+       <LBody xmlns="http://iso.org/pdf2/ssn"
+          id="ID.021"
+         >
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.022"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.023"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>Goossens et al.: LaTeX Companion
+          <?MarkedContent page="1" ?> 
+          <?MarkedContent page="1" ?>companion
+         </text>
+        </text-unit>
+       </LBody>
+      </LI>
+      <LI xmlns="http://iso.org/pdf2/ssn"
+         id="ID.024"
+         referenced-as="2"
+        >
+       <Lbl xmlns="http://iso.org/pdf2/ssn"
+          id="ID.025"
+         >
+        <?MarkedContent page="1" ?>
+       </Lbl>
+       <LBody xmlns="http://iso.org/pdf2/ssn"
+          id="ID.026"
+         >
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.027"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.028"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>Michel Goossens, Frank Mittelbach, and Alexander Samarin. 
+          <Em xmlns="http://iso.org/pdf2/ssn"
+             id="ID.029"
+            >
+           <?MarkedContent page="1" ?>The LaTeX Com­panion
+          </Em>
+          <?MarkedContent page="1" ?>. 1st ed. Reading, Mass.: Addison-Wesley, 1994. 528 pp.
+         </text>
+        </text-unit>
+       </LBody>
+      </LI>
+      <LI xmlns="http://iso.org/pdf2/ssn"
+         id="ID.030"
+        >
+       <Lbl xmlns="http://iso.org/pdf2/ssn"
+          id="ID.031"
+         >
+        <?MarkedContent page="1" ?>
+       </Lbl>
+       <LBody xmlns="http://iso.org/pdf2/ssn"
+          id="ID.032"
+         >
+       </LBody>
+      </LI>
+     </list>
+    </text-unit>
+    <LI xmlns="http://iso.org/pdf2/ssn"
+       id="ID.033"
+      >
+     <Lbl xmlns="http://iso.org/pdf2/ssn"
+        id="ID.034"
+       >
+      <?MarkedContent page="1" ?>
+     </Lbl>
+     <LBody xmlns="http://iso.org/pdf2/ssn"
+        id="ID.035"
+       >
+      <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.036"
+         rolemaps-to="Part"
+        >
+       <text xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.037"
+          xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+          Layout:TextAlign="Justify"
+          rolemaps-to="P"
+         >
+        <?MarkedContent page="1" ?>Knuth: Computers &amp; Typesetting
+        <?MarkedContent page="1" ?> 
+        <?MarkedContent page="1" ?>knuth:ct
+       </text>
+      </text-unit>
+     </LBody>
+    </LI>
+    <LI xmlns="http://iso.org/pdf2/ssn"
+       id="ID.038"
+       referenced-as="1"
+      >
+     <Lbl xmlns="http://iso.org/pdf2/ssn"
+        id="ID.039"
+       >
+      <?MarkedContent page="1" ?>
+     </Lbl>
+     <LBody xmlns="http://iso.org/pdf2/ssn"
+        id="ID.040"
+       >
+      <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.041"
+         rolemaps-to="Part"
+        >
+       <text xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.042"
+          xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+          Layout:TextAlign="Justify"
+          rolemaps-to="P"
+         >
+        <?MarkedContent page="1" ?>Donald E. Knuth. 
+        <Em xmlns="http://iso.org/pdf2/ssn"
+           id="ID.043"
+          >
+         <?MarkedContent page="1" ?>Computers &amp; Typesetting
+        </Em>
+        <?MarkedContent page="1" ?>. 5 vols. Reading, Mass.: Addison-Wesley, 1984–1986.
+       </text>
+      </text-unit>
+     </LBody>
+    </LI>
+    <LI xmlns="http://iso.org/pdf2/ssn"
+       id="ID.044"
+      >
+     <Lbl xmlns="http://iso.org/pdf2/ssn"
+        id="ID.045"
+       >
+     </Lbl>
+     <LBody xmlns="http://iso.org/pdf2/ssn"
+        id="ID.046"
+       >
+     </LBody>
+    </LI>
+   </Sect>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-partial/biblatex/biblatex-biber-01-BAD.tex
+++ b/tagging-status/testfiles-partial/biblatex/biblatex-biber-01-BAD.tex
@@ -1,0 +1,26 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on
+  }
+\documentclass{article}
+
+\usepackage[
+  style=reading,
+  backend=biber]{biblatex}
+\usepackage{hyperref}
+
+\addbibresource{biblatex-examples.bib}
+
+\title{biblatex tagging test -- 01}
+
+\begin{document}
+
+\cite{knuth:ct}
+
+\cite{companion}
+
+\printbibliography
+\end{document}

--- a/tagging-status/testfiles-partial/circledtext/circledtext-01.pdftex.struct.xml
+++ b/tagging-status/testfiles-partial/circledtext/circledtext-01.pdftex.struct.xml
@@ -1,0 +1,34 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.02"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.05"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.06"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>A number888and another8
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.07"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.08"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Another12
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-partial/circledtext/circledtext-01.struct.xml
+++ b/tagging-status/testfiles-partial/circledtext/circledtext-01.struct.xml
@@ -1,0 +1,34 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.02"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.05"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.06"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>A number 888 and another 8
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.07"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.08"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Another 12
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-partial/circledtext/circledtext-01.tex
+++ b/tagging-status/testfiles-partial/circledtext/circledtext-01.tex
@@ -1,0 +1,20 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on
+  }
+\documentclass{article}
+
+\usepackage{circledtext}
+
+\title{circledtext tagging test}
+
+\begin{document}
+
+A number \circledtext{888} and another \circledtext*{8}
+
+Another \circledtext[boxtype=OX]{12}
+
+\end{document}


### PR DESCRIPTION
Lists amsaddr as currently-incompatible since `\maketitle` is not tagged correctly. Adds two tests.

Lists amsmidx as partially-compatible since `\indexcomment` produces a section heading which is not tagged correctly in amsbook. Adds a test.

Lists arabi as no-support since it is obsolete and does not work with UTF8.

Adds a biblatex test that errors.

Lists circledsteps as partially-compatible since the circled numbers are missing TextDecoration attributes and are not supported by luamml in math. Adds a test.

Lists circledtext as partially-compatible for the same reason and adds a test.

Lists codehigh as currently-incompatible and adds two tests.
