### PR TITLE
add tests

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -534,7 +534,7 @@
   status: partially-compatible
   included-in: [tlc3, arxiv10]
   priority: 2
-  issues: [83,733,736,759,790,792,835,944]
+  issues: [83,733,736,759,790,792,835,944,1083]
   tests: true
   updated: 2025-09-12
 
@@ -660,11 +660,11 @@
   status: unchecked
   included-in: [tlc3]
   priority: 2
-  issues:
+  issues: [1085]
   luatex-only: true
-  tests: false
-  tasks: needs tests
-  updated: 2024-07-13
+  tests: true
+  tasks: needs more tests
+  updated: 2025-11-22
 
 - name: arev
   type: package
@@ -2115,10 +2115,9 @@
   included-in: [tlc3, arxiv01]
   priority: 2
   issues:
-  comments: "Relies on incompatible multirow."
-  tests: false
-  tasks: needs tests
-  updated: 2025-06-09
+  comments: "Relies on incompatible multirow. No luamml support in math mode."
+  tests: true
+  updated: 2025-11-22
 
 - name: bigfoot
   type: package
@@ -3070,9 +3069,9 @@
   priority: 2
   comments: "Breaks tagging if tables are nested. #90 issue with longtable fixed at the last release. #749 fixed in newest colortbl version"
   issues: [90,379,749]
-  tests: false
-  tasks: needs tests
-  updated: 2024-10-29
+  tests: true
+  tasks: needs more tests
+  updated: 2025-11-22
 
 - name: comfortaa
   type: package
@@ -5085,9 +5084,9 @@
   priority: 2
   comments: "See fancyvrb."
   issues: [1060]
-  tests: false
-  tasks: needs tests
-  updated: 2025-11-11
+  tests: true
+  tasks: needs more tests
+  updated: 2025-11-22
 
 - name: fwlw
   type: package
@@ -6652,7 +6651,7 @@
   issues: [162,210]
   tests: true
   comments: "loses linenumbers and doesn't tag line numbers"
-  tasks: needs tests
+  tasks: needs more tests
   updated: 2024-07-19
 
 - name: linguex
@@ -6903,14 +6902,14 @@
 
 - name: luamesh
   type: package
-  status: unchecked
+  status: currently-incompatible
   included-in:
   priority: 9
   issues:
   luatex-only: true
-  tests: false
-  tasks: needs tests
-  updated: 2024-07-18
+  tests: true
+  comments: "Missing way to add Alt text to underlying mplibcode or tikz environments."
+  updated: 2025-11-22
 
 - name: luamplib
   type: package
@@ -7012,7 +7011,7 @@
   status: unchecked
   included-in: [tlc3]
   priority: 2
-  issues:
+  issues: [1084]
   tests: false
   tasks: needs tests
   updated: 2024-07-15
@@ -10890,7 +10889,7 @@
   status: unchecked
   included-in:
   priority: 9
-  issues:
+  issues: [1084]
   tests: false
   tasks: needs tests
   updated: 2024-07-18
@@ -10900,7 +10899,7 @@
   status: unchecked
   included-in: [tlc3]
   priority: 2
-  issues:
+  issues: [1084]
   tests: false
   tasks: needs tests
   updated: 2024-07-15

--- a/tagging-status/testfiles-incompatible-luatex/luamesh/luamesh-01-BAD.struct.xml
+++ b/tagging-status/testfiles-incompatible-luatex/luamesh/luamesh-01-BAD.struct.xml
@@ -1,0 +1,272 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.005"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.006"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <Figure xmlns="http://iso.org/pdf2/ssn"
+        id="ID.007"
+        alt="metapost figure luamesh"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:BBox="{ 148.71233, 595.9334, 268.16583, 667.19801 }"
+       >
+      <?MarkedContent page="1" ?>
+     </Figure>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.008"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.009"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <Figure xmlns="http://iso.org/pdf2/ssn"
+        id="ID.010"
+        alt="metapost figure luamesh"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:BBox="{ 148.71233, 563.59068, 222.57845, 594.93713 }"
+       >
+      <?MarkedContent page="1" ?>
+     </Figure>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.011"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.012"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.013"
+        title="math"
+        af="tag-AFfile1.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="tag-AFfile1.tex" xmlns="">
+       $\bullet $
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>•
+     </Formula>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.014"
+        title="math"
+        af="tag-AFfile2.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="tag-AFfile2.tex" xmlns="">
+       $\MeshPoint _{1}$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>x1
+     </Formula>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.015"
+        title="math"
+        af="tag-AFfile3.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="tag-AFfile3.tex" xmlns="">
+       $\bullet $
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>•
+     </Formula>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.016"
+        title="math"
+        af="tag-AFfile4.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="tag-AFfile4.tex" xmlns="">
+       $\MeshPoint _{2}$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>x2
+     </Formula>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.017"
+        title="math"
+        af="tag-AFfile5.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="tag-AFfile5.tex" xmlns="">
+       $\bullet $
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>•
+     </Formula>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.018"
+        title="math"
+        af="tag-AFfile6.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="tag-AFfile6.tex" xmlns="">
+       $\MeshPoint _{3}$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>x3
+     </Formula>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.019"
+        title="math"
+        af="tag-AFfile7.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="tag-AFfile7.tex" xmlns="">
+       $\bullet $
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>•
+     </Formula>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.020"
+        title="math"
+        af="tag-AFfile8.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="tag-AFfile8.tex" xmlns="">
+       $\MeshPoint _{4}$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>x4
+     </Formula>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.021"
+        title="math"
+        af="tag-AFfile9.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="tag-AFfile9.tex" xmlns="">
+       $\bullet $
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>•
+     </Formula>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.022"
+        title="math"
+        af="tag-AFfile10.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="tag-AFfile10.tex" xmlns="">
+       $\MeshPoint _{5}$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>x5
+     </Formula>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.023"
+        title="math"
+        af="tag-AFfile11.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="tag-AFfile11.tex" xmlns="">
+       $\bullet $
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>•
+     </Formula>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.024"
+        title="math"
+        af="tag-AFfile12.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="tag-AFfile12.tex" xmlns="">
+       $\MeshPoint _{6}$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>x6
+     </Formula>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.025"
+        title="math"
+        af="tag-AFfile13.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="tag-AFfile13.tex" xmlns="">
+       $\bullet $
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>•
+     </Formula>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.026"
+        title="math"
+        af="tag-AFfile14.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="tag-AFfile14.tex" xmlns="">
+       $\MeshPoint _{7}$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>x7
+     </Formula>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>Mesh
+     <?MarkedContent page="1" ?>
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-incompatible-luatex/luamesh/luamesh-01-BAD.tex
+++ b/tagging-status/testfiles-incompatible-luatex/luamesh/luamesh-01-BAD.tex
@@ -1,0 +1,33 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on
+  }
+\documentclass{article}
+
+\usepackage{luamesh}
+
+\title{luamesh tagging test}
+
+\begin{document}
+
+\buildMeshBW{(0.3,0.3);(1.5,1);(4,0);(4.5,2.5);(1.81,2.14);(2.5,0.5);(2.8,1.5)}
+
+\meshPolygon[step=points,scale=2cm]{(0,0);(1,0);(1,0.5);(0,0.5);(-0.20,0.35);(-0.25,0.25);(-0.20,0.15)}
+
+\drawPointsMeshinc[
+tikz,
+color = blue!50,
+print = points,
+meshpoint = x,
+scale=0.8cm,
+]{(0.3,0.3);(1.5,1);(4,0);(4.5,2.5);(1.81,2.14);(2.5,0.5);(2.8,1.5)}%
+{% code before
+}%
+{% code after
+\node[color = blue!50] at (0,2) {Mesh} ;
+}
+
+\end{document}

--- a/tagging-status/testfiles-incompatible-mathml/bigdelim/bigdelim-01-BAD.pdftex.struct.xml
+++ b/tagging-status/testfiles-incompatible-mathml/bigdelim/bigdelim-01-BAD.pdftex.struct.xml
@@ -1,0 +1,234 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.005"
+      rolemaps-to="Part"
+     >
+    <Formula xmlns="http://iso.org/pdf2/ssn"
+       id="ID.006"
+       title="equation"
+       af="mathml-1.xml tag-AFfile1.tex"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:Placement="Block"
+      >
+      <AssociatedFile name="mathml-1.xml" xmlns="">
+      <math display="block" xmlns="http://www.w3.org/1998/Math/MathML"> <mtable displaystyle="true"> <mtr> <mtd intent=":equation-label"> <mtext> (1) </mtext> </mtd> <mtd intent=":pause-medium"> <mrow/> <mrow> <mspace width="4.981pt"/> <mtable> <mtr> <mtd> <mi> <mglyph/> </mi> </mtd> <mtd> <mi>𝑥</mi> </mtd> <mtd> <mi>𝑥</mi> </mtd> <mtd> <mi>𝑥</mi> </mtd> <mtd> <mi>𝑥</mi> </mtd> <mtd> <mi> <mglyph/> </mi> </mtd> </mtr> <mtr> <mtd> <mi>𝑥</mi> </mtd> <mtd> <mi>𝑥</mi> </mtd> <mtd> <mi>𝑥</mi> </mtd> <mtd> <mi>𝑥</mi> </mtd> <mtd> <mi>𝑖</mi> </mtd> </mtr> <mtr> <mtd> <mi>𝑥</mi> </mtd> <mtd> <mi>𝑥</mi> </mtd> <mtd> <mi>𝑥</mi> </mtd> <mtd> <mi>𝑥</mi> </mtd> <mtd> <mi>𝑗</mi> </mtd> </mtr> <mtr> <mtd> <mi>𝑥</mi> </mtd> <mtd> <mi>𝑥</mi> </mtd> <mtd> <mi>𝑥</mi> </mtd> <mtd> <mi>𝑥</mi> </mtd> </mtr> <mtr> <mtd> <mi>𝑢</mi> </mtd> <mtd> <mi>𝑣</mi> </mtd> </mtr> </mtable> <mspace width="4.981pt"/> </mrow> </mtd> </mtr> </mtable> </math>
+      </AssociatedFile>
+      <AssociatedFile name="tag-AFfile1.tex" xmlns="">
+      \begin {equation}\begin {array}{ccccccc} \ldelim ({4}{4mm} &amp; x &amp; x &amp; x &amp; x &amp; \rdelim ){4}{4mm} \\ &amp; x &amp; x &amp; x &amp; x &amp; &amp; i \\ &amp; x &amp; x &amp; x &amp; x &amp; &amp; j \\ &amp; x &amp; x &amp; x &amp; x &amp; \\ &amp; &amp; u &amp; v &amp; &amp; \end {array}\end {equation}
+      </AssociatedFile>
+     <?MarkedContent page="1" ?>⎛⎜⎜⎝xxxx⎞⎟⎟⎠xxxxixxxxjxxxxuv
+     <Lbl xmlns="http://iso.org/pdf2/ssn"
+        id="ID.007"
+       >
+      <?MarkedContent page="1" ?>(1)
+     </Lbl>
+     <?MarkedContent page="1" ?>
+    </Formula>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.008"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.009"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+    </text>
+    <Table xmlns="http://iso.org/pdf2/ssn"
+       id="ID.010"
+      >
+     <TR xmlns="http://iso.org/pdf2/ssn"
+        id="ID.011"
+       >
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.012"
+        >
+       <Formula xmlns="http://iso.org/pdf2/ssn"
+          id="ID.013"
+          title="math"
+          af="mathml-2.xml tag-AFfile2.tex"
+          xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+          Layout:Placement="Inline"
+         >
+         <AssociatedFile name="mathml-2.xml" xmlns="">
+         <math xmlns="http://www.w3.org/1998/Math/MathML"> <mspace width="1.196pt"/> <mi> <mglyph/> </mi> <mtext> type </mtext> <mo fence="true" lspace="0" rspace="0" symmetric="true">{</mo> </math>
+         </AssociatedFile>
+         <AssociatedFile name="tag-AFfile2.tex" xmlns="">
+         $\relax \left .\vcenter {\hsize =0pt\vrule height \multirow@dima width 0pt}\textnormal {type}\right \{$
+         </AssociatedFile>
+        <?MarkedContent page="1" ?>type⎧⎨⎩
+       </Formula>
+       <Div xmlns="http://iso.org/pdf2/ssn"
+          id="ID.014"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.015"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="1" ?>type⎧⎨⎩
+        </text>
+       </Div>
+      </TD>
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.016"
+        >
+       <?MarkedContent page="1" ?>dvi
+      </TD>
+     </TR>
+     <TR xmlns="http://iso.org/pdf2/ssn"
+        id="ID.017"
+       >
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.018"
+        >
+      </TD>
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.019"
+        >
+       <?MarkedContent page="1" ?>ps
+      </TD>
+     </TR>
+     <TR xmlns="http://iso.org/pdf2/ssn"
+        id="ID.020"
+       >
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.021"
+        >
+      </TD>
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.022"
+        >
+       <?MarkedContent page="1" ?>pdf
+      </TD>
+     </TR>
+    </Table>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.023"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.024"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.025"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+    </text>
+    <Table xmlns="http://iso.org/pdf2/ssn"
+       id="ID.026"
+      >
+     <TR xmlns="http://iso.org/pdf2/ssn"
+        id="ID.027"
+       >
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.028"
+        >
+       <?MarkedContent page="1" ?>
+      </TD>
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.029"
+        >
+       <?MarkedContent page="1" ?>1
+      </TD>
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.030"
+        >
+       <?MarkedContent page="1" ?>2
+      </TD>
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.031"
+        >
+       <?MarkedContent page="1" ?>3
+      </TD>
+     </TR>
+     <TR xmlns="http://iso.org/pdf2/ssn"
+        id="ID.032"
+       >
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.033"
+        >
+       <?MarkedContent page="1" ?>
+      </TD>
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.034"
+        >
+       <?MarkedContent page="1" ?>4
+      </TD>
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.035"
+        >
+       <?MarkedContent page="1" ?>5
+      </TD>
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.036"
+        >
+       <?MarkedContent page="1" ?>6
+      </TD>
+     </TR>
+     <TR xmlns="http://iso.org/pdf2/ssn"
+        id="ID.037"
+       >
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.038"
+        >
+       <?MarkedContent page="1" ?>
+       <Formula xmlns="http://iso.org/pdf2/ssn"
+          id="ID.039"
+          title="math"
+          af="mathml-3.xml tag-AFfile3.tex"
+          xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+          Layout:Placement="Inline"
+         >
+         <AssociatedFile name="mathml-3.xml" xmlns="">
+         <math xmlns="http://www.w3.org/1998/Math/MathML"> <mspace width="1.196pt"/> <mi> <mglyph/> </mi> <mtext/> <mo fence="true" lspace="0" rspace="0" symmetric="true">{</mo> </math>
+         </AssociatedFile>
+         <AssociatedFile name="tag-AFfile3.tex" xmlns="">
+         $\relax \left .\vcenter {\hsize =0pt\vrule height \multirow@dima width 0pt}\textnormal {\null }\right \{$
+         </AssociatedFile>
+        <?MarkedContent page="1" ?>⎧⎨⎩
+       </Formula>
+       <?MarkedContent page="1" ?>
+      </TD>
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.040"
+        >
+       <?MarkedContent page="1" ?>7
+      </TD>
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.041"
+        >
+       <?MarkedContent page="1" ?>8
+      </TD>
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.042"
+        >
+       <?MarkedContent page="1" ?>9
+      </TD>
+     </TR>
+    </Table>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.043"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-incompatible-mathml/bigdelim/bigdelim-01-BAD.struct.xml
+++ b/tagging-status/testfiles-incompatible-mathml/bigdelim/bigdelim-01-BAD.struct.xml
@@ -1,0 +1,230 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.005"
+      rolemaps-to="Part"
+     >
+    <Formula xmlns="http://iso.org/pdf2/ssn"
+       id="ID.006"
+       title="equation"
+       af="mathml-1.xml tag-AFfile1.tex"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:Placement="Block"
+      >
+      <AssociatedFile name="mathml-1.xml" xmlns="">
+      <math display="block" xmlns="http://www.w3.org/1998/Math/MathML"> <mtable displaystyle="true"> <mtr> <mtd intent=":equation-label"> <mtext> (1) </mtext> </mtd> <mtd intent=":pause-medium"> <mrow/> <mrow> <mspace width="4.981pt"/> <mtable> <mtr> <mtd> <mi> <mglyph/> </mi> </mtd> <mtd> <mi>𝑥</mi> </mtd> <mtd> <mi>𝑥</mi> </mtd> <mtd> <mi>𝑥</mi> </mtd> <mtd> <mi>𝑥</mi> </mtd> <mtd> <mi> <mglyph/> </mi> </mtd> </mtr> <mtr> <mtd> <mi>𝑥</mi> </mtd> <mtd> <mi>𝑥</mi> </mtd> <mtd> <mi>𝑥</mi> </mtd> <mtd> <mi>𝑥</mi> </mtd> <mtd> <mi>𝑖</mi> </mtd> </mtr> <mtr> <mtd> <mi>𝑥</mi> </mtd> <mtd> <mi>𝑥</mi> </mtd> <mtd> <mi>𝑥</mi> </mtd> <mtd> <mi>𝑥</mi> </mtd> <mtd> <mi>𝑗</mi> </mtd> </mtr> <mtr> <mtd> <mi>𝑥</mi> </mtd> <mtd> <mi>𝑥</mi> </mtd> <mtd> <mi>𝑥</mi> </mtd> <mtd> <mi>𝑥</mi> </mtd> </mtr> <mtr> <mtd> <mi>𝑢</mi> </mtd> <mtd> <mi>𝑣</mi> </mtd> </mtr> </mtable> <mspace width="4.981pt"/> </mrow> </mtd> </mtr> </mtable> </math>
+      </AssociatedFile>
+      <AssociatedFile name="tag-AFfile1.tex" xmlns="">
+      \begin {equation}\begin {array}{ccccccc} \ldelim ({4}{4mm} &amp; x &amp; x &amp; x &amp; x &amp; \rdelim ){4}{4mm} \\ &amp; x &amp; x &amp; x &amp; x &amp; &amp; i \\ &amp; x &amp; x &amp; x &amp; x &amp; &amp; j \\ &amp; x &amp; x &amp; x &amp; x &amp; \\ &amp; &amp; u &amp; v &amp; &amp; \end {array}\end {equation}
+      </AssociatedFile>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>⎛⎜⎜⎜⎝
+     <?MarkedContent page="1" ?>𝑥𝑥𝑥𝑥
+     <?MarkedContent page="1" ?>⎞⎟⎟⎟⎠
+     <?MarkedContent page="1" ?>𝑥𝑥𝑥𝑥𝑖𝑥𝑥𝑥𝑥𝑗𝑥𝑥𝑥𝑥𝑢𝑣
+     <Lbl xmlns="http://iso.org/pdf2/ssn"
+        id="ID.007"
+       >
+      <?MarkedContent page="1" ?>(1)
+     </Lbl>
+    </Formula>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.008"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.009"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+    </text>
+    <Table xmlns="http://iso.org/pdf2/ssn"
+       id="ID.010"
+      >
+     <TR xmlns="http://iso.org/pdf2/ssn"
+        id="ID.011"
+       >
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.012"
+        >
+       <Formula xmlns="http://iso.org/pdf2/ssn"
+          id="ID.013"
+          title="math"
+          af="mathml-2.xml tag-AFfile2.tex"
+          xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+          Layout:Placement="Inline"
+         >
+         <AssociatedFile name="mathml-2.xml" xmlns="">
+         <math xmlns="http://www.w3.org/1998/Math/MathML"> <mspace width="1.196pt"/> <mi> <mglyph/> </mi> <mtext> type </mtext> <mo fence="true" lspace="0" rspace="0" symmetric="true">{</mo> </math>
+         </AssociatedFile>
+         <AssociatedFile name="tag-AFfile2.tex" xmlns="">
+         $\relax \left .\vcenter {\hsize =0pt\vrule height \multirow@dima width 0pt}\textnormal {type}\right \{$
+         </AssociatedFile>
+        <?MarkedContent page="1" ?>type⎧{⎨{⎩
+       </Formula>
+       <Div xmlns="http://iso.org/pdf2/ssn"
+          id="ID.014"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.015"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="1" ?>
+         <?MarkedContent page="1" ?>
+        </text>
+       </Div>
+      </TD>
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.016"
+        >
+       <?MarkedContent page="1" ?>dvi
+      </TD>
+     </TR>
+     <TR xmlns="http://iso.org/pdf2/ssn"
+        id="ID.017"
+       >
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.018"
+        >
+      </TD>
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.019"
+        >
+       <?MarkedContent page="1" ?>ps
+      </TD>
+     </TR>
+     <TR xmlns="http://iso.org/pdf2/ssn"
+        id="ID.020"
+       >
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.021"
+        >
+      </TD>
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.022"
+        >
+       <?MarkedContent page="1" ?>pdf
+      </TD>
+     </TR>
+    </Table>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.023"
+       rolemaps-to="P"
+      >
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.024"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.025"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+    </text>
+    <Table xmlns="http://iso.org/pdf2/ssn"
+       id="ID.026"
+      >
+     <TR xmlns="http://iso.org/pdf2/ssn"
+        id="ID.027"
+       >
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.028"
+        >
+      </TD>
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.029"
+        >
+       <?MarkedContent page="1" ?>1
+      </TD>
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.030"
+        >
+       <?MarkedContent page="1" ?>2
+      </TD>
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.031"
+        >
+       <?MarkedContent page="1" ?>3
+      </TD>
+     </TR>
+     <TR xmlns="http://iso.org/pdf2/ssn"
+        id="ID.032"
+       >
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.033"
+        >
+      </TD>
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.034"
+        >
+       <?MarkedContent page="1" ?>4
+      </TD>
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.035"
+        >
+       <?MarkedContent page="1" ?>5
+      </TD>
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.036"
+        >
+       <?MarkedContent page="1" ?>6
+      </TD>
+     </TR>
+     <TR xmlns="http://iso.org/pdf2/ssn"
+        id="ID.037"
+       >
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.038"
+        >
+       <Formula xmlns="http://iso.org/pdf2/ssn"
+          id="ID.039"
+          title="math"
+          af="mathml-3.xml tag-AFfile3.tex"
+          xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+          Layout:Placement="Inline"
+         >
+         <AssociatedFile name="mathml-3.xml" xmlns="">
+         <math xmlns="http://www.w3.org/1998/Math/MathML"> <mspace width="1.196pt"/> <mi> <mglyph/> </mi> <mtext/> <mo fence="true" lspace="0" rspace="0" symmetric="true">{</mo> </math>
+         </AssociatedFile>
+         <AssociatedFile name="tag-AFfile3.tex" xmlns="">
+         $\relax \left .\vcenter {\hsize =0pt\vrule height \multirow@dima width 0pt}\textnormal {\null }\right \{$
+         </AssociatedFile>
+        <?MarkedContent page="1" ?>⎧{⎨{⎩
+       </Formula>
+      </TD>
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.040"
+        >
+       <?MarkedContent page="1" ?>7
+      </TD>
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.041"
+        >
+       <?MarkedContent page="1" ?>8
+      </TD>
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.042"
+        >
+       <?MarkedContent page="1" ?>9
+      </TD>
+     </TR>
+    </Table>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.043"
+       rolemaps-to="P"
+      >
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-incompatible-mathml/bigdelim/bigdelim-01-BAD.tex
+++ b/tagging-status/testfiles-incompatible-mathml/bigdelim/bigdelim-01-BAD.tex
@@ -1,0 +1,46 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on,
+%    tagging-setup={math/setup=mathml-SE},
+  }
+\documentclass{article}
+
+\ifdefined\Uchar
+  \usepackage{unicode-math}
+\fi
+\usepackage{bigdelim}
+\usepackage{xcolor}
+\usepackage{colortbl}
+
+\title{bigdelim tagging test}
+
+\begin{document}
+
+\begin{equation}
+\begin{array}{ccccccc}
+\ldelim({4}{4mm} & x & x & x & x & \rdelim){4}{4mm} \\
+& x & x & x & x & & i \\
+& x & x & x & x & & j \\
+& x & x & x & x & \\
+& & u & v & &
+\end{array}
+\end{equation}
+
+\begin{tabular}{p{2em}l}
+\ldelim\{{3}{*}[type] & dvi \\
+& ps \\
+& pdf \\
+\end{tabular}
+
+\newcolumntype{z}{@{}>{\columncolor{white}[0pt][\tabcolsep]}}
+\rowcolors{2}{green!25}{green!75}
+\begin{tabular}{ c zc c c }
+& 1 & 2 & 3 \\
+& 4 & 5 & 6 \\
+\ldelim\{{-3}{*} & 7 & 8 & 9 \\
+\end{tabular}
+
+\end{document}

--- a/tagging-status/testfiles-incompatible/fvextra/fvextra-01-BAD.pdftex.struct.xml
+++ b/tagging-status/testfiles-incompatible/fvextra/fvextra-01-BAD.pdftex.struct.xml
@@ -1,0 +1,18 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.02"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.05"
+      rolemaps-to="Part"
+     >
+    <verbatim xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.06"
+       rolemaps-to="Code"
+      >
+    </verbatim>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-incompatible/fvextra/fvextra-01-BAD.struct.xml
+++ b/tagging-status/testfiles-incompatible/fvextra/fvextra-01-BAD.struct.xml
@@ -1,0 +1,18 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.02"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.05"
+      rolemaps-to="Part"
+     >
+    <verbatim xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.06"
+       rolemaps-to="Code"
+      >
+    </verbatim>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-incompatible/fvextra/fvextra-01-BAD.tex
+++ b/tagging-status/testfiles-incompatible/fvextra/fvextra-01-BAD.tex
@@ -1,0 +1,19 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on,
+  }
+\documentclass{article}
+\usepackage{fvextra}
+
+\title{fvextra tagging test}
+
+\begin{document}
+\begin{Verbatim}
+First verbatim line.
+Second verbatim line.
+Third verbatim line.
+\end{Verbatim}
+\end{document}

--- a/tagging-status/testfiles-partial/colortbl/colortbl-01-BAD.pdftex.struct.xml
+++ b/tagging-status/testfiles-partial/colortbl/colortbl-01-BAD.pdftex.struct.xml
@@ -1,0 +1,107 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.005"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.006"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+    </text>
+    <Table xmlns="http://iso.org/pdf2/ssn"
+       id="ID.007"
+      >
+     <TR xmlns="http://iso.org/pdf2/ssn"
+        id="ID.008"
+       >
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.009"
+        >
+       <?MarkedContent page="1" ?>a
+      </TD>
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.010"
+        >
+       <?MarkedContent page="1" ?>b
+      </TD>
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.011"
+        >
+       <?MarkedContent page="1" ?>c
+      </TD>
+     </TR>
+     <TR xmlns="http://iso.org/pdf2/ssn"
+        id="ID.012"
+       >
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.013"
+        >
+       <?MarkedContent page="1" ?>
+       <Table xmlns="http://iso.org/pdf2/ssn"
+          id="ID.014"
+         >
+        <TR xmlns="http://iso.org/pdf2/ssn"
+           id="ID.015"
+          >
+         <TD xmlns="http://iso.org/pdf2/ssn"
+            id="ID.016"
+           >
+          <?MarkedContent page="1" ?>a
+         </TD>
+         <TD xmlns="http://iso.org/pdf2/ssn"
+            id="ID.017"
+           >
+          <?MarkedContent page="1" ?>b
+         </TD>
+        </TR>
+        <?MarkedContent page="1" ?>
+       </Table>
+       <TD xmlns="http://iso.org/pdf2/ssn"
+          id="ID.018"
+         >
+        <?MarkedContent page="1" ?>
+       </TD>
+       <TD xmlns="http://iso.org/pdf2/ssn"
+          id="ID.019"
+         >
+        <?MarkedContent page="1" ?>
+       </TD>
+      </TD>
+      <TR xmlns="http://iso.org/pdf2/ssn"
+         id="ID.020"
+        >
+       <TD xmlns="http://iso.org/pdf2/ssn"
+          id="ID.021"
+         >
+        <?MarkedContent page="1" ?>a
+       </TD>
+       <TD xmlns="http://iso.org/pdf2/ssn"
+          id="ID.022"
+         >
+        <?MarkedContent page="1" ?>b
+       </TD>
+       <TD xmlns="http://iso.org/pdf2/ssn"
+          id="ID.023"
+         >
+        <?MarkedContent page="1" ?>
+       </TD>
+      </TR>
+     </TR>
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.024"
+        rolemaps-to="P"
+       >
+      <?MarkedContent page="1" ?>
+     </text>
+    </Table>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-partial/colortbl/colortbl-01-BAD.struct.xml
+++ b/tagging-status/testfiles-partial/colortbl/colortbl-01-BAD.struct.xml
@@ -1,0 +1,100 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.005"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.006"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+    </text>
+    <Table xmlns="http://iso.org/pdf2/ssn"
+       id="ID.007"
+      >
+     <TR xmlns="http://iso.org/pdf2/ssn"
+        id="ID.008"
+       >
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.009"
+        >
+       <?MarkedContent page="1" ?>a
+      </TD>
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.010"
+        >
+       <?MarkedContent page="1" ?>b
+      </TD>
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.011"
+        >
+       <?MarkedContent page="1" ?>c
+      </TD>
+     </TR>
+     <TR xmlns="http://iso.org/pdf2/ssn"
+        id="ID.012"
+       >
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.013"
+        >
+       <Table xmlns="http://iso.org/pdf2/ssn"
+          id="ID.014"
+         >
+        <TR xmlns="http://iso.org/pdf2/ssn"
+           id="ID.015"
+          >
+         <TD xmlns="http://iso.org/pdf2/ssn"
+            id="ID.016"
+           >
+          <?MarkedContent page="1" ?>a
+         </TD>
+         <TD xmlns="http://iso.org/pdf2/ssn"
+            id="ID.017"
+           >
+          <?MarkedContent page="1" ?>b
+         </TD>
+        </TR>
+       </Table>
+       <TD xmlns="http://iso.org/pdf2/ssn"
+          id="ID.018"
+         >
+       </TD>
+       <TD xmlns="http://iso.org/pdf2/ssn"
+          id="ID.019"
+         >
+       </TD>
+      </TD>
+      <TR xmlns="http://iso.org/pdf2/ssn"
+         id="ID.020"
+        >
+       <TD xmlns="http://iso.org/pdf2/ssn"
+          id="ID.021"
+         >
+        <?MarkedContent page="1" ?>a
+       </TD>
+       <TD xmlns="http://iso.org/pdf2/ssn"
+          id="ID.022"
+         >
+        <?MarkedContent page="1" ?>b
+       </TD>
+       <TD xmlns="http://iso.org/pdf2/ssn"
+          id="ID.023"
+         >
+       </TD>
+      </TR>
+     </TR>
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.024"
+        rolemaps-to="P"
+       >
+     </text>
+    </Table>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-partial/colortbl/colortbl-01-BAD.tex
+++ b/tagging-status/testfiles-partial/colortbl/colortbl-01-BAD.tex
@@ -1,0 +1,19 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on,
+  }
+\documentclass{article}
+\usepackage{colortbl}
+
+\title{colortbl tagging test}
+
+\begin{document}
+\begin{tabular}{lll}
+a& b&c\\
+\begin{tabular}{cc}a&b\end{tabular}\\
+a& b & 
+\end{tabular}
+\end{document}

--- a/tagging-status/testfiles-unchecked-luatex/arabluatex/arabluatex-01.struct.xml
+++ b/tagging-status/testfiles-unchecked-luatex/arabluatex/arabluatex-01.struct.xml
@@ -1,0 +1,37 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.02"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.05"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.06"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Arabic, like Hebrew and Syriac, is written and read from right to left. The letters of the alphabet (ﺡُﺭُوفُ الهِجَﺁءِ, ﺡُﺭُوفُ الﺕَّهَجِّي, اَلﺡُﺭُوفُ الهِجَﺁﺉِيَّﺓُ, or ﺡُﺭُوفُ الﻡُﻉجَمِ) are twenty-eight in number and are all consonants, though three of them are also used as vowels (see § 3).
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.07"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.08"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>أَﺕَى ﺹَﺩِيقٌ إِلَى جُﺡَا يَطلُﺏُ ﻡِنهُ ﺡِﻡَارَهُ لِيَﺭﻙَﺏَهُ ﻑِي ﺱَﻑﺭَةٍ قَﺹِيﺭَةٍ ﻑَقَالَ لَهُ: ﺱَوفَ أُﻉِيﺩُهُ إِلَيكَ ﻑِي الﻡَﺱَﺁءِ وَأَدﻑَعُ 
+     <?MarkedContent page="1" ?>لَكَ أُجﺭَةً. ﻑَقَالَ جُﺡَا: أَنَا آﺱِﻑٌ جِﺩًّا أَنِّي لَﺍ أَﺱﺕَطِيعُ أَن أُﺡَقِّقَ لَكَ رَغﺏَﺕَكَ ﻑَالﺡِﻡَارُ لَيﺱَ هُنَا اليَومَ. وَقَﺏلَ أَن يُﺕِمَّ 
+     <?MarkedContent page="1" ?>جُﺡَا ﻙَلَﺍﻡَهُ ﺏَﺩَأَ الﺡِﻡَارُ يَنهَقُ ﻑِي إِﺹطَﺏلِهِ. ﻑَقَالَ لَهُ ﺹَﺩِيقُهُ: إِنِّي أَﺱﻡَعُ ﺡِﻡَارَكَ يَا جُﺡَا يَنهَقُ. ﻑَقَالَ لَهُ جُﺡَا: غَﺭِيﺏٌ أَﻡﺭُكَ 
+     <?MarkedContent page="1" ?>يَا ﺹَﺩِيقِي أَﺕُﺹَﺩِّقُ الﺡِﻡَارَ وَﺕُﻙَﺫِّﺏَنِي؟
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-unchecked-luatex/arabluatex/arabluatex-01.tex
+++ b/tagging-status/testfiles-unchecked-luatex/arabluatex/arabluatex-01.tex
@@ -1,0 +1,40 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on
+  }
+\documentclass{article}
+
+\usepackage{arabluatex}
+\newfontfamily\arabicfont{Amiri}[Script=Arabic]
+
+\title{arabluatex tagging test}
+
+\begin{document}
+
+Arabic, like Hebrew and
+Syriac, is written and read from right to left. The letters
+of the alphabet (\arb{.hurUf-u 'l-hijA'-i}, \arb{.hurUf-u
+  'l-tahajjI}, \arb{al-.hurUf-u 'l-hijA'iyyaT-u}, or
+\arb{.hurUf-u 'l-mu`jam-i}) are twenty-eight in number and
+are all consonants, though three of them are also used as
+vowels (see §~3).
+
+\begin{arab}
+'at_A .sadIquN 'il_A ju.hA ya.tlubu min-hu .himAra-hu
+li-yarkaba-hu fI safraTiN qa.sIraTiN fa-qAla la-hu:
+sawfa 'u`Idu-hu 'ilay-ka fI 'l-masA'-i
+wa-'adfa`u la-ka 'ujraTaN. fa-qAla ju.hA:
+'anA 'AsifuN jiddaN 'annI lA 'asta.tI`u 'an
+'u.haqqiqa la-ka ra.gbata-ka fa-'l-.himAr-u laysa hunA
+'l-yawm-a.  wa-qabla 'an yutimma ju.hA kalAma-hu bada'a
+'l-.himAr-u yanhaqu fI 'i.s.tabli-hi. fa-qAla la-hu
+.sadIqu-hu: 'innI 'asma`u .himAra-ka yA ju.hA
+yanhaqu. fa-qAla la-hu ju.hA: .garIbuN
+'amru-ka yA .sadIqI 'a-tu.saddiqu 'l-.himAr-a
+wa-tuka_d_diba-nI?
+\end{arab}
+
+\end{document}


### PR DESCRIPTION
Adds a test for arabluatex but does not change the status, see #1085.

Adds "-BAD" tests for bigdelim, colortbl, and fvextra.

Lists luamesh as incompatible since there is no way to add Alt text to the figures. Also adds a test.

Links a few issues.