### PR TITLE
add status for html packages

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -7008,13 +7008,13 @@
 
 - name: lwarp
   type: package
-  status: unchecked
+  status: currently-incompatible
   included-in: [tlc3]
   priority: 2
   issues: [1084]
-  tests: false
-  tasks: needs tests
-  updated: 2024-07-15
+  tests: true
+  comments: "Package errors if `\\DocumentMetadata` detected."
+  updated: 2025-11-24
 
 - name: lxfonts
   type: package
@@ -10885,23 +10885,23 @@
 
 - name: tex4ebook
   type: package
-  status: unchecked
+  status: currently-incompatible
   included-in:
   priority: 9
   issues: [1084]
   tests: false
-  tasks: needs tests
-  updated: 2024-07-18
+  comments: See tex4ht.
+  updated: 2025-11-24
 
 - name: tex4ht
   type: package
-  status: unchecked
+  status: currently-incompatible
   included-in: [tlc3]
   priority: 2
   issues: [1084]
   tests: false
-  tasks: needs tests
-  updated: 2024-07-15
+  comments: "Simple files with `\\DocumentMetadata` error when run with `tex4ht`."
+  updated: 2025-11-24
 
 - name: texosquery
   type: package

--- a/tagging-status/testfiles-incompatible/lwarp/lwarp-01-BAD.pdftex.struct.xml
+++ b/tagging-status/testfiles-incompatible/lwarp/lwarp-01-BAD.pdftex.struct.xml
@@ -1,0 +1,1 @@
+<run-error code="1" />

--- a/tagging-status/testfiles-incompatible/lwarp/lwarp-01-BAD.struct.xml
+++ b/tagging-status/testfiles-incompatible/lwarp/lwarp-01-BAD.struct.xml
@@ -1,0 +1,1 @@
+<run-error code="1" />

--- a/tagging-status/testfiles-incompatible/lwarp/lwarp-01-BAD.tex
+++ b/tagging-status/testfiles-incompatible/lwarp/lwarp-01-BAD.tex
@@ -1,0 +1,15 @@
+\DocumentMetadata
+  {
+    tagging=on,
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+  }
+\documentclass{article}
+\usepackage{lwarp}
+\title{lwarp tagging test}
+\begin{document}
+\maketitle
+\section{blub}
+abc
+\end{document}


### PR DESCRIPTION
See #1084. I did not add tests for tex4ht or tex4ebook because they are not packages in the usual sense (well tex4ebook is, but it is not required to run `tex4ebook` on a file).