### PR TITLE
update package statuses

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -2234,6 +2234,15 @@
   tests: false
   updated: 2024-08-26
 
+- name: bnumexpr
+  type: package
+  status: compatible
+  included-in:
+  priority: 9
+  issues:
+  tests: false
+  updated: 2025-12-16
+
 - name: boldline
   type: package
   status: currently-incompatible
@@ -3036,6 +3045,16 @@
   issues:
   tests: true
   updated: 2025-05-29
+
+- name: colophon
+  type: package
+  status: partially-compatible
+  included-in:
+  priority: 9
+  comments: "Colophon title is not tagged."
+  issues:
+  tests: true
+  updated: 2025-12-16
 
 - name: color
   type: package
@@ -5861,6 +5880,15 @@
   issues:
   tests: false
   updated: 2024-07-21
+
+- name: icomma
+  type: package
+  status: compatible
+  included-in:
+  priority: 9
+  issues:
+  tests: true
+  updated: 2025-12-16
 
 - name: ifetex
   type: package
@@ -9088,6 +9116,16 @@
   tests: true
   updated: 2024-08-16
 
+- name: pgfparser
+  ctan-pkg: pgf
+  type: package
+  status: compatible
+  included-in:
+  priority: 9
+  issues:
+  tests: false
+  updated: 2025-12-16
+
 - name: pgfplots
   type: package
   status: currently-incompatible
@@ -9285,6 +9323,16 @@
   issues:
   tests: true
   updated: 2024-08-21
+
+- name: polexpr
+  type: package
+  status: currently-incompatible
+  included-in:
+  priority: 9
+  comments:
+  issues: [1142]
+  tests: true
+  updated: 2025-12-16
 
 - name: polyglossia
   type: package
@@ -12190,12 +12238,13 @@
 - name: xint
   type: package
   status: unchecked
+  subpackages: [xintbinhex,xintcfrac,xintcore,xintexpr,xintfrac,xintgcd,xintkernel,xintlog,xintseries,xinttools,xinttrig]
   included-in:
   priority: 9
   issues:
   tests: false
   tasks: needs tests
-  updated: 2024-07-18
+  updated: 2025-12-16
 
 - name: xistercian
   type: package
@@ -12450,6 +12499,15 @@
   updated: 2024-07-29
 
 #------------------------ ZZZ ----------------------------
+
+- name: zeckendorf
+  type: package
+  status: compatible
+  included-in:
+  priority: 9
+  issues:
+  tests: false
+  updated: 2025-12-16
 
 - name: zhnumber
   type: package

--- a/tagging-status/testfiles-compatible-mathml/icomma/icomma-01.pdftex.struct.xml
+++ b/tagging-status/testfiles-compatible-mathml/icomma/icomma-01.pdftex.struct.xml
@@ -1,0 +1,92 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.005"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.006"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>1,234
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.007"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.008"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>hello, and goodbye
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.009"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.010"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.011"
+        title="math"
+        af="mathml-1.xml tag-AFfile1.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-1.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑥</mi> <mi mathvariant="normal">,</mi> <mi>𝑦</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile1.tex" xmlns="">
+       $(x,y)$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>(x,y)
+     </Formula>
+     <?MarkedContent page="1" ?>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.012"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.013"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.014"
+        title="math"
+        af="mathml-2.xml tag-AFfile2.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-2.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑥</mi> <mo lspace="0" rspace="0.167em">,</mo> <mi>𝑦</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile2.tex" xmlns="">
+       $(x, y)$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>(x,y)
+     </Formula>
+     <?MarkedContent page="1" ?>
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-compatible-mathml/icomma/icomma-01.struct.xml
+++ b/tagging-status/testfiles-compatible-mathml/icomma/icomma-01.struct.xml
@@ -1,0 +1,88 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.005"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.006"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>1,234
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.007"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.008"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>hello, and goodbye
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.009"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.010"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.011"
+        title="math"
+        af="mathml-1.xml tag-AFfile1.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-1.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑥</mi> <mi mathvariant="normal">,</mi> <mi>𝑦</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile1.tex" xmlns="">
+       $(x,y)$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>(𝑥,𝑦)
+     </Formula>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.012"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.013"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.014"
+        title="math"
+        af="mathml-2.xml tag-AFfile2.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-2.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑥</mi> <mo lspace="0" rspace="0.167em">,</mo> <mi>𝑦</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile2.tex" xmlns="">
+       $(x, y)$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>(𝑥,𝑦)
+     </Formula>
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-compatible-mathml/icomma/icomma-01.tex
+++ b/tagging-status/testfiles-compatible-mathml/icomma/icomma-01.tex
@@ -1,0 +1,27 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on,
+  }
+\documentclass{article}
+
+\ifdefined\Uchar
+  \usepackage{unicode-math}
+\fi
+\usepackage{icomma}
+
+\title{icomma tagging test}
+
+\begin{document}
+
+1,234
+
+hello, and goodbye
+
+$(x,y)$
+
+$(x, y)$
+
+\end{document}

--- a/tagging-status/testfiles-incompatible-mathml/polexpr/polexpr-01-BAD.pdftex.struct.xml
+++ b/tagging-status/testfiles-incompatible-mathml/polexpr/polexpr-01-BAD.pdftex.struct.xml
@@ -1,0 +1,1 @@
+<run-error code="1" />

--- a/tagging-status/testfiles-incompatible-mathml/polexpr/polexpr-01-BAD.struct.xml
+++ b/tagging-status/testfiles-incompatible-mathml/polexpr/polexpr-01-BAD.struct.xml
@@ -1,0 +1,1 @@
+<run-error code="1" />

--- a/tagging-status/testfiles-incompatible-mathml/polexpr/polexpr-01-BAD.tex
+++ b/tagging-status/testfiles-incompatible-mathml/polexpr/polexpr-01-BAD.tex
@@ -1,0 +1,23 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on,
+  }
+\documentclass{article}
+
+\ifdefined\Uchar
+  \usepackage{unicode-math}
+\fi
+\usepackage{polexpr}
+
+\title{polexpr tagging test}
+
+\begin{document}
+
+\poldef f(x) := x^7 - x^6 - 2x + 1;
+
+\PolTypeset{f}
+
+\end{document}

--- a/tagging-status/testfiles-partial/colophon/colophon-01-BAD.pdftex.struct.xml
+++ b/tagging-status/testfiles-partial/colophon/colophon-01-BAD.pdftex.struct.xml
@@ -1,0 +1,60 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.005"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.006"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>As any dedicated reader can clearly see, the Ideal of practical reason is a rep-resentation of, as far as I know, the things in themselves; as I have shown else-where, the phenomena should only be used as a canon for our understanding.The paralogisms of practical reason are what first give rise to the architectonicof practical reason.
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.007"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.008"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Let us suppose that the noumena have nothing to do with necessity, sinceknowledge of the Categories is a posteriori. Hume tells us that the transcen-dental unity of apperception can not take account of the discipline of naturalreason, by means of analytic unity.
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.009"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.010"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="2" ?>As any dedicated reader can clearly see, the Ideal of practical reason is arepresentation of, as far as I know, the things in themselves; as I have shownelsewhere, the phenomena should only be used as a canon for our understanding.The paralogisms of practical reason are what first give rise to the architectonicof practical reason. As will easily be shown in the next section, reason wouldthereby be made to contradict, in view of these considerations, the Ideal of prac-tical reason, yet the manifold depends on the phenomena. Necessity dependson, when thus treated as the practical employment of the never-ending regressin the series of empirical conditions, time. Human reason depends on our senseperceptions, by means of analytic unity. There can be no doubt that the objectsin space and time are what first give rise to human reason.
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.011"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.012"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="2" ?>Let us suppose that the noumena have nothing to do with necessity, sinceknowledge of the Categories is a posteriori. Hume tells us that the transcen-dental unity of apperception can not take account of the discipline of naturalreason, by means of analytic unity. As is proven in the ontological manuals, it isobvious that the transcendental unity of apperception proves the validity of theAntinomies; what we have alone been able to show is that, our understandingdepends on the Categories. It remains a mystery why the Ideal stands in needof reason. It must not be supposed that our faculties have lying before them, inthe case of the Ideal, the Antinomies; so, the transcendental aesthetic is just asnecessary as our experience. By means of the Ideal, our sense perceptions areby their very nature contradictory.
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-partial/colophon/colophon-01-BAD.struct.xml
+++ b/tagging-status/testfiles-partial/colophon/colophon-01-BAD.struct.xml
@@ -1,0 +1,60 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.005"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.006"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>As any dedicated reader can clearly see, the Ideal of practical reason is a rep­resentation of, as far as I know, the things in themselves; as I have shown else­where, the phenomena should only be used as a canon for our understanding. The paralogisms of practical reason are what first give rise to the architectonic of practical reason.
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.007"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.008"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Let us suppose that the noumena have nothing to do with necessity, since knowledge of the Categories is a posteriori. Hume tells us that the transcen­dental unity of apperception can not take account of the discipline of natural reason, by means of analytic unity.
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.009"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.010"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="2" ?>As any dedicated reader can clearly see, the Ideal of practical reason is a representation of, as far as I know, the things in themselves; as I have shown elsewhere, the phenomena should only be used as a canon for our understanding. The paralogisms of practical reason are what first give rise to the architectonic of practical reason. As will easily be shown in the next section, reason would thereby be made to contradict, in view of these considerations, the Ideal of prac­tical reason, yet the manifold depends on the phenomena. Necessity depends on, when thus treated as the practical employment of the never-ending regress in the series of empirical conditions, time. Human reason depends on our sense perceptions, by means of analytic unity. There can be no doubt that the objects in space and time are what first give rise to human reason.
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.011"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.012"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="2" ?>Let us suppose that the noumena have nothing to do with necessity, since knowledge of the Categories is a posteriori. Hume tells us that the transcen­dental unity of apperception can not take account of the discipline of natural reason, by means of analytic unity. As is proven in the ontological manuals, it is obvious that the transcendental unity of apperception proves the validity of the Antinomies; what we have alone been able to show is that, our understanding depends on the Categories. It remains a mystery why the Ideal stands in need of reason. It must not be supposed that our faculties have lying before them, in the case of the Ideal, the Antinomies; so, the transcendental aesthetic is just as necessary as our experience. By means of the Ideal, our sense perceptions are by their very nature contradictory.
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-partial/colophon/colophon-01-BAD.tex
+++ b/tagging-status/testfiles-partial/colophon/colophon-01-BAD.tex
@@ -1,0 +1,24 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on,
+  }
+\documentclass{article}
+
+\usepackage[parsize=10pt]{colophon}
+\usepackage{kantlipsum}
+
+\title{colophon tagging test}
+\colophontitle{Some title}
+
+\begin{document}
+
+\begin{colophon}
+\kant[1][1-2]
+\kant[2][1-2]
+\end{colophon}
+\kant[1-2]
+
+\end{document}


### PR DESCRIPTION
Lists bnumexpr, pgfparser, and zeckendorf as compatible without tests.

Lists colophon as partially-compatible because the title is not tagged at all and adds a test.

Lists icomma as compatible with a test.

Lists polexpr as incompatible with a test.

Adds the xint subpackages to its entry.