### PR TITLE
status update for prooftrees (v0.9.2 with forest-ext v0.2)

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -9470,14 +9470,14 @@
 
 - name: prooftrees
   type: package
-  status: currently-incompatible
+  status: compatible
   included-in:
   priority: 9
   issues: [1117]
-  tests: false
+  tests: true
   tasks: needs tests
-  comments: "Relies on incompatible forest package."
-  updated: 2025-12-11
+  comments: "Depends on forest-ext. Note tableaux are syntactic not semantic."
+  updated: 2026-01-19
 
 - name: psfrag
   type: package

--- a/tagging-status/testfiles-compatible/prooftrees/prooftrees-01.luatex.struct.xml
+++ b/tagging-status/testfiles-compatible/prooftrees/prooftrees-01.luatex.struct.xml
@@ -1,0 +1,41 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.02"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.05"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.06"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <Figure xmlns="http://iso.org/pdf2/ssn"
+        id="ID.07"
+        alt="To prove: $\vdash p\vee \lnot p$ 1 $\lnot (p\vee \lnot p)$ $\lnot $ conc  2 $\lnot p$ 1 $\vee $E  3 $\lnot \lnot p$ 1 $\vee $E  closed 2, 3    "
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:BBox="{ 133.76837, 667.19801, 261.63507, 744.77107 }"
+       >
+      <?MarkedContent page="1" ?>
+      <?MarkedContent page="1" ?>
+      <?MarkedContent page="1" ?>
+      <?MarkedContent page="1" ?>
+      <?MarkedContent page="1" ?>
+      <?MarkedContent page="1" ?>
+      <?MarkedContent page="1" ?>
+      <?MarkedContent page="1" ?>
+      <?MarkedContent page="1" ?>
+      <?MarkedContent page="1" ?>
+      <?MarkedContent page="1" ?>
+      <?MarkedContent page="1" ?>
+      <?MarkedContent page="1" ?>
+     </Figure>
+     <?MarkedContent page="1" ?>
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-compatible/prooftrees/prooftrees-01.pdftex.struct.xml
+++ b/tagging-status/testfiles-compatible/prooftrees/prooftrees-01.pdftex.struct.xml
@@ -1,0 +1,30 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.02"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.05"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.06"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+     <Figure xmlns="http://iso.org/pdf2/ssn"
+        id="ID.07"
+        alt="To prove: $\vdash p\vee \lnot p$ 1 $\lnot (p\vee \lnot p)$ $\lnot $ conc  2 $\lnot p$ 1 $\vee $E  3 $\lnot \lnot p$ 1 $\vee $E  closed 2, 3    "
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:BBox="{ 133.76837, 667.19801, 261.30963, 744.87625 }"
+       >
+      <?MarkedContent page="1" ?>⊢p∨¬p1.2.3.¬(p∨¬p)¬p¬¬p⊗2,3¬ conc1∨E1∨E
+     </Figure>
+     <?MarkedContent page="1" ?>
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-compatible/prooftrees/prooftrees-01.tex
+++ b/tagging-status/testfiles-compatible/prooftrees/prooftrees-01.tex
@@ -1,0 +1,31 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% derived from \ProvidesFileSVN{$Id: prooftrees-tag-t1.lvt 11509 2026-01-18 01:43:16Z cfrees $}[\revinfo][\filebase: tag support test]
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\DocumentMetadata{
+ tagging=on,
+ lang=en-GB,
+ pdfversion=2.0,
+ pdfstandard=ua-2,
+ uncompress,
+}
+\documentclass{article}
+\usepackage[tableaux]{prooftrees}
+\usepackage{amsmath}
+\ifdefined\directlua
+  \usepackage{lua-unicode-math}
+\else
+  \usepackage[T1]{fontenc}
+\fi
+\title{prooftrees 01}
+\begin{document}
+\begin{tableau}{%
+    to prove=\vdash p\vee\lnot p,
+  }
+  [\lnot(p\vee\lnot p),just=$\lnot$ conc
+    [\lnot p,just=$\vee$E:!u,
+      [\lnot\lnot p,just=$\vee$E:!uu,close={:!u,!c},]
+    ]
+  ]
+\end{tableau}%
+\end{document}
+


### PR DESCRIPTION
Current version auto-generates alt text for tableaux if tagging is active.