### PR TITLE
add comments about obsolescence

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -7808,7 +7808,7 @@
   issues:
   tests: false
   tasks: needs tests
-  comments: "Superseded by `\NewCommandCopy` etc. provided by the kernel."
+  comments: "Superseded by `\\NewCommandCopy` etc. provided by the kernel."
   updated: 2026-01-27
 
 - name: letterspace


### PR DESCRIPTION
Adds comments about obsolete packages to tagging-status. Also links the CTAN name for several and removes a few duplicates. And I removed the `beamerthemesplit` entry since I don't think it's useful to list beamer themes when beamer will not be compatible.