### PR TITLE
status updates

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -4106,12 +4106,12 @@
 
 - name: cypriot
   type: package
-  status: unchecked
+  status: partially-compatible
   included-in:
   priority: 9
   issues:
   tests: false
-  comments:
+  comments: "Text not correctly mapped to Unicode."
   updated: 2026-02-01
 
 #------------------------ DDD ----------------------------
@@ -4417,7 +4417,7 @@
   priority: 9
   issues:
   tests: false
-  comments:
+  tasks: needs tests
   updated: 2026-02-01
 
 - name: docmute
@@ -4698,12 +4698,11 @@
 
 - name: egothic
   type: package
-  status: unchecked
+  status: compatible
   included-in:
   priority: 9
   issues:
   tests: false
-  comments:
   updated: 2026-02-01
 
 - name: ekdosis
@@ -5170,12 +5169,12 @@
 
 - name: etruscan
   type: package
-  status: unchecked
+  status: partially-compatible
   included-in:
   priority: 9
   issues:
   tests: false
-  comments:
+  comments: "Text not correctly mapped to Unicode."
   updated: 2026-02-01
 
 - name: eucal
@@ -6726,22 +6725,22 @@
 
 - name: greek4cbc
   type: package
-  status: unchecked
+  status: partialy-compatible
   included-in:
   priority: 9
   issues:
   tests: false
-  comments:
+  comments: "Text not correctly mapped to Unicode."
   updated: 2026-02-01
 
 - name: greek6cbc
   type: package
-  status: unchecked
+  status: partially-compatible
   included-in:
   priority: 9
   issues:
   tests: false
-  comments:
+  comments: "Text not correctly mapped to Unicode."
   updated: 2026-02-01
 
 - name: grfext
@@ -6924,12 +6923,12 @@
 
 - name: hieroglf
   type: package
-  status: unchecked
+  status: partially-compatible
   included-in:
   priority: 9
   issues:
   tests: false
-  comments:
+  comments: "Text not correctly mapped to Unicode."
   updated: 2026-02-01
 
 - name: hologo
@@ -6945,22 +6944,20 @@
 
 - name: humanist
   type: package
-  status: unchecked
+  status: compatible
   included-in:
   priority: 9
   issues:
   tests: false
-  comments:
   updated: 2026-02-01
 
 - name: huncial
   type: package
-  status: unchecked
+  status: compatible
   included-in:
   priority: 9
   issues:
   tests: false
-  comments:
   updated: 2026-02-01
 
 - name: hvfloat
@@ -7456,22 +7453,20 @@
 
 - name: inslrmaj
   type: package
-  status: unchecked
+  status: compatible
   included-in:
   priority: 9
   issues:
   tests: false
-  tasks: needs tests
   updated: 2026-02-01
 
 - name: inslrmin
   type: package
-  status: unchecked
+  status: compatible
   included-in:
   priority: 9
   issues:
   tests: false
-  tasks: needs tests
   updated: 2026-02-01
 
 - name: intcalc
@@ -8228,12 +8223,12 @@
 
 - name: linearb
   type: package
-  status: unchecked
+  status: partially-compatible
   included-in:
   priority: 9
   issues:
   tests: false
-  tasks: needs tests
+  comments: "Text not correctly mapped to Unicode."
   updated: 2026-02-01
 
 - name: linebreaker
@@ -8838,12 +8833,11 @@
 
 - name: makecmds
   type: package
-  status: unchecked
+  status: compatible
   included-in:
   priority: 9
   issues:
   tests: false
-  tasks: needs tests
   updated: 2026-02-01
 
 - name: makeidx
@@ -9789,12 +9783,12 @@
 
 - name: nabatean
   type: package
-  status: unchecked
+  status: partially-compatible
   included-in:
   priority: 9
   issues:
   tests: false
-  comments:
+  comments: "Text not correctly mapped to Unicode."
   updated: 2026-02-01
 
 - name: nag
@@ -10460,12 +10454,12 @@
 
 - name: oands
   type: package
-  status: unchecked
+  status: partially-compatible
   included-in:
   priority: 9
   issues:
   tests: false
-  comments:
+  comments: "Text not correctly mapped to Unicode."
   updated: 2026-02-01
 
 - name: ocg
@@ -10545,22 +10539,21 @@
 - name: oldgerm
   ctan-pkg: mfnfss
   type: package
-  status: unchecked
+  status: compatible
   included-in: [ol0.02]
   priority: 9
   issues:
   tests: false
-  tasks: needs tests
-  updated: 2026-01-23
+  updated: 2026-02-01
 
 - name: oldprsn
   type: package
-  status: unchecked
+  status: partially-compatible
   included-in:
   priority: 9
   issues:
   tests: false
-  comments:
+  comments: "Text not correctly mapped to Unicode."
   updated: 2026-02-01
 
 - name: onepagem
@@ -10783,12 +10776,11 @@
 
 - name: pacioli
   type: package
-  status: unchecked
+  status: compatible
   included-in:
   priority: 9
   issues:
   tests: false
-  comments:
   updated: 2026-02-01
 
 - name: pagecolor
@@ -11403,22 +11395,21 @@
 
 - name: pgothic
   type: package
-  status: unchecked
+  status: compatible
   included-in:
   priority: 9
   issues:
   tests: false
-  comments:
   updated: 2026-02-01
 
 - name: phoenician
   type: package
-  status: unchecked
+  status: partially-compatible
   included-in:
   priority: 9
   issues:
   tests: false
-  comments:
+  comments: "Text not correctly mapped to Unicode."
   updated: 2026-02-01
 
 - name: phonenumbers
@@ -11768,12 +11759,12 @@
 
 - name: protosem
   type: package
-  status: unchecked
+  status: partially-compatible
   included-in:
   priority: 9
   issues:
   tests: false
-  comments:
+  comments: "Text not correctly mapped to Unicode."
   updated: 2026-02-01
 
 - name: pseudocode
@@ -12606,12 +12597,11 @@
 
 - name: rotunda
   type: package
-  status: unchecked
+  status: compatible
   included-in:
   priority: 9
   issues:
   tests: false
-  comments:
   updated: 2026-02-01
 
 - name: rpgicons
@@ -12635,22 +12625,21 @@
 
 - name: runic
   type: package
-  status: unchecked
+  status: partially-compatible
   included-in:
   priority: 9
   issues:
   tests: false
-  comments:
+  comments: "Text not correctly mapped to Unicode."
   updated: 2026-02-01
 
 - name: rustic
   type: package
-  status: unchecked
+  status: compatible
   included-in:
   priority: 9
   issues:
   tests: false
-  comments:
   updated: 2026-02-01
 
 #------------------------ SSS ----------------------------
@@ -12718,12 +12707,12 @@
 
 - name: sarabian
   type: package
-  status: unchecked
+  status: partially-compatible
   included-in:
   priority: 9
   issues:
   tests: false
-  comments:
+  comments: "Text not correctly mapped to Unicode."
   updated: 2026-02-01
 
 - name: savesym
@@ -13516,12 +13505,11 @@
 
 - name: sqrcaps
   type: package
-  status: unchecked
+  status: compatible
   included-in:
   priority: 9
   issues:
   tests: false
-  comments:
   updated: 2026-02-01
 
 - name: stabular
@@ -14296,12 +14284,11 @@
 
 - name: tgothic
   type: package
-  status: unchecked
+  status: compatible
   included-in:
   priority: 9
   issues:
   tests: false
-  comments:
   updated: 2026-02-01
 
 - name: tgpagella
@@ -15175,12 +15162,12 @@
 
 - name: ugarite
   type: package
-  status: unchecked
+  status: partially-compatible
   included-in:
   priority: 9
   issues:
   tests: false
-  comments:
+  comments: "Text not correctly mapped to Unicode."
   updated: 2026-02-01
 
 - name: ulem
@@ -15195,12 +15182,11 @@
 
 - name: uncial
   type: package
-  status: unchecked
+  status: compatible
   included-in:
   priority: 9
   issues:
   tests: false
-  comments:
   updated: 2026-02-01
 
 - name: underoverlap


### PR DESCRIPTION
Adds several packages to tagging-status, most with a status but some unchecked. Also shortens a few long lines and lists the old presentation packages powerdot, prosper, and seminar as no-support since they require latex+dvips+ps2pdf.