### PR TITLE
add memoize-ext

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -8548,8 +8548,8 @@
   package-repository: "https://codeberg.org/cfr/prooftrees"
   tests: true
   comments: "Adds sockets to the utilisation of externs created by Memoize.
-    actualtext/alt/artifact supported for TikZ pictures."
-  updated: 2026-02-26
+             actualtext/alt/artifact supported for TikZ pictures."
+  updated: 2026-03-20
 
 
 - name: mercatormap

--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -8539,6 +8539,19 @@
   tasks: needs tests
   updated: 2024-07-18
 
+- name: memoize-ext
+  type: package
+  status: compatible
+  included-in:
+  priority: 9
+  issues: 
+  package-repository: "https://codeberg.org/cfr/prooftrees"
+  tests: true
+  comments: "Adds sockets to the utilisation of externs created by Memoize.
+    actualtext/alt/artifact supported for TikZ pictures."
+  updated: 2026-02-26
+
+
 - name: mercatormap
   type: package
   status: unchecked

--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -8551,7 +8551,6 @@
              actualtext/alt/artifact supported for TikZ pictures."
   updated: 2026-03-20
 
-
 - name: mercatormap
   type: package
   status: unchecked

--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -8542,9 +8542,7 @@
 - name: memoize-ext
   type: package
   status: compatible
-  included-in:
   priority: 9
-  issues: 
   package-repository: "https://codeberg.org/cfr/prooftrees"
   tests: true
   comments: "Adds sockets to the utilisation of externs created by Memoize.

--- a/tagging-status/testfiles-compatible/epic/epic-01.struct.xml
+++ b/tagging-status/testfiles-compatible/epic/epic-01.struct.xml
@@ -15,7 +15,7 @@
       >
      <Figure xmlns="http://iso.org/pdf2/ssn"
         id="ID.08"
-        alt="A matrix of dots"
+        alt="picture environment"
         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
         Layout:BBox="{ 148.71233, 567.98593, 588.0801, 667.19801 }"
        >

--- a/tagging-status/testfiles-compatible/memoize-ext/memoize-ext-01.luatex.struct.xml
+++ b/tagging-status/testfiles-compatible/memoize-ext/memoize-ext-01.luatex.struct.xml
@@ -1,0 +1,34 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.02"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.05"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.06"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <Figure xmlns="http://iso.org/pdf2/ssn"
+        id="ID.07"
+        alt="Square"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:BBox="{ 148.71233, 468.3744, 177.45728, 497.11934 }"
+       >
+      <?MarkedContent page="1" ?>
+     </Figure>
+     <Span xmlns="http://iso.org/pdf2/ssn"
+        id="ID.08"
+        actualtext="oircle"
+       >
+      <?MarkedContent page="1" ?>
+     </Span>
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-compatible/memoize-ext/memoize-ext-01.luatex.struct.xml
+++ b/tagging-status/testfiles-compatible/memoize-ext/memoize-ext-01.luatex.struct.xml
@@ -4,17 +4,17 @@
      id="ID.02"
     >
    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
-      id="ID.05"
+      id="ID.06"
       rolemaps-to="Part"
      >
     <text xmlns="https://www.latex-project.org/ns/dflt"
-       id="ID.06"
+       id="ID.07"
        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
        Layout:TextAlign="Justify"
        rolemaps-to="P"
       >
      <Figure xmlns="http://iso.org/pdf2/ssn"
-        id="ID.07"
+        id="ID.08"
         alt="Square"
         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
         Layout:BBox="{ 148.71233, 468.3744, 177.45728, 497.11934 }"
@@ -22,7 +22,7 @@
       <?MarkedContent page="1" ?>
      </Figure>
      <Span xmlns="http://iso.org/pdf2/ssn"
-        id="ID.08"
+        id="ID.09"
         actualtext="oircle"
        >
       <?MarkedContent page="1" ?>

--- a/tagging-status/testfiles-compatible/memoize-ext/memoize-ext-01.pdftex.struct.xml
+++ b/tagging-status/testfiles-compatible/memoize-ext/memoize-ext-01.pdftex.struct.xml
@@ -1,0 +1,38 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.02"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.05"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.06"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+     <Figure xmlns="http://iso.org/pdf2/ssn"
+        id="ID.07"
+        alt="Square"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:BBox="{ 148.71233, 468.3744, 177.45728, 497.11934 }"
+       >
+      <?MarkedContent page="1" ?>
+     </Figure>
+     <?MarkedContent page="1" ?>
+     <Span xmlns="http://iso.org/pdf2/ssn"
+        id="ID.08"
+        actualtext="oircle"
+       >
+      <?MarkedContent page="1" ?>
+     </Span>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-compatible/memoize-ext/memoize-ext-01.tex
+++ b/tagging-status/testfiles-compatible/memoize-ext/memoize-ext-01.tex
@@ -1,0 +1,24 @@
+\DocumentMetadata{%
+  tagging=on,
+  lang=en-GB,
+  pdfversion=2.0,
+  pdfstandard=UA-2,
+  uncompress,
+}
+\documentclass{article}
+\usepackage{memoize}
+\usepackage{memoize-ext}	
+\usepackage{tikz}
+\title{memoize-ext: 01}
+\begin{document}
+\begin{tikzpicture}[alt=Square]
+  \draw (0,0) rectangle (1,1);
+\end{tikzpicture}%
+\begin{tikzpicture}[actualtext=oircle]
+  \draw circle (10pt);
+\end{tikzpicture}%
+\begin{tikzpicture}[artifact]
+  \draw (0,0) .. controls +(1,-1) and +(1,1) .. (5,5);
+\end{tikzpicture}%
+\end{document}
+% vim: ts=2:sw=2:et:

--- a/tagging-status/testfiles-compatible/memoize-ext/memoize-ext-01.tex
+++ b/tagging-status/testfiles-compatible/memoize-ext/memoize-ext-01.tex
@@ -6,7 +6,6 @@
   uncompress,
 }
 \documentclass{article}
-\usepackage{memoize}
 \usepackage{memoize-ext}	
 \usepackage{tikz}
 \title{memoize-ext: 01}


### PR DESCRIPTION
I'm not sure if it would be better to just refuse to use memoize if tagging but I have documents which can't be realistically compiled at all in that case. Moreover, the tagging is actually more reliable for forest and prooftrees, in the sense that the bounding box is (I hope) correct if the are memoized, whereas it is merely approximated otherwise. For prooftrees, this is not so bad, but for forest it is more likely to be significantly wrong.

But, anyway, I am even less sure about this request ...
