### PR TITLE
remove microtype comment from tagging-status

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -9613,11 +9613,10 @@
   status: compatible
   included-in: [tlc3, arxiv5, ol10]
   priority: 2
-  comments: Footnote patching doesn’t work but otherwise supported.
+  comments:
   issues: [67]
   tests: false
-  tasks: needs tests
-  updated: 2024-07-06
+  updated: 2026-02-28
 
 - name: midfloat
   ctan-pkg: sttools


### PR DESCRIPTION
Removes the comment about footnote patching from the microtype entry since this is fixed in the latest release.