### PR TITLE
add tests and update statuses

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -5116,13 +5116,12 @@
 
 - name: esdiff
   type: package
-  status: unchecked
+  status: compatible
   included-in: [ol0.1]
   priority: 9
   issues:
-  tests: false
-  tasks: needs tests
-  updated: 2026-01-23
+  tests: true
+  updated: 2026-03-06
 
 - name: esint
   type: package
@@ -5497,14 +5496,13 @@
 - name: fancyheadings
   ctan-pkg: fancyhdr
   type: package
-  status: unchecked
+  status: compatible
   included-in: [ol0.02]
   priority: 9
   issues:
   tests: false
-  tasks: needs tests
   comments: "Obsolete. Use the fancyhdr package instead."
-  updated: 2026-01-23
+  updated: 2026-03-06
 
 - name: fancypar
   type: package
@@ -5755,13 +5753,12 @@
 
 - name: fixmath
   type: package
-  status: unchecked
+  status: compatible
   included-in: [ol0.02]
   priority: 9
   issues:
   tests: false
-  tasks: needs tests
-  updated: 2026-01-23
+  updated: 2026-03-06
 
 - name: fixme
   type: package
@@ -5971,13 +5968,13 @@
 
 - name: fontawesome
   type: package
-  status: unchecked
+  status: partially-compatible
   included-in: [ol1]
   priority: 9
   issues:
-  tests: false
-  tasks: needs tests
-  updated: 2026-01-23
+  tests: true
+  comments: "Symbols missing ToUnicode."
+  updated: 2026-03-06
 
 - name: fontawesome5
   type: package
@@ -6507,9 +6504,9 @@
   priority: 2
   issues: [1064]
   comments: "Compatible except that crop marks with `showcrop` are incorrectly tagged as figures."
-  tests: false
-  tasks: needs a crop mark test
-  updated: 2025-11-15
+  package-repository: "https://github.com/LaTeX-Package-Repositories/geometry"
+  tests: true
+  updated: 2026-03-06
 
 - name: german
   type: package
@@ -6677,14 +6674,13 @@
 
 - name: gitinfo-lua
   type: package
-  status: unchecked
+  status: compatible
   included-in:
   priority: 9
   issues:
   luatex-only: true
   tests: false
-  tasks: needs tests
-  updated: 2024-07-18
+  updated: 2026-03-06
 
 - name: gitinfo2
   type: package
@@ -6966,12 +6962,12 @@
 
 - name: here
   type: package
-  status: unchecked
+  status: currently-incompatible
   included-in: [ol0.1]
   priority: 9
   issues:
   tests: false
-  tasks: needs tests
+  comments: "Obsolete. Just loads the float package."
   updated: 2026-01-23
 
 - name: heros-otf
@@ -7872,7 +7868,7 @@
   priority: 2
   issues: [344]
   tests: true
-  tasks: needs tests
+  tasks: needs more tests
   updated: 2024-07-29
 
 - name: keystroke

--- a/tagging-status/testfiles-compatible-mathml/esdiff/esdiff-01.pdftex.struct.xml
+++ b/tagging-status/testfiles-compatible-mathml/esdiff/esdiff-01.pdftex.struct.xml
@@ -1,0 +1,124 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.005"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.006"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.007"
+        title="math"
+        af="mathml-1.xml tag-AFfile1.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-1.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mfrac> <mrow> <mi>𝑑</mi> <mi>𝑓</mi> </mrow> <mrow> <mi>𝑑</mi> <mi>𝑥</mi> </mrow> </mfrac> <mspace width="9.963pt"/> <mstyle displaystyle="true" scriptlevel="0"> <mfrac> <mrow> <mi mathvariant="normal">d</mi> <mi>𝑓</mi> </mrow> <mrow> <mi mathvariant="normal">d</mi> <mi>𝑥</mi> </mrow> </mfrac> </mstyle> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile1.tex" xmlns="">
+       $\frac {df}{dx} \quad \diff {f}{x}$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>dfdxdfdx
+     </Formula>
+     <?MarkedContent page="1" ?>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.008"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.009"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.010"
+        title="math"
+        af="mathml-2.xml tag-AFfile2.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-2.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <msub> <mrow> <mo fence="true" lspace="0" rspace="0" symmetric="true">(</mo> <mfrac> <mrow> <mi mathvariant="normal">d</mi> <mi>𝑓</mi> </mrow> <mrow> <mi mathvariant="normal">d</mi> <mi>𝑥</mi> </mrow> </mfrac> <mo fence="true" lspace="0" rspace="0" symmetric="true">)</mo> </mrow> <mrow> <mspace width="-0.389em"/> <msub> <mi>𝑥</mi> <mn>0</mn> </msub> </mrow> </msub> </mstyle> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile2.tex" xmlns="">
+       $\diff *{f}{x}{x_0}$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>(︃dfdx)︃x0
+     </Formula>
+     <?MarkedContent page="1" ?>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.011"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.012"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.013"
+        title="math"
+        af="mathml-3.xml tag-AFfile3.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-3.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <mfrac> <mrow> <mi>𝜕</mi> <mi>𝑓</mi> </mrow> <mrow> <mi>𝜕</mi> <mi>𝑥</mi> </mrow> </mfrac> </mstyle> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile3.tex" xmlns="">
+       $\diffp {f}{x}$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>∂f∂x
+     </Formula>
+     <?MarkedContent page="1" ?>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.014"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.015"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.016"
+        title="math"
+        af="mathml-4.xml tag-AFfile4.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-4.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <msub> <mrow> <mo fence="true" lspace="0" rspace="0" symmetric="true">(</mo> <mfrac> <mrow> <mi>𝜕</mi> <mi>𝑝</mi> </mrow> <mrow> <mi>𝜕</mi> <mi>𝑉</mi> </mrow> </mfrac> <mo fence="true" lspace="0" rspace="0" symmetric="true">)</mo> </mrow> <mrow> <mspace width="-0.389em"/> <mi>𝑇</mi> </mrow> </msub> </mstyle> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile4.tex" xmlns="">
+       $\diffp *{p}{V}{T}$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>(︃∂p∂V)︃T
+     </Formula>
+     <?MarkedContent page="1" ?>
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-compatible-mathml/esdiff/esdiff-01.struct.xml
+++ b/tagging-status/testfiles-compatible-mathml/esdiff/esdiff-01.struct.xml
@@ -1,0 +1,116 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.005"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.006"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.007"
+        title="math"
+        af="mathml-1.xml tag-AFfile1.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-1.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mfrac> <mrow> <mi>𝑑</mi> <mi>𝑓</mi> </mrow> <mrow> <mi>𝑑</mi> <mi>𝑥</mi> </mrow> </mfrac> <mspace width="9.963pt"/> <mstyle displaystyle="true" scriptlevel="0"> <mfrac> <mrow> <mi mathvariant="normal">d</mi> <mi>𝑓</mi> </mrow> <mrow> <mi mathvariant="normal">d</mi> <mi>𝑥</mi> </mrow> </mfrac> </mstyle> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile1.tex" xmlns="">
+       $\frac {df}{dx} \quad \diff {f}{x}$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>𝑑𝑓𝑑𝑥d𝑓d𝑥
+     </Formula>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.008"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.009"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.010"
+        title="math"
+        af="mathml-2.xml tag-AFfile2.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-2.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <msub> <mrow> <mo fence="true" lspace="0" rspace="0" symmetric="true">(</mo> <mfrac> <mrow> <mi mathvariant="normal">d</mi> <mi>𝑓</mi> </mrow> <mrow> <mi mathvariant="normal">d</mi> <mi>𝑥</mi> </mrow> </mfrac> <mo fence="true" lspace="0" rspace="0" symmetric="true">)</mo> </mrow> <mrow> <mspace width="-0.389em"/> <msub> <mi>𝑥</mi> <mn>0</mn> </msub> </mrow> </msub> </mstyle> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile2.tex" xmlns="">
+       $\diff *{f}{x}{x_0}$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>(d𝑓d𝑥)𝑥0
+     </Formula>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.011"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.012"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.013"
+        title="math"
+        af="mathml-3.xml tag-AFfile3.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-3.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <mfrac> <mrow> <mi>𝜕</mi> <mi>𝑓</mi> </mrow> <mrow> <mi>𝜕</mi> <mi>𝑥</mi> </mrow> </mfrac> </mstyle> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile3.tex" xmlns="">
+       $\diffp {f}{x}$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>𝜕𝑓𝜕𝑥
+     </Formula>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.014"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.015"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.016"
+        title="math"
+        af="mathml-4.xml tag-AFfile4.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-4.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <msub> <mrow> <mo fence="true" lspace="0" rspace="0" symmetric="true">(</mo> <mfrac> <mrow> <mi>𝜕</mi> <mi>𝑝</mi> </mrow> <mrow> <mi>𝜕</mi> <mi>𝑉</mi> </mrow> </mfrac> <mo fence="true" lspace="0" rspace="0" symmetric="true">)</mo> </mrow> <mrow> <mspace width="-0.389em"/> <mi>𝑇</mi> </mrow> </msub> </mstyle> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile4.tex" xmlns="">
+       $\diffp *{p}{V}{T}$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>(𝜕𝑝𝜕𝑉)𝑇
+     </Formula>
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-compatible-mathml/esdiff/esdiff-01.tex
+++ b/tagging-status/testfiles-compatible-mathml/esdiff/esdiff-01.tex
@@ -1,0 +1,27 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on,
+  }
+\documentclass{article}
+
+\ifdefined\Uchar
+  \usepackage{unicode-math}
+\fi
+\usepackage{esdiff}
+
+\title{esdiff tagging test}
+
+\begin{document}
+
+$\frac{df}{dx} \quad \diff{f}{x}$
+
+$\diff*{f}{x}{x_0}$
+
+$\diffp{f}{x}$
+
+$\diffp*{p}{V}{T}$
+
+\end{document}

--- a/tagging-status/testfiles-compatible/geometry/geometry-01-BAD.pdftex.struct.xml
+++ b/tagging-status/testfiles-compatible/geometry/geometry-01-BAD.pdftex.struct.xml
@@ -1,0 +1,66 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.005"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.006"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>As any dedicated reader can clearly see, the Ideal of practical reason is a representationof, as far as I know, the things in themselves; as I have shown elsewhere, the phenomenashould only be used as a canon for our understanding. The paralogisms of practical reasonare what first give rise to the architectonic of practical reason. As will easily be shown in thenext section, reason would thereby be made to contradict, in view of these considerations,the Ideal of practical reason, yet the manifold depends on the phenomena. Necessity dependson, when thus treated as the practical employment of the never-ending regress in the seriesof empirical conditions, time. Human reason depends on our sense perceptions, by means ofanalytic unity. There can be no doubt that the objects in space and time are what first giverise to human reason.
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.007"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.008"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Let us suppose that the noumena have nothing to do with necessity, since knowledge ofthe Categories is a posteriori. Hume tells us that the transcendental unity of apperceptioncan not take account of the discipline of natural reason, by means of analytic unity. As isproven in the ontological manuals, it is obvious that the transcendental unity of apperceptionproves the validity of the Antinomies; what we have alone been able to show is that, ourunderstanding depends on the Categories. It remains a mystery why the Ideal stands in needof reason. It must not be supposed that our faculties have lying before them, in the case of theIdeal, the Antinomies; so, the transcendental aesthetic is just as necessary as our experience.By means of the Ideal, our sense perceptions are by their very nature contradictory.
+    </text>
+   </text-unit>
+   <Figure xmlns="http://iso.org/pdf2/ssn"
+      id="ID.009"
+      alt="picture environment"
+      xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+      Layout:BBox="{ 0, 792, 0, 792 }"
+     >
+    <?MarkedContent page="1" ?>
+   </Figure>
+   <Figure xmlns="http://iso.org/pdf2/ssn"
+      id="ID.010"
+      alt="picture environment"
+      xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+      Layout:BBox="{ 576, 792, 576, 792 }"
+     >
+    <?MarkedContent page="1" ?>
+   </Figure>
+   <Figure xmlns="http://iso.org/pdf2/ssn"
+      id="ID.011"
+      alt="picture environment"
+      xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+      Layout:BBox="{ 0, 216, 0, 216 }"
+     >
+    <?MarkedContent page="1" ?>
+   </Figure>
+   <Figure xmlns="http://iso.org/pdf2/ssn"
+      id="ID.012"
+      alt="picture environment"
+      xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+      Layout:BBox="{ 576, 216, 576, 216 }"
+     >
+    <?MarkedContent page="1" ?>
+   </Figure>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-compatible/geometry/geometry-01-BAD.struct.xml
+++ b/tagging-status/testfiles-compatible/geometry/geometry-01-BAD.struct.xml
@@ -1,0 +1,66 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.005"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.006"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>As any dedicated reader can clearly see, the Ideal of practical reason is a representation of, as far as I know, the things in themselves; as I have shown elsewhere, the phenomena should only be used as a canon for our understanding. The paralogisms of practical reason are what first give rise to the architectonic of practical reason. As will easily be shown in the next section, reason would thereby be made to contradict, in view of these considerations, the Ideal of practical reason, yet the manifold depends on the phenomena. Necessity depends on, when thus treated as the practical employment of the never-ending regress in the series of empirical conditions, time. Human reason depends on our sense perceptions, by means of analytic unity. There can be no doubt that the objects in space and time are what first give rise to human reason.
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.007"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.008"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Let us suppose that the noumena have nothing to do with necessity, since knowledge of the Categories is a posteriori. Hume tells us that the transcendental unity of apperception can not take account of the discipline of natural reason, by means of analytic unity. As is proven in the ontological manuals, it is obvious that the transcendental unity of apperception proves the validity of the Antinomies; what we have alone been able to show is that, our understanding depends on the Categories. It remains a mystery why the Ideal stands in need of reason. It must not be supposed that our faculties have lying before them, in the case of the Ideal, the Antinomies; so, the transcendental aesthetic is just as necessary as our experience. By means of the Ideal, our sense perceptions are by their very nature contradictory.
+    </text>
+   </text-unit>
+   <Figure xmlns="http://iso.org/pdf2/ssn"
+      id="ID.009"
+      alt="picture environment"
+      xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+      Layout:BBox="{ 0, 792, 0, 792 }"
+     >
+    <?MarkedContent page="1" ?>
+   </Figure>
+   <Figure xmlns="http://iso.org/pdf2/ssn"
+      id="ID.010"
+      alt="picture environment"
+      xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+      Layout:BBox="{ 575.99998, 792, 575.99998, 792 }"
+     >
+    <?MarkedContent page="1" ?>
+   </Figure>
+   <Figure xmlns="http://iso.org/pdf2/ssn"
+      id="ID.011"
+      alt="picture environment"
+      xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+      Layout:BBox="{ 0, 216.00002, 0, 216.00002 }"
+     >
+    <?MarkedContent page="1" ?>
+   </Figure>
+   <Figure xmlns="http://iso.org/pdf2/ssn"
+      id="ID.012"
+      alt="picture environment"
+      xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+      Layout:BBox="{ 575.99998, 216.00002, 575.99998, 216.00002 }"
+     >
+    <?MarkedContent page="1" ?>
+   </Figure>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-compatible/geometry/geometry-01-BAD.tex
+++ b/tagging-status/testfiles-compatible/geometry/geometry-01-BAD.tex
@@ -1,0 +1,19 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on,
+  }
+\documentclass{article}
+
+\usepackage[layoutsize={8in,8in},showcrop]{geometry}
+\usepackage{kantlipsum}
+
+\title{geometry tagging test - showcrop}
+
+\begin{document}
+
+\kant[1-2]
+
+\end{document}

--- a/tagging-status/testfiles-partial/fontawesome/fontawesome-01-BAD.pdftex.struct.xml
+++ b/tagging-status/testfiles-partial/fontawesome/fontawesome-01-BAD.pdftex.struct.xml
@@ -1,0 +1,34 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.02"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.05"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.06"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>[TEXT]
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.07"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.08"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>[TEXT]
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-partial/fontawesome/fontawesome-01-BAD.struct.xml
+++ b/tagging-status/testfiles-partial/fontawesome/fontawesome-01-BAD.struct.xml
@@ -1,0 +1,34 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.02"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.05"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.06"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>[TEXT]
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.07"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.08"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>[TEXT]
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-partial/fontawesome/fontawesome-01-BAD.tex
+++ b/tagging-status/testfiles-partial/fontawesome/fontawesome-01-BAD.tex
@@ -1,0 +1,20 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on,
+  }
+\documentclass{article}
+
+\usepackage{fontawesome}
+
+\title{fontawesome tagging test}
+
+\begin{document}
+
+\faAmbulance
+
+\faFile
+
+\end{document}


### PR DESCRIPTION
Lists esdiff as compatible and adds a test.

Lists fancyheadings as compatible since it just loads fancyhdr.

Lists fixmath, gitinfo-lua as compatible without a test.

Lists fontawesome as partially-compatible with a test.

Adds a cropmark test for geometry but leaves it as compatible since the issue will be fixed soon.

Lists here as incompatible since it just loads the float package.