### PR TITLE
add tests for packages incompatible with mathml-SE

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -666,6 +666,7 @@
   status: partially-compatible
   included-in: [tlc3, arxiv1, ol0.1]
   priority: 2
+  issues: [1450]
   comments: "`\\accentedsymbol` not supported by luamml and errors with mathml-SE."
   tests: true
   updated: 2026-06-25
@@ -3110,6 +3111,7 @@
   priority: 7
   comments: "No luamml support."
   tests: true
+  issues: [1448]
   package-repository: "https://github.com/ho-tex/oberdiek"
   updated: 2025-05-29
 
@@ -3119,6 +3121,7 @@
   included-in: [ol0.02]
   priority: 9
   tests: true
+  issues: [1449]
   comments: No luamml support.
   updated: 2026-06-08
 
@@ -5035,6 +5038,7 @@
   status: partially-compatible
   included-in: [ol0.02]
   priority: 9
+  issues: [919]
   comments: "Incomplete luamml support. Must be loaded before unicode-math."
   tests: true
   updated: 2025-06-03
@@ -8755,7 +8759,7 @@
   comments: "`mathic` key produces errors.
              `centercolon` incompatible with unicode-math.
              luamml support is limited to `multlined` and `\\shortintertext`."
-  issues: [139,922,1368]
+  issues: [139,922,1368,1445,1446]
   closed-issues: [734,1119]
   tests: true
   updated: 2025-12-11
@@ -14433,6 +14437,7 @@
   included-in: [tlc3]
   priority: 3
   comments: "No luamml support."
+  issues: [1447]
   tests: true
   updated: 2024-07-26
 

--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -666,9 +666,9 @@
   status: partially-compatible
   included-in: [tlc3, arxiv1, ol0.1]
   priority: 2
-  comments: "`\\accentedsymbol` not supported by luamml."
+  comments: "`\\accentedsymbol` not supported by luamml and errors with mathml-SE."
   tests: true
-  updated: 2025-05-28
+  updated: 2026-06-25
 
 - name: andika
   type: package
@@ -5018,6 +5018,7 @@
   priority: 2
   comments: "Produces warnings with mathml-SE."
   issues: [919]
+  closed-issues: [1432]
   tests: true
   updated: 2026-02-28
 
@@ -6335,7 +6336,7 @@
     The alternative text will be ignored if tagging is not used. It seems that draft mode doesn’t work at present.
     An old issue with height appears to be fixed.
   references: [1]
-  closed-issues: [16,64]
+  closed-issues: [16,64,950]
   tests: false
   updated: 2024-07-06
 

--- a/tagging-status/testfiles-partial-mathml/amsxtra/amsxtra-02-BAD.pdftex.struct.xml
+++ b/tagging-status/testfiles-partial-mathml/amsxtra/amsxtra-02-BAD.pdftex.struct.xml
@@ -1,0 +1,1 @@
+<run-error code="1" />

--- a/tagging-status/testfiles-partial-mathml/amsxtra/amsxtra-02-BAD.struct.xml
+++ b/tagging-status/testfiles-partial-mathml/amsxtra/amsxtra-02-BAD.struct.xml
@@ -1,0 +1,1 @@
+<run-error code="1" />

--- a/tagging-status/testfiles-partial-mathml/amsxtra/amsxtra-02-BAD.tex
+++ b/tagging-status/testfiles-partial-mathml/amsxtra/amsxtra-02-BAD.tex
@@ -1,0 +1,20 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on,
+    tagging-setup={math/setup=mathml-SE},
+  }
+\documentclass{article}
+
+\ifdefined\Uchar\usepackage{unicode-math}\fi
+\usepackage{amsxtra}
+
+\accentedsymbol{\vx}{\vec{x}}
+
+\begin{document}
+
+$\vx$
+
+\end{document}

--- a/tagging-status/testfiles-partial-mathml/chemarr/chemarr-02-BAD.pdftex.struct.xml
+++ b/tagging-status/testfiles-partial-mathml/chemarr/chemarr-02-BAD.pdftex.struct.xml
@@ -1,0 +1,30 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.02"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.05"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.06"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>text
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.07"
+        title="math"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+      <?MarkedContent page="1" ?>above−−−⇀↽−−−below
+     </Formula>
+     <?MarkedContent page="1" ?>text
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-partial-mathml/chemarr/chemarr-02-BAD.struct.xml
+++ b/tagging-status/testfiles-partial-mathml/chemarr/chemarr-02-BAD.struct.xml
@@ -1,0 +1,1 @@
+<run-error code="1" />

--- a/tagging-status/testfiles-partial-mathml/chemarr/chemarr-02-BAD.tex
+++ b/tagging-status/testfiles-partial-mathml/chemarr/chemarr-02-BAD.tex
@@ -1,0 +1,22 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on,
+    tagging-setup={math/setup=mathml-SE},
+  }
+\documentclass{article}
+
+\UseName{sys_if_engine_opentype:T}{\usepackage{unicode-math}}
+\usepackage{chemarr}
+
+\title{chemarr tagging test}
+
+\begin{document}
+
+text
+\xrightleftharpoons[\text{below}]{\text{above}}
+text
+
+\end{document}

--- a/tagging-status/testfiles-partial-mathml/chemarr/chemarr-03-BAD.pdftex.struct.xml
+++ b/tagging-status/testfiles-partial-mathml/chemarr/chemarr-03-BAD.pdftex.struct.xml
@@ -1,0 +1,21 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.02"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.05"
+      rolemaps-to="Part"
+     >
+    <Formula xmlns="http://iso.org/pdf2/ssn"
+       id="ID.06"
+       title="equation*"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:Placement="Block"
+      >
+     <?MarkedContent page="1" ?>Ap>10hPa−−−−−−⇀↽−−−−−−T≥400KB
+    </Formula>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-partial-mathml/chemarr/chemarr-03-BAD.struct.xml
+++ b/tagging-status/testfiles-partial-mathml/chemarr/chemarr-03-BAD.struct.xml
@@ -1,0 +1,1 @@
+<run-error err="assertion failed!" />

--- a/tagging-status/testfiles-partial-mathml/chemarr/chemarr-03-BAD.tex
+++ b/tagging-status/testfiles-partial-mathml/chemarr/chemarr-03-BAD.tex
@@ -1,0 +1,25 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on,
+    tagging-setup={math/setup=mathml-SE},
+  }
+\documentclass{article}
+
+\UseName{sys_if_engine_opentype:T}{\usepackage{unicode-math}}
+\usepackage{chemarr}
+
+\title{chemarr tagging test}
+
+\begin{document}
+
+% does not error but produces warnings
+\[
+  A
+  \xrightleftharpoons[T \geq 400\,\mathrm{K}]{p > 10\,\mathrm{hPa}}
+  B
+\]
+
+\end{document}

--- a/tagging-status/testfiles-partial-mathml/chemarrow/chemarrow-02-BAD.pdftex.struct.xml
+++ b/tagging-status/testfiles-partial-mathml/chemarrow/chemarrow-02-BAD.pdftex.struct.xml
@@ -1,0 +1,278 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <Sect xmlns="http://iso.org/pdf2/ssn"
+      id="ID.005"
+     >
+    <section xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.006"
+       title="chemarrow"
+       rolemaps-to="H1"
+      >
+     <section-number xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.007"
+        rolemaps-to="Span"
+       >
+      <?MarkedContent page="1" ?>1
+     </section-number>
+     <?MarkedContent page="1" ?>chemarrow
+    </section>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.008"
+       rolemaps-to="Part"
+      >
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.009"
+        title="equation*"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Block"
+       >
+      <?MarkedContent page="1" ?>H2O + H2OA H3O++ OH−
+     </Formula>
+    </text-unit>
+   </Sect>
+   <Sect xmlns="http://iso.org/pdf2/ssn"
+      id="ID.010"
+     >
+    <section xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.011"
+       title="rarrowfill 2.5em"
+       rolemaps-to="H1"
+      >
+     <section-number xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.012"
+        rolemaps-to="Span"
+       >
+      <?MarkedContent page="1" ?>2
+     </section-number>
+     <?MarkedContent page="1" ?>rarrowfill 2.5em
+    </section>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.013"
+       rolemaps-to="Part"
+      >
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.014"
+        title="equation*"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Block"
+       >
+      <?MarkedContent page="1" ?>H2O + H2OGGGGAH3O++ OH−
+     </Formula>
+    </text-unit>
+   </Sect>
+   <Sect xmlns="http://iso.org/pdf2/ssn"
+      id="ID.015"
+     >
+    <section xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.016"
+       title="larrowfill 2.5em"
+       rolemaps-to="H1"
+      >
+     <section-number xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.017"
+        rolemaps-to="Span"
+       >
+      <?MarkedContent page="1" ?>3
+     </section-number>
+     <?MarkedContent page="1" ?>larrowfill 2.5em
+    </section>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.018"
+       rolemaps-to="Part"
+      >
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.019"
+        title="equation*"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Block"
+       >
+      <?MarkedContent page="1" ?>H2O + H2ODGGGGH3O++ OH−
+     </Formula>
+    </text-unit>
+   </Sect>
+   <Sect xmlns="http://iso.org/pdf2/ssn"
+      id="ID.020"
+     >
+    <section xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.021"
+       title="rightleftharpoonsfill 2.5em"
+       rolemaps-to="H1"
+      >
+     <section-number xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.022"
+        rolemaps-to="Span"
+       >
+      <?MarkedContent page="1" ?>4
+     </section-number>
+     <?MarkedContent page="1" ?>rightleftharpoonsfill 2.5em
+    </section>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.023"
+       rolemaps-to="Part"
+      >
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.024"
+        title="equation*"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Block"
+       >
+      <?MarkedContent page="1" ?>H2O + H2OGGGGBFGGGGH3O++ OH−
+     </Formula>
+    </text-unit>
+   </Sect>
+   <Sect xmlns="http://iso.org/pdf2/ssn"
+      id="ID.025"
+     >
+    <section xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.026"
+       title="leftrightharpoonsfill 2.5em"
+       rolemaps-to="H1"
+      >
+     <section-number xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.027"
+        rolemaps-to="Span"
+       >
+      <?MarkedContent page="1" ?>5
+     </section-number>
+     <?MarkedContent page="1" ?>leftrightharpoonsfill 2.5em
+    </section>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.028"
+       rolemaps-to="Part"
+      >
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.029"
+        title="equation*"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Block"
+       >
+      <?MarkedContent page="1" ?>H2O + H2OEGGGGGGGGCH3O++ OH−
+     </Formula>
+    </text-unit>
+   </Sect>
+   <Sect xmlns="http://iso.org/pdf2/ssn"
+      id="ID.030"
+     >
+    <section xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.031"
+       title="autorightleftharpoons"
+       rolemaps-to="H1"
+      >
+     <section-number xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.032"
+        rolemaps-to="Span"
+       >
+      <?MarkedContent page="1" ?>6
+     </section-number>
+     <?MarkedContent page="1" ?>autorightleftharpoons
+    </section>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.033"
+       rolemaps-to="Part"
+      >
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.034"
+        title="equation*"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Block"
+       >
+      <?MarkedContent page="1" ?>H2O + H2OkaGGGGGBFGGGGGkbH3O++ OH−
+     </Formula>
+    </text-unit>
+   </Sect>
+   <Sect xmlns="http://iso.org/pdf2/ssn"
+      id="ID.035"
+     >
+    <section xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.036"
+       title="autoleftrightharpoons"
+       rolemaps-to="H1"
+      >
+     <section-number xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.037"
+        rolemaps-to="Span"
+       >
+      <?MarkedContent page="1" ?>7
+     </section-number>
+     <?MarkedContent page="1" ?>autoleftrightharpoons
+    </section>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.038"
+       rolemaps-to="Part"
+      >
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.039"
+        title="equation*"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Block"
+       >
+      <?MarkedContent page="1" ?>H2O + H2OkaEGGGGGGGGGGCkbH3O++ OH−
+     </Formula>
+    </text-unit>
+   </Sect>
+   <Sect xmlns="http://iso.org/pdf2/ssn"
+      id="ID.040"
+     >
+    <section xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.041"
+       title="autorightarrow"
+       rolemaps-to="H1"
+      >
+     <section-number xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.042"
+        rolemaps-to="Span"
+       >
+      <?MarkedContent page="2" ?>8
+     </section-number>
+     <?MarkedContent page="2" ?>autorightarrow
+    </section>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.043"
+       rolemaps-to="Part"
+      >
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.044"
+        title="equation*"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Block"
+       >
+      <?MarkedContent page="2" ?>H2O + H2OkaGGGGGGAkbH3O++ OH−
+     </Formula>
+    </text-unit>
+   </Sect>
+   <Sect xmlns="http://iso.org/pdf2/ssn"
+      id="ID.045"
+     >
+    <section xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.046"
+       title="autoleftarrow"
+       rolemaps-to="H1"
+      >
+     <section-number xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.047"
+        rolemaps-to="Span"
+       >
+      <?MarkedContent page="2" ?>9
+     </section-number>
+     <?MarkedContent page="2" ?>autoleftarrow
+    </section>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.048"
+       rolemaps-to="Part"
+      >
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.049"
+        title="equation*"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Block"
+       >
+      <?MarkedContent page="2" ?>H2O + H2OkaDGGGGGGkbH3O++ OH−
+     </Formula>
+    </text-unit>
+   </Sect>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-partial-mathml/chemarrow/chemarrow-02-BAD.struct.xml
+++ b/tagging-status/testfiles-partial-mathml/chemarrow/chemarrow-02-BAD.struct.xml
@@ -1,0 +1,4218 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.0002"
+    >
+   <Sect xmlns="http://iso.org/pdf2/ssn"
+      id="ID.0006"
+     >
+    <section xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0007"
+       title="chemarrow"
+       rolemaps-to="H1"
+      >
+     <section-number xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.0008"
+        rolemaps-to="Span"
+       >
+      <?MarkedContent page="1" ?>1 
+     </section-number>
+     <?MarkedContent page="1" ?>chemarrow
+    </section>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0009"
+       rolemaps-to="Part"
+      >
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.0010"
+        title="equation*"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Block"
+       >
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0026"
+        >
+       <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0027"
+          displaystyle="true"
+          scriptlevel="0"
+         >
+        <msub xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0028"
+          >
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0011"
+           >
+          <?MarkedContent page="1" ?>H
+         </mtext>
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0012"
+           >
+          <?MarkedContent page="1" ?>2
+         </mtext>
+        </msub>
+        <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0013"
+          >
+         <?MarkedContent page="1" ?>O
+        </mtext>
+        <mo xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0029"
+           lspace="0.222em"
+           rspace="0.222em"
+          >
+         <?MarkedContent page="1" ?>+
+        </mo>
+        <msub xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0030"
+          >
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0014"
+           >
+          <?MarkedContent page="1" ?>H
+         </mtext>
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0015"
+           >
+          <?MarkedContent page="1" ?>2
+         </mtext>
+        </msub>
+        <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0016"
+          >
+         <?MarkedContent page="1" ?>O
+        </mtext>
+        <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0031"
+           width="3.897pt"
+          >
+        </mspace>
+        <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0017"
+          >
+         <?MarkedContent page="1" ?>A
+        </mtext>
+        <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0032"
+           width="3.897pt"
+          >
+        </mspace>
+        <msub xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0033"
+          >
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0018"
+           >
+          <?MarkedContent page="1" ?>H
+         </mtext>
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0019"
+           >
+          <?MarkedContent page="1" ?>3
+         </mtext>
+        </msub>
+        <msup xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0034"
+          >
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0020"
+           >
+          <?MarkedContent page="1" ?>O
+         </mtext>
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0021"
+           >
+          <?MarkedContent page="1" ?>+
+         </mtext>
+        </msup>
+        <mo xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0035"
+           lspace="0.222em"
+           rspace="0.222em"
+          >
+         <?MarkedContent page="1" ?>+
+        </mo>
+        <msup xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0036"
+          >
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0022"
+           >
+          <?MarkedContent page="1" ?>OH
+         </mtext>
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0023"
+           >
+          <?MarkedContent page="1" ?>
+          <math xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0024"
+            >
+           <mo xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0025"
+              lspace="0"
+              rspace="0"
+             >
+            <?MarkedContent page="1" ?>−
+           </mo>
+          </math>
+          <?MarkedContent page="1" ?>
+         </mtext>
+        </msup>
+       </mstyle>
+      </math>
+      <?MarkedContent page="1" ?>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0037"
+         display="block"
+        >
+       <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0038"
+         >
+        <math xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0039"
+          >
+         <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0040"
+            displaystyle="true"
+            scriptlevel="0"
+           >
+          <msub xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0041"
+            >
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0011"
+             >
+            <?MarkedContent page="1" ?>H
+           </mtext>
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0012"
+             >
+            <?MarkedContent page="1" ?>2
+           </mtext>
+          </msub>
+          <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0013"
+            >
+           <?MarkedContent page="1" ?>O
+          </mtext>
+          <mo xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0042"
+             lspace="0.222em"
+             rspace="0.222em"
+            >
+          </mo>
+          <msub xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0043"
+            >
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0014"
+             >
+            <?MarkedContent page="1" ?>H
+           </mtext>
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0015"
+             >
+            <?MarkedContent page="1" ?>2
+           </mtext>
+          </msub>
+          <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0016"
+            >
+           <?MarkedContent page="1" ?>O
+          </mtext>
+          <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0044"
+             width="3.897pt"
+            >
+          </mspace>
+          <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0017"
+            >
+           <?MarkedContent page="1" ?>A
+          </mtext>
+          <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0045"
+             width="3.897pt"
+            >
+          </mspace>
+          <msub xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0046"
+            >
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0018"
+             >
+            <?MarkedContent page="1" ?>H
+           </mtext>
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0019"
+             >
+            <?MarkedContent page="1" ?>3
+           </mtext>
+          </msub>
+          <msup xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0047"
+            >
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0020"
+             >
+            <?MarkedContent page="1" ?>O
+           </mtext>
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0021"
+             >
+            <?MarkedContent page="1" ?>+
+           </mtext>
+          </msup>
+          <mo xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0048"
+             lspace="0.222em"
+             rspace="0.222em"
+            >
+          </mo>
+          <msup xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0049"
+            >
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0022"
+             >
+            <?MarkedContent page="1" ?>OH
+           </mtext>
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0023"
+             >
+            <?MarkedContent page="1" ?>
+            <math xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0024"
+              >
+             <mo xmlns="http://www.w3.org/1998/Math/MathML"
+                id="ID.0025"
+                lspace="0"
+                rspace="0"
+               >
+              <?MarkedContent page="1" ?>−
+             </mo>
+            </math>
+            <?MarkedContent page="1" ?>
+           </mtext>
+          </msup>
+         </mstyle>
+        </math>
+       </mtext>
+      </math>
+     </Formula>
+    </text-unit>
+   </Sect>
+   <Sect xmlns="http://iso.org/pdf2/ssn"
+      id="ID.0050"
+     >
+    <section xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0051"
+       title="rarrowfill 2.5em"
+       rolemaps-to="H1"
+      >
+     <section-number xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.0052"
+        rolemaps-to="Span"
+       >
+      <?MarkedContent page="1" ?>2 
+     </section-number>
+     <?MarkedContent page="1" ?>rarrowfill 2.5em
+    </section>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0053"
+       rolemaps-to="Part"
+      >
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.0054"
+        title="equation*"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Block"
+       >
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0063"
+        >
+       <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0064"
+          width="-0.111em"
+         >
+       </mspace>
+       <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0062"
+         >
+       </mtext>
+       <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0065"
+          width="-0.111em"
+         >
+       </mspace>
+      </math>
+      <?MarkedContent page="1" ?>GGGG
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0067"
+        >
+       <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0061"
+         >
+        <?MarkedContent page="1" ?>G
+       </mtext>
+       <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0068"
+          width="-0.333em"
+         >
+       </mspace>
+       <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0069"
+          width="-0.333em"
+         >
+       </mspace>
+       <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0066"
+         >
+        <?MarkedContent page="1" ?>A
+       </mtext>
+      </math>
+      <?MarkedContent page="1" ?>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0078"
+        >
+       <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0079"
+          displaystyle="true"
+          scriptlevel="0"
+         >
+        <msub xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0080"
+          >
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0055"
+           >
+          <?MarkedContent page="1" ?>H
+         </mtext>
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0056"
+           >
+          <?MarkedContent page="1" ?>2
+         </mtext>
+        </msub>
+        <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0057"
+          >
+         <?MarkedContent page="1" ?>O
+        </mtext>
+        <mo xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0081"
+           lspace="0.222em"
+           rspace="0.222em"
+          >
+         <?MarkedContent page="1" ?>+
+        </mo>
+        <msub xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0082"
+          >
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0058"
+           >
+          <?MarkedContent page="1" ?>H
+         </mtext>
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0059"
+           >
+          <?MarkedContent page="1" ?>2
+         </mtext>
+        </msub>
+        <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0060"
+          >
+         <?MarkedContent page="1" ?>O
+        </mtext>
+        <mo xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0083"
+           lspace="0.167em"
+           rspace="0.167em"
+          >
+         <math xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0084"
+           >
+          <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0061"
+            >
+           <?MarkedContent page="1" ?>G
+          </mtext>
+          <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0085"
+             width="-0.333em"
+            >
+          </mspace>
+          <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0086"
+             width="-0.333em"
+            >
+          </mspace>
+          <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0066"
+            >
+           <?MarkedContent page="1" ?>A
+          </mtext>
+         </math>
+        </mo>
+        <msub xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0087"
+          >
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0070"
+           >
+          <?MarkedContent page="1" ?>H
+         </mtext>
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0071"
+           >
+          <?MarkedContent page="1" ?>3
+         </mtext>
+        </msub>
+        <msup xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0088"
+          >
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0072"
+           >
+          <?MarkedContent page="1" ?>O
+         </mtext>
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0073"
+           >
+          <?MarkedContent page="1" ?>+
+         </mtext>
+        </msup>
+        <mo xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0089"
+           lspace="0.222em"
+           rspace="0.222em"
+          >
+         <?MarkedContent page="1" ?>+
+        </mo>
+        <msup xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0090"
+          >
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0074"
+           >
+          <?MarkedContent page="1" ?>OH
+         </mtext>
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0075"
+           >
+          <?MarkedContent page="1" ?>
+          <math xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0076"
+            >
+           <mo xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0077"
+              lspace="0"
+              rspace="0"
+             >
+            <?MarkedContent page="1" ?>−
+           </mo>
+          </math>
+          <?MarkedContent page="1" ?>
+         </mtext>
+        </msup>
+       </mstyle>
+      </math>
+      <?MarkedContent page="1" ?>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0091"
+         display="block"
+        >
+       <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0092"
+         >
+        <math xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0093"
+          >
+         <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0094"
+            displaystyle="true"
+            scriptlevel="0"
+           >
+          <msub xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0095"
+            >
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0055"
+             >
+            <?MarkedContent page="1" ?>H
+           </mtext>
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0056"
+             >
+            <?MarkedContent page="1" ?>2
+           </mtext>
+          </msub>
+          <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0057"
+            >
+           <?MarkedContent page="1" ?>O
+          </mtext>
+          <mo xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0096"
+             lspace="0.222em"
+             rspace="0.222em"
+            >
+          </mo>
+          <msub xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0097"
+            >
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0058"
+             >
+            <?MarkedContent page="1" ?>H
+           </mtext>
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0059"
+             >
+            <?MarkedContent page="1" ?>2
+           </mtext>
+          </msub>
+          <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0060"
+            >
+           <?MarkedContent page="1" ?>O
+          </mtext>
+          <mo xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0098"
+             lspace="0.167em"
+             rspace="0.167em"
+            >
+           <math xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0099"
+             >
+            <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0061"
+              >
+             <?MarkedContent page="1" ?>G
+            </mtext>
+            <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0100"
+               width="-0.333em"
+              >
+            </mspace>
+            <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0101"
+               width="-0.333em"
+              >
+            </mspace>
+            <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0066"
+              >
+             <?MarkedContent page="1" ?>A
+            </mtext>
+           </math>
+          </mo>
+          <msub xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0102"
+            >
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0070"
+             >
+            <?MarkedContent page="1" ?>H
+           </mtext>
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0071"
+             >
+            <?MarkedContent page="1" ?>3
+           </mtext>
+          </msub>
+          <msup xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0103"
+            >
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0072"
+             >
+            <?MarkedContent page="1" ?>O
+           </mtext>
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0073"
+             >
+            <?MarkedContent page="1" ?>+
+           </mtext>
+          </msup>
+          <mo xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0104"
+             lspace="0.222em"
+             rspace="0.222em"
+            >
+          </mo>
+          <msup xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0105"
+            >
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0074"
+             >
+            <?MarkedContent page="1" ?>OH
+           </mtext>
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0075"
+             >
+            <?MarkedContent page="1" ?>
+            <math xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0076"
+              >
+             <mo xmlns="http://www.w3.org/1998/Math/MathML"
+                id="ID.0077"
+                lspace="0"
+                rspace="0"
+               >
+              <?MarkedContent page="1" ?>−
+             </mo>
+            </math>
+            <?MarkedContent page="1" ?>
+           </mtext>
+          </msup>
+         </mstyle>
+        </math>
+       </mtext>
+      </math>
+     </Formula>
+    </text-unit>
+   </Sect>
+   <Sect xmlns="http://iso.org/pdf2/ssn"
+      id="ID.0106"
+     >
+    <section xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0107"
+       title="larrowfill 2.5em"
+       rolemaps-to="H1"
+      >
+     <section-number xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.0108"
+        rolemaps-to="Span"
+       >
+      <?MarkedContent page="1" ?>3 
+     </section-number>
+     <?MarkedContent page="1" ?>larrowfill 2.5em
+    </section>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0109"
+       rolemaps-to="Part"
+      >
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.0110"
+        title="equation*"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Block"
+       >
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0119"
+        >
+       <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0120"
+          width="-0.111em"
+         >
+       </mspace>
+       <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0118"
+         >
+       </mtext>
+       <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0121"
+          width="-0.111em"
+         >
+       </mspace>
+      </math>
+      <?MarkedContent page="1" ?>GGGG
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0123"
+        >
+       <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0117"
+         >
+        <?MarkedContent page="1" ?>D
+       </mtext>
+       <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0124"
+          width="-0.333em"
+         >
+       </mspace>
+       <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0125"
+          width="-0.333em"
+         >
+       </mspace>
+       <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0122"
+         >
+        <?MarkedContent page="1" ?>G
+       </mtext>
+      </math>
+      <?MarkedContent page="1" ?>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0134"
+        >
+       <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0135"
+          displaystyle="true"
+          scriptlevel="0"
+         >
+        <msub xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0136"
+          >
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0111"
+           >
+          <?MarkedContent page="1" ?>H
+         </mtext>
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0112"
+           >
+          <?MarkedContent page="1" ?>2
+         </mtext>
+        </msub>
+        <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0113"
+          >
+         <?MarkedContent page="1" ?>O
+        </mtext>
+        <mo xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0137"
+           lspace="0.222em"
+           rspace="0.222em"
+          >
+         <?MarkedContent page="1" ?>+
+        </mo>
+        <msub xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0138"
+          >
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0114"
+           >
+          <?MarkedContent page="1" ?>H
+         </mtext>
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0115"
+           >
+          <?MarkedContent page="1" ?>2
+         </mtext>
+        </msub>
+        <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0116"
+          >
+         <?MarkedContent page="1" ?>O
+        </mtext>
+        <mo xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0139"
+           lspace="0.167em"
+           rspace="0.167em"
+          >
+         <math xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0140"
+           >
+          <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0117"
+            >
+           <?MarkedContent page="1" ?>D
+          </mtext>
+          <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0141"
+             width="-0.333em"
+            >
+          </mspace>
+          <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0142"
+             width="-0.333em"
+            >
+          </mspace>
+          <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0122"
+            >
+           <?MarkedContent page="1" ?>G
+          </mtext>
+         </math>
+        </mo>
+        <msub xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0143"
+          >
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0126"
+           >
+          <?MarkedContent page="1" ?>H
+         </mtext>
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0127"
+           >
+          <?MarkedContent page="1" ?>3
+         </mtext>
+        </msub>
+        <msup xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0144"
+          >
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0128"
+           >
+          <?MarkedContent page="1" ?>O
+         </mtext>
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0129"
+           >
+          <?MarkedContent page="1" ?>+
+         </mtext>
+        </msup>
+        <mo xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0145"
+           lspace="0.222em"
+           rspace="0.222em"
+          >
+         <?MarkedContent page="1" ?>+
+        </mo>
+        <msup xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0146"
+          >
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0130"
+           >
+          <?MarkedContent page="1" ?>OH
+         </mtext>
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0131"
+           >
+          <?MarkedContent page="1" ?>
+          <math xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0132"
+            >
+           <mo xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0133"
+              lspace="0"
+              rspace="0"
+             >
+            <?MarkedContent page="1" ?>−
+           </mo>
+          </math>
+          <?MarkedContent page="1" ?>
+         </mtext>
+        </msup>
+       </mstyle>
+      </math>
+      <?MarkedContent page="1" ?>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0147"
+         display="block"
+        >
+       <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0148"
+         >
+        <math xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0149"
+          >
+         <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0150"
+            displaystyle="true"
+            scriptlevel="0"
+           >
+          <msub xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0151"
+            >
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0111"
+             >
+            <?MarkedContent page="1" ?>H
+           </mtext>
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0112"
+             >
+            <?MarkedContent page="1" ?>2
+           </mtext>
+          </msub>
+          <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0113"
+            >
+           <?MarkedContent page="1" ?>O
+          </mtext>
+          <mo xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0152"
+             lspace="0.222em"
+             rspace="0.222em"
+            >
+          </mo>
+          <msub xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0153"
+            >
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0114"
+             >
+            <?MarkedContent page="1" ?>H
+           </mtext>
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0115"
+             >
+            <?MarkedContent page="1" ?>2
+           </mtext>
+          </msub>
+          <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0116"
+            >
+           <?MarkedContent page="1" ?>O
+          </mtext>
+          <mo xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0154"
+             lspace="0.167em"
+             rspace="0.167em"
+            >
+           <math xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0155"
+             >
+            <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0117"
+              >
+             <?MarkedContent page="1" ?>D
+            </mtext>
+            <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0156"
+               width="-0.333em"
+              >
+            </mspace>
+            <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0157"
+               width="-0.333em"
+              >
+            </mspace>
+            <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0122"
+              >
+             <?MarkedContent page="1" ?>G
+            </mtext>
+           </math>
+          </mo>
+          <msub xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0158"
+            >
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0126"
+             >
+            <?MarkedContent page="1" ?>H
+           </mtext>
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0127"
+             >
+            <?MarkedContent page="1" ?>3
+           </mtext>
+          </msub>
+          <msup xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0159"
+            >
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0128"
+             >
+            <?MarkedContent page="1" ?>O
+           </mtext>
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0129"
+             >
+            <?MarkedContent page="1" ?>+
+           </mtext>
+          </msup>
+          <mo xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0160"
+             lspace="0.222em"
+             rspace="0.222em"
+            >
+          </mo>
+          <msup xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0161"
+            >
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0130"
+             >
+            <?MarkedContent page="1" ?>OH
+           </mtext>
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0131"
+             >
+            <?MarkedContent page="1" ?>
+            <math xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0132"
+              >
+             <mo xmlns="http://www.w3.org/1998/Math/MathML"
+                id="ID.0133"
+                lspace="0"
+                rspace="0"
+               >
+              <?MarkedContent page="1" ?>−
+             </mo>
+            </math>
+            <?MarkedContent page="1" ?>
+           </mtext>
+          </msup>
+         </mstyle>
+        </math>
+       </mtext>
+      </math>
+     </Formula>
+    </text-unit>
+   </Sect>
+   <Sect xmlns="http://iso.org/pdf2/ssn"
+      id="ID.0162"
+     >
+    <section xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0163"
+       title="rightleftharpoonsfill 2.5em"
+       rolemaps-to="H1"
+      >
+     <section-number xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.0164"
+        rolemaps-to="Span"
+       >
+      <?MarkedContent page="1" ?>4 
+     </section-number>
+     <?MarkedContent page="1" ?>rightleftharpoonsfill 2.5em
+    </section>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0165"
+       rolemaps-to="Part"
+      >
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.0166"
+        title="equation*"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Block"
+       >
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0175"
+        >
+       <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0176"
+          width="-0.111em"
+         >
+       </mspace>
+       <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0174"
+         >
+       </mtext>
+       <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0177"
+          width="-0.111em"
+         >
+       </mspace>
+      </math>
+      <?MarkedContent page="1" ?>GGG
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0179"
+        >
+       <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0173"
+         >
+        <?MarkedContent page="1" ?>G
+       </mtext>
+       <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0180"
+          width="-0.333em"
+         >
+       </mspace>
+       <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0181"
+          width="-0.333em"
+         >
+       </mspace>
+       <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0178"
+         >
+        <?MarkedContent page="1" ?>B
+       </mtext>
+      </math>
+      <?MarkedContent page="1" ?>
+      <?MarkedContent page="1" ?>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0182"
+        >
+       <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0183"
+         >
+        <math xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0184"
+          >
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0173"
+           >
+          <?MarkedContent page="1" ?>G
+         </mtext>
+         <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0185"
+            width="-0.333em"
+           >
+         </mspace>
+         <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0186"
+            width="-0.333em"
+           >
+         </mspace>
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0178"
+           >
+          <?MarkedContent page="1" ?>B
+         </mtext>
+        </math>
+       </mtext>
+      </math>
+      <?MarkedContent page="1" ?>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0189"
+        >
+       <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0190"
+          width="-0.111em"
+         >
+       </mspace>
+       <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0188"
+         >
+       </mtext>
+       <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0191"
+          width="-0.111em"
+         >
+       </mspace>
+      </math>
+      <?MarkedContent page="1" ?>GGG
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0193"
+        >
+       <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0187"
+         >
+        <?MarkedContent page="1" ?>F
+       </mtext>
+       <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0194"
+          width="-0.333em"
+         >
+       </mspace>
+       <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0195"
+          width="-0.333em"
+         >
+       </mspace>
+       <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0192"
+         >
+        <?MarkedContent page="1" ?>G
+       </mtext>
+      </math>
+      <?MarkedContent page="1" ?>
+      <?MarkedContent page="1" ?> 
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0196"
+        >
+       <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0197"
+         >
+        <math xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0198"
+          >
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0187"
+           >
+          <?MarkedContent page="1" ?>F
+         </mtext>
+         <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0199"
+            width="-0.333em"
+           >
+         </mspace>
+         <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0200"
+            width="-0.333em"
+           >
+         </mspace>
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0192"
+           >
+          <?MarkedContent page="1" ?>G
+         </mtext>
+        </math>
+       </mtext>
+      </math>
+      <?MarkedContent page="1" ?>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0209"
+        >
+       <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0210"
+          displaystyle="true"
+          scriptlevel="0"
+         >
+        <msub xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0211"
+          >
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0167"
+           >
+          <?MarkedContent page="1" ?>H
+         </mtext>
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0168"
+           >
+          <?MarkedContent page="1" ?>2
+         </mtext>
+        </msub>
+        <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0169"
+          >
+         <?MarkedContent page="1" ?>O
+        </mtext>
+        <mo xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0212"
+           lspace="0.222em"
+           rspace="0.222em"
+          >
+         <?MarkedContent page="1" ?>+
+        </mo>
+        <msub xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0213"
+          >
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0170"
+           >
+          <?MarkedContent page="1" ?>H
+         </mtext>
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0171"
+           >
+          <?MarkedContent page="1" ?>2
+         </mtext>
+        </msub>
+        <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0172"
+          >
+         <?MarkedContent page="1" ?>O
+        </mtext>
+        <mo xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0214"
+           lspace="0.167em"
+           rspace="0.167em"
+          >
+         <mglyph xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0215"
+           >
+         </mglyph>
+        </mo>
+        <msub xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0216"
+          >
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0201"
+           >
+          <?MarkedContent page="1" ?>H
+         </mtext>
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0202"
+           >
+          <?MarkedContent page="1" ?>3
+         </mtext>
+        </msub>
+        <msup xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0217"
+          >
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0203"
+           >
+          <?MarkedContent page="1" ?>O
+         </mtext>
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0204"
+           >
+          <?MarkedContent page="1" ?>+
+         </mtext>
+        </msup>
+        <mo xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0218"
+           lspace="0.222em"
+           rspace="0.222em"
+          >
+         <?MarkedContent page="1" ?>+
+        </mo>
+        <msup xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0219"
+          >
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0205"
+           >
+          <?MarkedContent page="1" ?>OH
+         </mtext>
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0206"
+           >
+          <?MarkedContent page="1" ?>
+          <math xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0207"
+            >
+           <mo xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0208"
+              lspace="0"
+              rspace="0"
+             >
+            <?MarkedContent page="1" ?>−
+           </mo>
+          </math>
+          <?MarkedContent page="1" ?>
+         </mtext>
+        </msup>
+       </mstyle>
+      </math>
+      <?MarkedContent page="1" ?>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0220"
+         display="block"
+        >
+       <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0221"
+         >
+        <math xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0222"
+          >
+         <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0223"
+            displaystyle="true"
+            scriptlevel="0"
+           >
+          <msub xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0224"
+            >
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0167"
+             >
+            <?MarkedContent page="1" ?>H
+           </mtext>
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0168"
+             >
+            <?MarkedContent page="1" ?>2
+           </mtext>
+          </msub>
+          <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0169"
+            >
+           <?MarkedContent page="1" ?>O
+          </mtext>
+          <mo xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0225"
+             lspace="0.222em"
+             rspace="0.222em"
+            >
+          </mo>
+          <msub xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0226"
+            >
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0170"
+             >
+            <?MarkedContent page="1" ?>H
+           </mtext>
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0171"
+             >
+            <?MarkedContent page="1" ?>2
+           </mtext>
+          </msub>
+          <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0172"
+            >
+           <?MarkedContent page="1" ?>O
+          </mtext>
+          <mo xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0227"
+             lspace="0.167em"
+             rspace="0.167em"
+            >
+           <mglyph xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0228"
+             >
+           </mglyph>
+          </mo>
+          <msub xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0229"
+            >
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0201"
+             >
+            <?MarkedContent page="1" ?>H
+           </mtext>
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0202"
+             >
+            <?MarkedContent page="1" ?>3
+           </mtext>
+          </msub>
+          <msup xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0230"
+            >
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0203"
+             >
+            <?MarkedContent page="1" ?>O
+           </mtext>
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0204"
+             >
+            <?MarkedContent page="1" ?>+
+           </mtext>
+          </msup>
+          <mo xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0231"
+             lspace="0.222em"
+             rspace="0.222em"
+            >
+          </mo>
+          <msup xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0232"
+            >
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0205"
+             >
+            <?MarkedContent page="1" ?>OH
+           </mtext>
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0206"
+             >
+            <?MarkedContent page="1" ?>
+            <math xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0207"
+              >
+             <mo xmlns="http://www.w3.org/1998/Math/MathML"
+                id="ID.0208"
+                lspace="0"
+                rspace="0"
+               >
+              <?MarkedContent page="1" ?>−
+             </mo>
+            </math>
+            <?MarkedContent page="1" ?>
+           </mtext>
+          </msup>
+         </mstyle>
+        </math>
+       </mtext>
+      </math>
+     </Formula>
+    </text-unit>
+   </Sect>
+   <Sect xmlns="http://iso.org/pdf2/ssn"
+      id="ID.0233"
+     >
+    <section xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0234"
+       title="leftrightharpoonsfill 2.5em"
+       rolemaps-to="H1"
+      >
+     <section-number xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.0235"
+        rolemaps-to="Span"
+       >
+      <?MarkedContent page="1" ?>5 
+     </section-number>
+     <?MarkedContent page="1" ?>leftrightharpoonsfill 2.5em
+    </section>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0236"
+       rolemaps-to="Part"
+      >
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.0237"
+        title="equation*"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Block"
+       >
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0246"
+        >
+       <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0247"
+          width="-0.111em"
+         >
+       </mspace>
+       <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0245"
+         >
+       </mtext>
+       <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0248"
+          width="-0.111em"
+         >
+       </mspace>
+      </math>
+      <?MarkedContent page="1" ?>GGG
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0250"
+        >
+       <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0244"
+         >
+        <?MarkedContent page="1" ?>E
+       </mtext>
+       <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0251"
+          width="-0.333em"
+         >
+       </mspace>
+       <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0252"
+          width="-0.333em"
+         >
+       </mspace>
+       <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0249"
+         >
+        <?MarkedContent page="1" ?>G
+       </mtext>
+      </math>
+      <?MarkedContent page="1" ?>
+      <?MarkedContent page="1" ?> 
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0253"
+        >
+       <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0254"
+         >
+        <math xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0255"
+          >
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0244"
+           >
+          <?MarkedContent page="1" ?>E
+         </mtext>
+         <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0256"
+            width="-0.333em"
+           >
+         </mspace>
+         <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0257"
+            width="-0.333em"
+           >
+         </mspace>
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0249"
+           >
+          <?MarkedContent page="1" ?>G
+         </mtext>
+        </math>
+       </mtext>
+      </math>
+      <?MarkedContent page="1" ?>
+      <?MarkedContent page="1" ?> 
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0260"
+        >
+       <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0261"
+          width="-0.111em"
+         >
+       </mspace>
+       <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0259"
+         >
+       </mtext>
+       <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0262"
+          width="-0.111em"
+         >
+       </mspace>
+      </math>
+      <?MarkedContent page="1" ?>GGG
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0264"
+        >
+       <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0258"
+         >
+        <?MarkedContent page="1" ?>G
+       </mtext>
+       <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0265"
+          width="-0.333em"
+         >
+       </mspace>
+       <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0266"
+          width="-0.333em"
+         >
+       </mspace>
+       <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0263"
+         >
+        <?MarkedContent page="1" ?>C
+       </mtext>
+      </math>
+      <?MarkedContent page="1" ?>
+      <?MarkedContent page="1" ?>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0267"
+        >
+       <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0268"
+         >
+        <math xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0269"
+          >
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0258"
+           >
+          <?MarkedContent page="1" ?>G
+         </mtext>
+         <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0270"
+            width="-0.333em"
+           >
+         </mspace>
+         <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0271"
+            width="-0.333em"
+           >
+         </mspace>
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0263"
+           >
+          <?MarkedContent page="1" ?>C
+         </mtext>
+        </math>
+       </mtext>
+      </math>
+      <?MarkedContent page="1" ?>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0280"
+        >
+       <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0281"
+          displaystyle="true"
+          scriptlevel="0"
+         >
+        <msub xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0282"
+          >
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0238"
+           >
+          <?MarkedContent page="1" ?>H
+         </mtext>
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0239"
+           >
+          <?MarkedContent page="1" ?>2
+         </mtext>
+        </msub>
+        <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0240"
+          >
+         <?MarkedContent page="1" ?>O
+        </mtext>
+        <mo xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0283"
+           lspace="0.222em"
+           rspace="0.222em"
+          >
+         <?MarkedContent page="1" ?>+
+        </mo>
+        <msub xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0284"
+          >
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0241"
+           >
+          <?MarkedContent page="1" ?>H
+         </mtext>
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0242"
+           >
+          <?MarkedContent page="1" ?>2
+         </mtext>
+        </msub>
+        <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0243"
+          >
+         <?MarkedContent page="1" ?>O
+        </mtext>
+        <mo xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0285"
+           lspace="0.167em"
+           rspace="0.167em"
+          >
+         <mglyph xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0286"
+           >
+         </mglyph>
+        </mo>
+        <msub xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0287"
+          >
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0272"
+           >
+          <?MarkedContent page="1" ?>H
+         </mtext>
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0273"
+           >
+          <?MarkedContent page="1" ?>3
+         </mtext>
+        </msub>
+        <msup xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0288"
+          >
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0274"
+           >
+          <?MarkedContent page="1" ?>O
+         </mtext>
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0275"
+           >
+          <?MarkedContent page="1" ?>+
+         </mtext>
+        </msup>
+        <mo xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0289"
+           lspace="0.222em"
+           rspace="0.222em"
+          >
+         <?MarkedContent page="1" ?>+
+        </mo>
+        <msup xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0290"
+          >
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0276"
+           >
+          <?MarkedContent page="1" ?>OH
+         </mtext>
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0277"
+           >
+          <?MarkedContent page="1" ?>
+          <math xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0278"
+            >
+           <mo xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0279"
+              lspace="0"
+              rspace="0"
+             >
+            <?MarkedContent page="1" ?>−
+           </mo>
+          </math>
+          <?MarkedContent page="1" ?>
+         </mtext>
+        </msup>
+       </mstyle>
+      </math>
+      <?MarkedContent page="1" ?>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0291"
+         display="block"
+        >
+       <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0292"
+         >
+        <math xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0293"
+          >
+         <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0294"
+            displaystyle="true"
+            scriptlevel="0"
+           >
+          <msub xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0295"
+            >
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0238"
+             >
+            <?MarkedContent page="1" ?>H
+           </mtext>
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0239"
+             >
+            <?MarkedContent page="1" ?>2
+           </mtext>
+          </msub>
+          <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0240"
+            >
+           <?MarkedContent page="1" ?>O
+          </mtext>
+          <mo xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0296"
+             lspace="0.222em"
+             rspace="0.222em"
+            >
+          </mo>
+          <msub xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0297"
+            >
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0241"
+             >
+            <?MarkedContent page="1" ?>H
+           </mtext>
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0242"
+             >
+            <?MarkedContent page="1" ?>2
+           </mtext>
+          </msub>
+          <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0243"
+            >
+           <?MarkedContent page="1" ?>O
+          </mtext>
+          <mo xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0298"
+             lspace="0.167em"
+             rspace="0.167em"
+            >
+           <mglyph xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0299"
+             >
+           </mglyph>
+          </mo>
+          <msub xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0300"
+            >
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0272"
+             >
+            <?MarkedContent page="1" ?>H
+           </mtext>
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0273"
+             >
+            <?MarkedContent page="1" ?>3
+           </mtext>
+          </msub>
+          <msup xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0301"
+            >
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0274"
+             >
+            <?MarkedContent page="1" ?>O
+           </mtext>
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0275"
+             >
+            <?MarkedContent page="1" ?>+
+           </mtext>
+          </msup>
+          <mo xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0302"
+             lspace="0.222em"
+             rspace="0.222em"
+            >
+          </mo>
+          <msup xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0303"
+            >
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0276"
+             >
+            <?MarkedContent page="1" ?>OH
+           </mtext>
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0277"
+             >
+            <?MarkedContent page="1" ?>
+            <math xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0278"
+              >
+             <mo xmlns="http://www.w3.org/1998/Math/MathML"
+                id="ID.0279"
+                lspace="0"
+                rspace="0"
+               >
+              <?MarkedContent page="1" ?>−
+             </mo>
+            </math>
+            <?MarkedContent page="1" ?>
+           </mtext>
+          </msup>
+         </mstyle>
+        </math>
+       </mtext>
+      </math>
+     </Formula>
+    </text-unit>
+   </Sect>
+   <Sect xmlns="http://iso.org/pdf2/ssn"
+      id="ID.0304"
+     >
+    <section xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0305"
+       title="autorightleftharpoons"
+       rolemaps-to="H1"
+      >
+     <section-number xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.0306"
+        rolemaps-to="Span"
+       >
+      <?MarkedContent page="1" ?>6 
+     </section-number>
+     <?MarkedContent page="1" ?>autorightleftharpoons
+    </section>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0307"
+       rolemaps-to="Part"
+      >
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.0308"
+        title="equation*"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Block"
+       >
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0315"
+        >
+       <msub xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0316"
+         >
+        <mi xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0317"
+          >
+        </mi>
+        <mi xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0318"
+          >
+        </mi>
+       </msub>
+      </math>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0319"
+        >
+       <msub xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0320"
+         >
+        <mi xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0321"
+          >
+        </mi>
+        <mi xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0322"
+          >
+        </mi>
+       </msub>
+      </math>
+      <?MarkedContent page="1" ?> 
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0325"
+        >
+       <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0326"
+          width="-0.111em"
+         >
+       </mspace>
+       <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0324"
+         >
+       </mtext>
+       <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0327"
+          width="-0.111em"
+         >
+       </mspace>
+      </math>
+      <?MarkedContent page="1" ?>GGGGG
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0329"
+        >
+       <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0323"
+         >
+        <?MarkedContent page="1" ?>G
+       </mtext>
+       <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0330"
+          width="-0.333em"
+         >
+       </mspace>
+       <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0331"
+          width="-0.333em"
+         >
+       </mspace>
+       <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0328"
+         >
+        <?MarkedContent page="1" ?>B
+       </mtext>
+      </math>
+      <?MarkedContent page="1" ?>
+      <?MarkedContent page="1" ?>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0332"
+        >
+       <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0333"
+         >
+        <math xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0334"
+          >
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0323"
+           >
+          <?MarkedContent page="1" ?>G
+         </mtext>
+         <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0335"
+            width="-0.333em"
+           >
+         </mspace>
+         <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0336"
+            width="-0.333em"
+           >
+         </mspace>
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0328"
+           >
+          <?MarkedContent page="1" ?>B
+         </mtext>
+        </math>
+       </mtext>
+      </math>
+      <?MarkedContent page="1" ?>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0339"
+        >
+       <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0340"
+          width="-0.111em"
+         >
+       </mspace>
+       <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0338"
+         >
+       </mtext>
+       <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0341"
+          width="-0.111em"
+         >
+       </mspace>
+      </math>
+      <?MarkedContent page="1" ?>GGGGG
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0343"
+        >
+       <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0337"
+         >
+        <?MarkedContent page="1" ?>F
+       </mtext>
+       <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0344"
+          width="-0.333em"
+         >
+       </mspace>
+       <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0345"
+          width="-0.333em"
+         >
+       </mspace>
+       <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0342"
+         >
+        <?MarkedContent page="1" ?>G
+       </mtext>
+      </math>
+      <?MarkedContent page="1" ?>
+      <?MarkedContent page="1" ?> 
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0346"
+        >
+       <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0347"
+         >
+        <math xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0348"
+          >
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0337"
+           >
+          <?MarkedContent page="1" ?>F
+         </mtext>
+         <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0349"
+            width="-0.333em"
+           >
+         </mspace>
+         <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0350"
+            width="-0.333em"
+           >
+         </mspace>
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0342"
+           >
+          <?MarkedContent page="1" ?>G
+         </mtext>
+        </math>
+       </mtext>
+      </math>
+      <?MarkedContent page="1" ?>
+      <?MarkedContent page="1" ?>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0351"
+        >
+       <msub xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0352"
+         >
+        <mi xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0353"
+          >
+         <?MarkedContent page="1" ?>𝑘
+        </mi>
+        <mi xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0354"
+          >
+         <?MarkedContent page="1" ?>𝑎
+        </mi>
+       </msub>
+      </math>
+      <?MarkedContent page="1" ?>
+      <?MarkedContent page="1" ?>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0355"
+        >
+       <msub xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0356"
+         >
+        <mi xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0357"
+          >
+         <?MarkedContent page="1" ?>𝑘
+        </mi>
+        <mi xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0358"
+          >
+         <?MarkedContent page="1" ?>𝑏
+        </mi>
+       </msub>
+      </math>
+      <?MarkedContent page="1" ?>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0367"
+        >
+       <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0368"
+          displaystyle="true"
+          scriptlevel="0"
+         >
+        <msub xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0369"
+          >
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0309"
+           >
+          <?MarkedContent page="1" ?>H
+         </mtext>
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0310"
+           >
+          <?MarkedContent page="1" ?>2
+         </mtext>
+        </msub>
+        <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0311"
+          >
+         <?MarkedContent page="1" ?>O
+        </mtext>
+        <mo xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0370"
+           lspace="0.222em"
+           rspace="0.222em"
+          >
+         <?MarkedContent page="1" ?>+
+        </mo>
+        <msub xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0371"
+          >
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0312"
+           >
+          <?MarkedContent page="1" ?>H
+         </mtext>
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0313"
+           >
+          <?MarkedContent page="1" ?>2
+         </mtext>
+        </msub>
+        <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0314"
+          >
+         <?MarkedContent page="1" ?>O
+        </mtext>
+        <munderover xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0372"
+          >
+         <mo xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0373"
+            lspace="0.167em"
+            movablelimits="false"
+            rspace="0.167em"
+           >
+          <mglyph xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0374"
+            >
+          </mglyph>
+         </mo>
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0375"
+           >
+          <math xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0376"
+            >
+           <msub xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0377"
+             >
+            <mi xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0378"
+              >
+            </mi>
+            <mi xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0379"
+              >
+            </mi>
+           </msub>
+          </math>
+         </mtext>
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0380"
+           >
+          <math xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0381"
+            >
+           <msub xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0382"
+             >
+            <mi xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0383"
+              >
+            </mi>
+            <mi xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0384"
+              >
+            </mi>
+           </msub>
+          </math>
+         </mtext>
+        </munderover>
+        <msub xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0385"
+          >
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0359"
+           >
+          <?MarkedContent page="1" ?>H
+         </mtext>
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0360"
+           >
+          <?MarkedContent page="1" ?>3
+         </mtext>
+        </msub>
+        <msup xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0386"
+          >
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0361"
+           >
+          <?MarkedContent page="1" ?>O
+         </mtext>
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0362"
+           >
+          <?MarkedContent page="1" ?>+
+         </mtext>
+        </msup>
+        <mo xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0387"
+           lspace="0.222em"
+           rspace="0.222em"
+          >
+         <?MarkedContent page="1" ?>+
+        </mo>
+        <msup xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0388"
+          >
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0363"
+           >
+          <?MarkedContent page="1" ?>OH
+         </mtext>
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0364"
+           >
+          <?MarkedContent page="1" ?>
+          <math xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0365"
+            >
+           <mo xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0366"
+              lspace="0"
+              rspace="0"
+             >
+            <?MarkedContent page="1" ?>−
+           </mo>
+          </math>
+          <?MarkedContent page="1" ?>
+         </mtext>
+        </msup>
+       </mstyle>
+      </math>
+      <?MarkedContent page="1" ?>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0389"
+         display="block"
+        >
+       <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0390"
+         >
+        <math xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0391"
+          >
+         <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0392"
+            displaystyle="true"
+            scriptlevel="0"
+           >
+          <msub xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0393"
+            >
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0309"
+             >
+            <?MarkedContent page="1" ?>H
+           </mtext>
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0310"
+             >
+            <?MarkedContent page="1" ?>2
+           </mtext>
+          </msub>
+          <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0311"
+            >
+           <?MarkedContent page="1" ?>O
+          </mtext>
+          <mo xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0394"
+             lspace="0.222em"
+             rspace="0.222em"
+            >
+          </mo>
+          <msub xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0395"
+            >
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0312"
+             >
+            <?MarkedContent page="1" ?>H
+           </mtext>
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0313"
+             >
+            <?MarkedContent page="1" ?>2
+           </mtext>
+          </msub>
+          <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0314"
+            >
+           <?MarkedContent page="1" ?>O
+          </mtext>
+          <munderover xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0396"
+            >
+           <mo xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0397"
+              lspace="0.167em"
+              movablelimits="false"
+              rspace="0.167em"
+             >
+            <mglyph xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0398"
+              >
+            </mglyph>
+           </mo>
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0399"
+             >
+            <math xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0400"
+              >
+             <msub xmlns="http://www.w3.org/1998/Math/MathML"
+                id="ID.0401"
+               >
+              <mi xmlns="http://www.w3.org/1998/Math/MathML"
+                 id="ID.0402"
+                >
+              </mi>
+              <mi xmlns="http://www.w3.org/1998/Math/MathML"
+                 id="ID.0403"
+                >
+              </mi>
+             </msub>
+            </math>
+           </mtext>
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0404"
+             >
+            <math xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0405"
+              >
+             <msub xmlns="http://www.w3.org/1998/Math/MathML"
+                id="ID.0406"
+               >
+              <mi xmlns="http://www.w3.org/1998/Math/MathML"
+                 id="ID.0407"
+                >
+              </mi>
+              <mi xmlns="http://www.w3.org/1998/Math/MathML"
+                 id="ID.0408"
+                >
+              </mi>
+             </msub>
+            </math>
+           </mtext>
+          </munderover>
+          <msub xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0409"
+            >
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0359"
+             >
+            <?MarkedContent page="1" ?>H
+           </mtext>
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0360"
+             >
+            <?MarkedContent page="1" ?>3
+           </mtext>
+          </msub>
+          <msup xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0410"
+            >
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0361"
+             >
+            <?MarkedContent page="1" ?>O
+           </mtext>
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0362"
+             >
+            <?MarkedContent page="1" ?>+
+           </mtext>
+          </msup>
+          <mo xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0411"
+             lspace="0.222em"
+             rspace="0.222em"
+            >
+          </mo>
+          <msup xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0412"
+            >
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0363"
+             >
+            <?MarkedContent page="1" ?>OH
+           </mtext>
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0364"
+             >
+            <?MarkedContent page="1" ?>
+            <math xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0365"
+              >
+             <mo xmlns="http://www.w3.org/1998/Math/MathML"
+                id="ID.0366"
+                lspace="0"
+                rspace="0"
+               >
+              <?MarkedContent page="1" ?>−
+             </mo>
+            </math>
+            <?MarkedContent page="1" ?>
+           </mtext>
+          </msup>
+         </mstyle>
+        </math>
+       </mtext>
+      </math>
+     </Formula>
+    </text-unit>
+   </Sect>
+   <Sect xmlns="http://iso.org/pdf2/ssn"
+      id="ID.0413"
+     >
+    <section xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0414"
+       title="autoleftrightharpoons"
+       rolemaps-to="H1"
+      >
+     <section-number xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.0415"
+        rolemaps-to="Span"
+       >
+      <?MarkedContent page="1" ?>7 
+     </section-number>
+     <?MarkedContent page="1" ?>autoleftrightharpoons
+    </section>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0416"
+       rolemaps-to="Part"
+      >
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.0417"
+        title="equation*"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Block"
+       >
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0424"
+        >
+       <msub xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0425"
+         >
+        <mi xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0426"
+          >
+        </mi>
+        <mi xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0427"
+          >
+        </mi>
+       </msub>
+      </math>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0428"
+        >
+       <msub xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0429"
+         >
+        <mi xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0430"
+          >
+        </mi>
+        <mi xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0431"
+          >
+        </mi>
+       </msub>
+      </math>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0434"
+        >
+       <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0435"
+          width="-0.111em"
+         >
+       </mspace>
+       <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0433"
+         >
+       </mtext>
+       <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0436"
+          width="-0.111em"
+         >
+       </mspace>
+      </math>
+      <?MarkedContent page="1" ?>GGGGG
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0438"
+        >
+       <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0432"
+         >
+        <?MarkedContent page="1" ?>E
+       </mtext>
+       <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0439"
+          width="-0.333em"
+         >
+       </mspace>
+       <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0440"
+          width="-0.333em"
+         >
+       </mspace>
+       <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0437"
+         >
+        <?MarkedContent page="1" ?>G
+       </mtext>
+      </math>
+      <?MarkedContent page="1" ?>
+      <?MarkedContent page="1" ?> 
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0441"
+        >
+       <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0442"
+         >
+        <math xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0443"
+          >
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0432"
+           >
+          <?MarkedContent page="1" ?>E
+         </mtext>
+         <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0444"
+            width="-0.333em"
+           >
+         </mspace>
+         <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0445"
+            width="-0.333em"
+           >
+         </mspace>
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0437"
+           >
+          <?MarkedContent page="1" ?>G
+         </mtext>
+        </math>
+       </mtext>
+      </math>
+      <?MarkedContent page="1" ?>
+      <?MarkedContent page="1" ?> 
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0448"
+        >
+       <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0449"
+          width="-0.111em"
+         >
+       </mspace>
+       <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0447"
+         >
+       </mtext>
+       <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0450"
+          width="-0.111em"
+         >
+       </mspace>
+      </math>
+      <?MarkedContent page="1" ?>GGGGG
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0452"
+        >
+       <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0446"
+         >
+        <?MarkedContent page="1" ?>G
+       </mtext>
+       <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0453"
+          width="-0.333em"
+         >
+       </mspace>
+       <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0454"
+          width="-0.333em"
+         >
+       </mspace>
+       <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0451"
+         >
+        <?MarkedContent page="1" ?>C
+       </mtext>
+      </math>
+      <?MarkedContent page="1" ?>
+      <?MarkedContent page="1" ?>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0455"
+        >
+       <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0456"
+         >
+        <math xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0457"
+          >
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0446"
+           >
+          <?MarkedContent page="1" ?>G
+         </mtext>
+         <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0458"
+            width="-0.333em"
+           >
+         </mspace>
+         <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0459"
+            width="-0.333em"
+           >
+         </mspace>
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0451"
+           >
+          <?MarkedContent page="1" ?>C
+         </mtext>
+        </math>
+       </mtext>
+      </math>
+      <?MarkedContent page="1" ?>
+      <?MarkedContent page="1" ?>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0460"
+        >
+       <msub xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0461"
+         >
+        <mi xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0462"
+          >
+         <?MarkedContent page="1" ?>𝑘
+        </mi>
+        <mi xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0463"
+          >
+         <?MarkedContent page="1" ?>𝑎
+        </mi>
+       </msub>
+      </math>
+      <?MarkedContent page="1" ?>
+      <?MarkedContent page="1" ?>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0464"
+        >
+       <msub xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0465"
+         >
+        <mi xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0466"
+          >
+         <?MarkedContent page="1" ?>𝑘
+        </mi>
+        <mi xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0467"
+          >
+         <?MarkedContent page="1" ?>𝑏
+        </mi>
+       </msub>
+      </math>
+      <?MarkedContent page="1" ?>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0476"
+        >
+       <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0477"
+          displaystyle="true"
+          scriptlevel="0"
+         >
+        <msub xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0478"
+          >
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0418"
+           >
+          <?MarkedContent page="1" ?>H
+         </mtext>
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0419"
+           >
+          <?MarkedContent page="1" ?>2
+         </mtext>
+        </msub>
+        <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0420"
+          >
+         <?MarkedContent page="1" ?>O
+        </mtext>
+        <mo xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0479"
+           lspace="0.222em"
+           rspace="0.222em"
+          >
+         <?MarkedContent page="1" ?>+
+        </mo>
+        <msub xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0480"
+          >
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0421"
+           >
+          <?MarkedContent page="1" ?>H
+         </mtext>
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0422"
+           >
+          <?MarkedContent page="1" ?>2
+         </mtext>
+        </msub>
+        <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0423"
+          >
+         <?MarkedContent page="1" ?>O
+        </mtext>
+        <munderover xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0481"
+          >
+         <mo xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0482"
+            lspace="0.167em"
+            movablelimits="false"
+            rspace="0.167em"
+           >
+          <mglyph xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0483"
+            >
+          </mglyph>
+         </mo>
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0484"
+           >
+          <math xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0485"
+            >
+           <msub xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0486"
+             >
+            <mi xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0487"
+              >
+            </mi>
+            <mi xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0488"
+              >
+            </mi>
+           </msub>
+          </math>
+         </mtext>
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0489"
+           >
+          <math xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0490"
+            >
+           <msub xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0491"
+             >
+            <mi xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0492"
+              >
+            </mi>
+            <mi xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0493"
+              >
+            </mi>
+           </msub>
+          </math>
+         </mtext>
+        </munderover>
+        <msub xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0494"
+          >
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0468"
+           >
+          <?MarkedContent page="1" ?>H
+         </mtext>
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0469"
+           >
+          <?MarkedContent page="1" ?>3
+         </mtext>
+        </msub>
+        <msup xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0495"
+          >
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0470"
+           >
+          <?MarkedContent page="1" ?>O
+         </mtext>
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0471"
+           >
+          <?MarkedContent page="1" ?>+
+         </mtext>
+        </msup>
+        <mo xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0496"
+           lspace="0.222em"
+           rspace="0.222em"
+          >
+         <?MarkedContent page="1" ?>+
+        </mo>
+        <msup xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0497"
+          >
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0472"
+           >
+          <?MarkedContent page="1" ?>OH
+         </mtext>
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0473"
+           >
+          <?MarkedContent page="1" ?>
+          <math xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0474"
+            >
+           <mo xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0475"
+              lspace="0"
+              rspace="0"
+             >
+            <?MarkedContent page="1" ?>−
+           </mo>
+          </math>
+          <?MarkedContent page="1" ?>
+         </mtext>
+        </msup>
+       </mstyle>
+      </math>
+      <?MarkedContent page="1" ?>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0498"
+         display="block"
+        >
+       <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0499"
+         >
+        <math xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0500"
+          >
+         <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0501"
+            displaystyle="true"
+            scriptlevel="0"
+           >
+          <msub xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0502"
+            >
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0418"
+             >
+            <?MarkedContent page="1" ?>H
+           </mtext>
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0419"
+             >
+            <?MarkedContent page="1" ?>2
+           </mtext>
+          </msub>
+          <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0420"
+            >
+           <?MarkedContent page="1" ?>O
+          </mtext>
+          <mo xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0503"
+             lspace="0.222em"
+             rspace="0.222em"
+            >
+          </mo>
+          <msub xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0504"
+            >
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0421"
+             >
+            <?MarkedContent page="1" ?>H
+           </mtext>
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0422"
+             >
+            <?MarkedContent page="1" ?>2
+           </mtext>
+          </msub>
+          <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0423"
+            >
+           <?MarkedContent page="1" ?>O
+          </mtext>
+          <munderover xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0505"
+            >
+           <mo xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0506"
+              lspace="0.167em"
+              movablelimits="false"
+              rspace="0.167em"
+             >
+            <mglyph xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0507"
+              >
+            </mglyph>
+           </mo>
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0508"
+             >
+            <math xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0509"
+              >
+             <msub xmlns="http://www.w3.org/1998/Math/MathML"
+                id="ID.0510"
+               >
+              <mi xmlns="http://www.w3.org/1998/Math/MathML"
+                 id="ID.0511"
+                >
+              </mi>
+              <mi xmlns="http://www.w3.org/1998/Math/MathML"
+                 id="ID.0512"
+                >
+              </mi>
+             </msub>
+            </math>
+           </mtext>
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0513"
+             >
+            <math xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0514"
+              >
+             <msub xmlns="http://www.w3.org/1998/Math/MathML"
+                id="ID.0515"
+               >
+              <mi xmlns="http://www.w3.org/1998/Math/MathML"
+                 id="ID.0516"
+                >
+              </mi>
+              <mi xmlns="http://www.w3.org/1998/Math/MathML"
+                 id="ID.0517"
+                >
+              </mi>
+             </msub>
+            </math>
+           </mtext>
+          </munderover>
+          <msub xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0518"
+            >
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0468"
+             >
+            <?MarkedContent page="1" ?>H
+           </mtext>
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0469"
+             >
+            <?MarkedContent page="1" ?>3
+           </mtext>
+          </msub>
+          <msup xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0519"
+            >
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0470"
+             >
+            <?MarkedContent page="1" ?>O
+           </mtext>
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0471"
+             >
+            <?MarkedContent page="1" ?>+
+           </mtext>
+          </msup>
+          <mo xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0520"
+             lspace="0.222em"
+             rspace="0.222em"
+            >
+          </mo>
+          <msup xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0521"
+            >
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0472"
+             >
+            <?MarkedContent page="1" ?>OH
+           </mtext>
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0473"
+             >
+            <?MarkedContent page="1" ?>
+            <math xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0474"
+              >
+             <mo xmlns="http://www.w3.org/1998/Math/MathML"
+                id="ID.0475"
+                lspace="0"
+                rspace="0"
+               >
+              <?MarkedContent page="1" ?>−
+             </mo>
+            </math>
+            <?MarkedContent page="1" ?>
+           </mtext>
+          </msup>
+         </mstyle>
+        </math>
+       </mtext>
+      </math>
+     </Formula>
+    </text-unit>
+   </Sect>
+   <Sect xmlns="http://iso.org/pdf2/ssn"
+      id="ID.0522"
+     >
+    <section xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0523"
+       title="autorightarrow"
+       rolemaps-to="H1"
+      >
+     <section-number xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.0524"
+        rolemaps-to="Span"
+       >
+      <?MarkedContent page="2" ?>8 
+     </section-number>
+     <?MarkedContent page="2" ?>autorightarrow
+    </section>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0525"
+       rolemaps-to="Part"
+      >
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.0526"
+        title="equation*"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Block"
+       >
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0533"
+        >
+       <msub xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0534"
+         >
+        <mi xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0535"
+          >
+        </mi>
+        <mi xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0536"
+          >
+        </mi>
+       </msub>
+      </math>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0537"
+        >
+       <msub xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0538"
+         >
+        <mi xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0539"
+          >
+        </mi>
+        <mi xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0540"
+          >
+        </mi>
+       </msub>
+      </math>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0543"
+        >
+       <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0544"
+          width="-0.111em"
+         >
+       </mspace>
+       <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0542"
+         >
+       </mtext>
+       <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0545"
+          width="-0.111em"
+         >
+       </mspace>
+      </math>
+      <?MarkedContent page="2" ?>GGGGG
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0547"
+        >
+       <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0541"
+         >
+        <?MarkedContent page="2" ?>G
+       </mtext>
+       <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0548"
+          width="-0.333em"
+         >
+       </mspace>
+       <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0549"
+          width="-0.333em"
+         >
+       </mspace>
+       <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0546"
+         >
+        <?MarkedContent page="2" ?>A
+       </mtext>
+      </math>
+      <?MarkedContent page="2" ?>
+      <?MarkedContent page="2" ?>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0550"
+        >
+       <msub xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0551"
+         >
+        <mi xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0552"
+          >
+         <?MarkedContent page="2" ?>𝑘
+        </mi>
+        <mi xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0553"
+          >
+         <?MarkedContent page="2" ?>𝑎
+        </mi>
+       </msub>
+      </math>
+      <?MarkedContent page="2" ?>
+      <?MarkedContent page="2" ?>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0554"
+        >
+       <msub xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0555"
+         >
+        <mi xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0556"
+          >
+         <?MarkedContent page="2" ?>𝑘
+        </mi>
+        <mi xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0557"
+          >
+         <?MarkedContent page="2" ?>𝑏
+        </mi>
+       </msub>
+      </math>
+      <?MarkedContent page="2" ?>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0566"
+        >
+       <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0567"
+          displaystyle="true"
+          scriptlevel="0"
+         >
+        <msub xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0568"
+          >
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0527"
+           >
+          <?MarkedContent page="2" ?>H
+         </mtext>
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0528"
+           >
+          <?MarkedContent page="2" ?>2
+         </mtext>
+        </msub>
+        <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0529"
+          >
+         <?MarkedContent page="2" ?>O
+        </mtext>
+        <mo xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0569"
+           lspace="0.222em"
+           rspace="0.222em"
+          >
+         <?MarkedContent page="2" ?>+
+        </mo>
+        <msub xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0570"
+          >
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0530"
+           >
+          <?MarkedContent page="2" ?>H
+         </mtext>
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0531"
+           >
+          <?MarkedContent page="2" ?>2
+         </mtext>
+        </msub>
+        <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0532"
+          >
+         <?MarkedContent page="2" ?>O
+        </mtext>
+        <munderover xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0571"
+          >
+         <mi xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0572"
+           >
+          <math xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0573"
+            >
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0541"
+             >
+            <?MarkedContent page="2" ?>G
+           </mtext>
+           <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0574"
+              width="-0.333em"
+             >
+           </mspace>
+           <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0575"
+              width="-0.333em"
+             >
+           </mspace>
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0546"
+             >
+            <?MarkedContent page="2" ?>A
+           </mtext>
+          </math>
+         </mi>
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0576"
+           >
+          <math xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0577"
+            >
+           <msub xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0578"
+             >
+            <mi xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0579"
+              >
+            </mi>
+            <mi xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0580"
+              >
+            </mi>
+           </msub>
+          </math>
+         </mtext>
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0581"
+           >
+          <math xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0582"
+            >
+           <msub xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0583"
+             >
+            <mi xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0584"
+              >
+            </mi>
+            <mi xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0585"
+              >
+            </mi>
+           </msub>
+          </math>
+         </mtext>
+        </munderover>
+        <msub xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0586"
+          >
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0558"
+           >
+          <?MarkedContent page="2" ?>H
+         </mtext>
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0559"
+           >
+          <?MarkedContent page="2" ?>3
+         </mtext>
+        </msub>
+        <msup xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0587"
+          >
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0560"
+           >
+          <?MarkedContent page="2" ?>O
+         </mtext>
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0561"
+           >
+          <?MarkedContent page="2" ?>+
+         </mtext>
+        </msup>
+        <mo xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0588"
+           lspace="0.222em"
+           rspace="0.222em"
+          >
+         <?MarkedContent page="2" ?>+
+        </mo>
+        <msup xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0589"
+          >
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0562"
+           >
+          <?MarkedContent page="2" ?>OH
+         </mtext>
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0563"
+           >
+          <?MarkedContent page="2" ?>
+          <math xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0564"
+            >
+           <mo xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0565"
+              lspace="0"
+              rspace="0"
+             >
+            <?MarkedContent page="2" ?>−
+           </mo>
+          </math>
+          <?MarkedContent page="2" ?>
+         </mtext>
+        </msup>
+       </mstyle>
+      </math>
+      <?MarkedContent page="2" ?>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0590"
+         display="block"
+        >
+       <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0591"
+         >
+        <math xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0592"
+          >
+         <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0593"
+            displaystyle="true"
+            scriptlevel="0"
+           >
+          <msub xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0594"
+            >
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0527"
+             >
+            <?MarkedContent page="2" ?>H
+           </mtext>
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0528"
+             >
+            <?MarkedContent page="2" ?>2
+           </mtext>
+          </msub>
+          <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0529"
+            >
+           <?MarkedContent page="2" ?>O
+          </mtext>
+          <mo xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0595"
+             lspace="0.222em"
+             rspace="0.222em"
+            >
+          </mo>
+          <msub xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0596"
+            >
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0530"
+             >
+            <?MarkedContent page="2" ?>H
+           </mtext>
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0531"
+             >
+            <?MarkedContent page="2" ?>2
+           </mtext>
+          </msub>
+          <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0532"
+            >
+           <?MarkedContent page="2" ?>O
+          </mtext>
+          <munderover xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0597"
+            >
+           <mi xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0598"
+             >
+            <math xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0599"
+              >
+             <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+                id="ID.0541"
+               >
+              <?MarkedContent page="2" ?>G
+             </mtext>
+             <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+                id="ID.0600"
+                width="-0.333em"
+               >
+             </mspace>
+             <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+                id="ID.0601"
+                width="-0.333em"
+               >
+             </mspace>
+             <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+                id="ID.0546"
+               >
+              <?MarkedContent page="2" ?>A
+             </mtext>
+            </math>
+           </mi>
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0602"
+             >
+            <math xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0603"
+              >
+             <msub xmlns="http://www.w3.org/1998/Math/MathML"
+                id="ID.0604"
+               >
+              <mi xmlns="http://www.w3.org/1998/Math/MathML"
+                 id="ID.0605"
+                >
+              </mi>
+              <mi xmlns="http://www.w3.org/1998/Math/MathML"
+                 id="ID.0606"
+                >
+              </mi>
+             </msub>
+            </math>
+           </mtext>
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0607"
+             >
+            <math xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0608"
+              >
+             <msub xmlns="http://www.w3.org/1998/Math/MathML"
+                id="ID.0609"
+               >
+              <mi xmlns="http://www.w3.org/1998/Math/MathML"
+                 id="ID.0610"
+                >
+              </mi>
+              <mi xmlns="http://www.w3.org/1998/Math/MathML"
+                 id="ID.0611"
+                >
+              </mi>
+             </msub>
+            </math>
+           </mtext>
+          </munderover>
+          <msub xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0612"
+            >
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0558"
+             >
+            <?MarkedContent page="2" ?>H
+           </mtext>
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0559"
+             >
+            <?MarkedContent page="2" ?>3
+           </mtext>
+          </msub>
+          <msup xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0613"
+            >
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0560"
+             >
+            <?MarkedContent page="2" ?>O
+           </mtext>
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0561"
+             >
+            <?MarkedContent page="2" ?>+
+           </mtext>
+          </msup>
+          <mo xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0614"
+             lspace="0.222em"
+             rspace="0.222em"
+            >
+          </mo>
+          <msup xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0615"
+            >
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0562"
+             >
+            <?MarkedContent page="2" ?>OH
+           </mtext>
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0563"
+             >
+            <?MarkedContent page="2" ?>
+            <math xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0564"
+              >
+             <mo xmlns="http://www.w3.org/1998/Math/MathML"
+                id="ID.0565"
+                lspace="0"
+                rspace="0"
+               >
+              <?MarkedContent page="2" ?>−
+             </mo>
+            </math>
+            <?MarkedContent page="2" ?>
+           </mtext>
+          </msup>
+         </mstyle>
+        </math>
+       </mtext>
+      </math>
+     </Formula>
+    </text-unit>
+   </Sect>
+   <Sect xmlns="http://iso.org/pdf2/ssn"
+      id="ID.0616"
+     >
+    <section xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0617"
+       title="autoleftarrow"
+       rolemaps-to="H1"
+      >
+     <section-number xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.0618"
+        rolemaps-to="Span"
+       >
+      <?MarkedContent page="2" ?>9 
+     </section-number>
+     <?MarkedContent page="2" ?>autoleftarrow
+    </section>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0619"
+       rolemaps-to="Part"
+      >
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.0620"
+        title="equation*"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Block"
+       >
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0627"
+        >
+       <msub xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0628"
+         >
+        <mi xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0629"
+          >
+        </mi>
+        <mi xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0630"
+          >
+        </mi>
+       </msub>
+      </math>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0631"
+        >
+       <msub xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0632"
+         >
+        <mi xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0633"
+          >
+        </mi>
+        <mi xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0634"
+          >
+        </mi>
+       </msub>
+      </math>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0637"
+        >
+       <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0638"
+          width="-0.111em"
+         >
+       </mspace>
+       <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0636"
+         >
+       </mtext>
+       <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0639"
+          width="-0.111em"
+         >
+       </mspace>
+      </math>
+      <?MarkedContent page="2" ?>GGGGG
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0641"
+        >
+       <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0635"
+         >
+        <?MarkedContent page="2" ?>D
+       </mtext>
+       <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0642"
+          width="-0.333em"
+         >
+       </mspace>
+       <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0643"
+          width="-0.333em"
+         >
+       </mspace>
+       <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0640"
+         >
+        <?MarkedContent page="2" ?>G
+       </mtext>
+      </math>
+      <?MarkedContent page="2" ?>
+      <?MarkedContent page="2" ?>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0644"
+        >
+       <msub xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0645"
+         >
+        <mi xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0646"
+          >
+         <?MarkedContent page="2" ?>𝑘
+        </mi>
+        <mi xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0647"
+          >
+         <?MarkedContent page="2" ?>𝑎
+        </mi>
+       </msub>
+      </math>
+      <?MarkedContent page="2" ?>
+      <?MarkedContent page="2" ?>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0648"
+        >
+       <msub xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0649"
+         >
+        <mi xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0650"
+          >
+         <?MarkedContent page="2" ?>𝑘
+        </mi>
+        <mi xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0651"
+          >
+         <?MarkedContent page="2" ?>𝑏
+        </mi>
+       </msub>
+      </math>
+      <?MarkedContent page="2" ?>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0660"
+        >
+       <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0661"
+          displaystyle="true"
+          scriptlevel="0"
+         >
+        <msub xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0662"
+          >
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0621"
+           >
+          <?MarkedContent page="2" ?>H
+         </mtext>
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0622"
+           >
+          <?MarkedContent page="2" ?>2
+         </mtext>
+        </msub>
+        <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0623"
+          >
+         <?MarkedContent page="2" ?>O
+        </mtext>
+        <mo xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0663"
+           lspace="0.222em"
+           rspace="0.222em"
+          >
+         <?MarkedContent page="2" ?>+
+        </mo>
+        <msub xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0664"
+          >
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0624"
+           >
+          <?MarkedContent page="2" ?>H
+         </mtext>
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0625"
+           >
+          <?MarkedContent page="2" ?>2
+         </mtext>
+        </msub>
+        <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0626"
+          >
+         <?MarkedContent page="2" ?>O
+        </mtext>
+        <munderover xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0665"
+          >
+         <mi xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0666"
+           >
+          <math xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0667"
+            >
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0635"
+             >
+            <?MarkedContent page="2" ?>D
+           </mtext>
+           <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0668"
+              width="-0.333em"
+             >
+           </mspace>
+           <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0669"
+              width="-0.333em"
+             >
+           </mspace>
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0640"
+             >
+            <?MarkedContent page="2" ?>G
+           </mtext>
+          </math>
+         </mi>
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0670"
+           >
+          <math xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0671"
+            >
+           <msub xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0672"
+             >
+            <mi xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0673"
+              >
+            </mi>
+            <mi xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0674"
+              >
+            </mi>
+           </msub>
+          </math>
+         </mtext>
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0675"
+           >
+          <math xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0676"
+            >
+           <msub xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0677"
+             >
+            <mi xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0678"
+              >
+            </mi>
+            <mi xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0679"
+              >
+            </mi>
+           </msub>
+          </math>
+         </mtext>
+        </munderover>
+        <msub xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0680"
+          >
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0652"
+           >
+          <?MarkedContent page="2" ?>H
+         </mtext>
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0653"
+           >
+          <?MarkedContent page="2" ?>3
+         </mtext>
+        </msub>
+        <msup xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0681"
+          >
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0654"
+           >
+          <?MarkedContent page="2" ?>O
+         </mtext>
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0655"
+           >
+          <?MarkedContent page="2" ?>+
+         </mtext>
+        </msup>
+        <mo xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0682"
+           lspace="0.222em"
+           rspace="0.222em"
+          >
+         <?MarkedContent page="2" ?>+
+        </mo>
+        <msup xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0683"
+          >
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0656"
+           >
+          <?MarkedContent page="2" ?>OH
+         </mtext>
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0657"
+           >
+          <?MarkedContent page="2" ?>
+          <math xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0658"
+            >
+           <mo xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0659"
+              lspace="0"
+              rspace="0"
+             >
+            <?MarkedContent page="2" ?>−
+           </mo>
+          </math>
+          <?MarkedContent page="2" ?>
+         </mtext>
+        </msup>
+       </mstyle>
+      </math>
+      <?MarkedContent page="2" ?>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0684"
+         display="block"
+        >
+       <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0685"
+         >
+        <math xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0686"
+          >
+         <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0687"
+            displaystyle="true"
+            scriptlevel="0"
+           >
+          <msub xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0688"
+            >
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0621"
+             >
+            <?MarkedContent page="2" ?>H
+           </mtext>
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0622"
+             >
+            <?MarkedContent page="2" ?>2
+           </mtext>
+          </msub>
+          <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0623"
+            >
+           <?MarkedContent page="2" ?>O
+          </mtext>
+          <mo xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0689"
+             lspace="0.222em"
+             rspace="0.222em"
+            >
+          </mo>
+          <msub xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0690"
+            >
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0624"
+             >
+            <?MarkedContent page="2" ?>H
+           </mtext>
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0625"
+             >
+            <?MarkedContent page="2" ?>2
+           </mtext>
+          </msub>
+          <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0626"
+            >
+           <?MarkedContent page="2" ?>O
+          </mtext>
+          <munderover xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0691"
+            >
+           <mi xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0692"
+             >
+            <math xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0693"
+              >
+             <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+                id="ID.0635"
+               >
+              <?MarkedContent page="2" ?>D
+             </mtext>
+             <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+                id="ID.0694"
+                width="-0.333em"
+               >
+             </mspace>
+             <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+                id="ID.0695"
+                width="-0.333em"
+               >
+             </mspace>
+             <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+                id="ID.0640"
+               >
+              <?MarkedContent page="2" ?>G
+             </mtext>
+            </math>
+           </mi>
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0696"
+             >
+            <math xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0697"
+              >
+             <msub xmlns="http://www.w3.org/1998/Math/MathML"
+                id="ID.0698"
+               >
+              <mi xmlns="http://www.w3.org/1998/Math/MathML"
+                 id="ID.0699"
+                >
+              </mi>
+              <mi xmlns="http://www.w3.org/1998/Math/MathML"
+                 id="ID.0700"
+                >
+              </mi>
+             </msub>
+            </math>
+           </mtext>
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0701"
+             >
+            <math xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0702"
+              >
+             <msub xmlns="http://www.w3.org/1998/Math/MathML"
+                id="ID.0703"
+               >
+              <mi xmlns="http://www.w3.org/1998/Math/MathML"
+                 id="ID.0704"
+                >
+              </mi>
+              <mi xmlns="http://www.w3.org/1998/Math/MathML"
+                 id="ID.0705"
+                >
+              </mi>
+             </msub>
+            </math>
+           </mtext>
+          </munderover>
+          <msub xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0706"
+            >
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0652"
+             >
+            <?MarkedContent page="2" ?>H
+           </mtext>
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0653"
+             >
+            <?MarkedContent page="2" ?>3
+           </mtext>
+          </msub>
+          <msup xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0707"
+            >
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0654"
+             >
+            <?MarkedContent page="2" ?>O
+           </mtext>
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0655"
+             >
+            <?MarkedContent page="2" ?>+
+           </mtext>
+          </msup>
+          <mo xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0708"
+             lspace="0.222em"
+             rspace="0.222em"
+            >
+          </mo>
+          <msup xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0709"
+            >
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0656"
+             >
+            <?MarkedContent page="2" ?>OH
+           </mtext>
+           <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0657"
+             >
+            <?MarkedContent page="2" ?>
+            <math xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0658"
+              >
+             <mo xmlns="http://www.w3.org/1998/Math/MathML"
+                id="ID.0659"
+                lspace="0"
+                rspace="0"
+               >
+              <?MarkedContent page="2" ?>−
+             </mo>
+            </math>
+            <?MarkedContent page="2" ?>
+           </mtext>
+          </msup>
+         </mstyle>
+        </math>
+       </mtext>
+      </math>
+     </Formula>
+    </text-unit>
+   </Sect>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-partial-mathml/chemarrow/chemarrow-02-BAD.tex
+++ b/tagging-status/testfiles-partial-mathml/chemarrow/chemarrow-02-BAD.tex
@@ -1,0 +1,92 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on,
+    tagging-setup={math/setup=mathml-SE},
+  }
+\documentclass[fleqn,12pt,a4paper]{article}
+
+\ifdefined\Uchar
+  \usepackage{unicode-math}
+\fi
+\usepackage{amsmath,chemarrow}
+\begin{document}
+
+\newcommand{\aqua}{\ensuremath{\text{H}_{\text{2}}\text{O}}}
+\newcommand{\acid}{\ensuremath{\text{H}_{\text{3}}\text{O}^{\text{+}}}}
+\newcommand{\base}{\ensuremath{\text{OH}^{\text{$-$}}}}
+
+\section{chemarrow}
+
+
+\begin{displaymath}
+\aqua + \aqua\ \chemarrow\ \acid + \base
+\end{displaymath}
+
+
+\section{rarrowfill 2.5em}
+
+
+\begin{displaymath}
+\aqua + \aqua \rarrowfill{2.5em} \acid + \base
+\end{displaymath}
+
+\section{larrowfill 2.5em}
+
+
+\begin{displaymath}
+\aqua + \aqua \larrowfill{2.5em} \acid + \base
+\end{displaymath}
+
+
+\section{rightleftharpoonsfill 2.5em}
+
+
+\begin{displaymath}
+\aqua + \aqua \rightleftharpoonsfill{2.5em} \acid + \base
+\end{displaymath}
+
+
+\section{leftrightharpoonsfill 2.5em}
+
+
+\begin{displaymath}
+\aqua + \aqua \leftrightharpoonsfill{2.5em} \acid + \base
+\end{displaymath}
+
+
+
+\section{autorightleftharpoons}
+
+
+\begin{displaymath}
+\aqua + \aqua \autorightleftharpoons{$k_a$}{$k_b$} \acid + \base
+\end{displaymath}
+
+
+\section{autoleftrightharpoons}
+
+
+\begin{displaymath}
+\aqua + \aqua \autoleftrightharpoons{$k_a$}{$k_b$} \acid + \base
+\end{displaymath}
+
+
+\section{autorightarrow}
+
+
+\begin{displaymath}
+\aqua + \aqua \autorightarrow{$k_a$}{$k_b$} \acid + \base
+\end{displaymath}
+
+
+\section{autoleftarrow}
+
+
+\begin{displaymath}
+\aqua + \aqua \autoleftarrow{$k_a$}{$k_b$} \acid + \base
+\end{displaymath}
+
+\end{document}

--- a/tagging-status/testfiles-partial-mathml/extpfeil/extpfeil-02-BAD.pdftex.struct.xml
+++ b/tagging-status/testfiles-partial-mathml/extpfeil/extpfeil-02-BAD.pdftex.struct.xml
@@ -1,0 +1,140 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.005"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.006"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.007"
+        title="math"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+      <?MarkedContent page="1" ?>[TEXT]
+     </Formula>
+     <?MarkedContent page="1" ?>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.008"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.009"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.010"
+        title="math"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+      <?MarkedContent page="1" ?>[TEXT]
+     </Formula>
+     <?MarkedContent page="1" ?>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.011"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.012"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.013"
+        title="math"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+      <?MarkedContent page="1" ?>sup====sub
+     </Formula>
+     <?MarkedContent page="1" ?>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.014"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.015"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.016"
+        title="math"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+      <?MarkedContent page="1" ?>sup↞−−−−sub
+     </Formula>
+     <?MarkedContent page="1" ?>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.017"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.018"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.019"
+        title="math"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+      <?MarkedContent page="1" ?>sup−−−−↠sub
+     </Formula>
+     <?MarkedContent page="1" ?>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.020"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.021"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.022"
+        title="math"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+      <?MarkedContent page="1" ?>sup−[TEXT]
+     </Formula>
+     <?MarkedContent page="1" ?>
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-partial-mathml/extpfeil/extpfeil-02-BAD.struct.xml
+++ b/tagging-status/testfiles-partial-mathml/extpfeil/extpfeil-02-BAD.struct.xml
@@ -1,0 +1,1834 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.0002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.0006"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0007"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.0008"
+        title="math"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+      <?MarkedContent page="1" ?>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0009"
+        >
+       <mo xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0010"
+          lspace="0"
+          rspace="0"
+         >
+        <?MarkedContent page="1" ?>[NULL]
+       </mo>
+      </math>
+      <?MarkedContent page="1" ?>
+     </Formula>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.0011"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0012"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.0013"
+        title="math"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+      <?MarkedContent page="1" ?>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0014"
+        >
+       <mo xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0015"
+          lspace="0"
+          rspace="0"
+         >
+        <?MarkedContent page="1" ?>[CTRL]
+       </mo>
+      </math>
+      <?MarkedContent page="1" ?>
+     </Formula>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.0016"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0017"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.0018"
+        title="math"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0019"
+        >
+       <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0020"
+          displaystyle="true"
+          scriptlevel="0"
+         >
+        <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0021"
+           width="-0.111em"
+          >
+        </mspace>
+        <mo xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0022"
+           lspace="0"
+           rspace="0"
+          >
+        </mo>
+        <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0023"
+           width="-0.111em"
+          >
+        </mspace>
+       </mstyle>
+      </math>
+      <?MarkedContent page="1" ?>
+      <?MarkedContent page="1" ?>==
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0024"
+        >
+       <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0025"
+          displaystyle="true"
+          scriptlevel="0"
+         >
+        <mo xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0026"
+           lspace="0"
+           rspace="0"
+          >
+         <?MarkedContent page="1" ?>=
+        </mo>
+        <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0027"
+           width="-0.389em"
+          >
+        </mspace>
+        <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0028"
+           width="-0.389em"
+          >
+        </mspace>
+        <mo xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0029"
+           lspace="0"
+           rspace="0"
+          >
+         <?MarkedContent page="1" ?>=
+        </mo>
+       </mstyle>
+      </math>
+      <?MarkedContent page="1" ?>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0030"
+        >
+       <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0031"
+          displaystyle="false"
+          scriptlevel="1"
+         >
+        <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0032"
+           width="0.500em"
+          >
+        </mspace>
+        <mrow xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0033"
+          >
+         <mi xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0034"
+           >
+         </mi>
+         <mi xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0035"
+           >
+         </mi>
+         <mi xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0036"
+           >
+         </mi>
+        </mrow>
+        <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0037"
+           width="0.500em"
+          >
+        </mspace>
+       </mstyle>
+      </math>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0038"
+        >
+       <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0039"
+          displaystyle="false"
+          scriptlevel="1"
+         >
+        <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0040"
+           width="0.500em"
+          >
+        </mspace>
+        <mrow xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0041"
+          >
+         <mi xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0042"
+           >
+         </mi>
+         <mi xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0043"
+           >
+         </mi>
+         <mi xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0044"
+           >
+         </mi>
+        </mrow>
+        <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0045"
+           width="0.500em"
+          >
+        </mspace>
+       </mstyle>
+      </math>
+      <?MarkedContent page="1" ?>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0046"
+        >
+       <munderover xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0047"
+         >
+        <mo xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0048"
+           lspace="0"
+           movablelimits="false"
+           rspace="0"
+          >
+         <math xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0049"
+           >
+          <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0050"
+             displaystyle="true"
+             scriptlevel="0"
+            >
+           <mo xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0051"
+              lspace="0"
+              rspace="0"
+             >
+           </mo>
+           <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0052"
+              width="-0.389em"
+             >
+           </mspace>
+           <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0053"
+              width="-0.389em"
+             >
+           </mspace>
+           <mo xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0054"
+              lspace="0"
+              rspace="0"
+             >
+           </mo>
+          </mstyle>
+         </math>
+        </mo>
+        <mrow xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0055"
+          >
+         <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0056"
+            width="0.278em"
+           >
+         </mspace>
+         <mi xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0057"
+           >
+          <?MarkedContent page="1" ?>𝑠
+         </mi>
+         <mi xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0058"
+           >
+          <?MarkedContent page="1" ?>𝑢
+         </mi>
+         <mi xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0059"
+           >
+          <?MarkedContent page="1" ?>𝑏
+         </mi>
+         <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0060"
+            width="0.278em"
+           >
+         </mspace>
+        </mrow>
+        <mrow xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0061"
+          >
+         <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0062"
+            width="0.278em"
+           >
+         </mspace>
+         <mi xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0063"
+           >
+          <?MarkedContent page="1" ?>𝑠
+         </mi>
+         <mi xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0064"
+           >
+          <?MarkedContent page="1" ?>𝑢
+         </mi>
+         <mi xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0065"
+           >
+          <?MarkedContent page="1" ?>𝑝
+         </mi>
+         <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0066"
+            width="0.278em"
+           >
+         </mspace>
+        </mrow>
+       </munderover>
+      </math>
+      <?MarkedContent page="1" ?>
+     </Formula>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.0067"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0068"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.0069"
+        title="math"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0070"
+        >
+       <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0071"
+          displaystyle="true"
+          scriptlevel="0"
+         >
+        <mi xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0072"
+           mathvariant="normal"
+          >
+        </mi>
+       </mstyle>
+      </math>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0073"
+        >
+       <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0074"
+          displaystyle="true"
+          scriptlevel="0"
+         >
+        <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0075"
+           width="-0.111em"
+          >
+        </mspace>
+        <mo xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0076"
+           lspace="0"
+           rspace="0"
+          >
+         <math xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0077"
+           >
+          <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0078"
+             displaystyle="true"
+             scriptlevel="0"
+            >
+           <mi xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0079"
+              mathvariant="normal"
+             >
+           </mi>
+          </mstyle>
+         </math>
+        </mo>
+        <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0080"
+           width="-0.111em"
+          >
+        </mspace>
+       </mstyle>
+      </math>
+      <?MarkedContent page="1" ?>−−−
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0081"
+        >
+       <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0082"
+          displaystyle="true"
+          scriptlevel="0"
+         >
+        <mi xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0083"
+           mathvariant="normal"
+          >
+         <?MarkedContent page="1" ?>−
+        </mi>
+       </mstyle>
+      </math>
+      <?MarkedContent page="1" ?>
+      <?MarkedContent page="1" ?>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0084"
+        >
+       <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0085"
+          displaystyle="true"
+          scriptlevel="0"
+         >
+        <mo xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0086"
+           lspace="0"
+           rspace="0"
+           stretchy="false"
+          >
+         <?MarkedContent page="1" ?>↞
+        </mo>
+        <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0087"
+           width="-0.389em"
+          >
+        </mspace>
+        <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0088"
+           width="-0.389em"
+          >
+        </mspace>
+        <mo xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0089"
+           lspace="0"
+           rspace="0"
+          >
+         <math xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0090"
+           >
+          <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0091"
+             displaystyle="true"
+             scriptlevel="0"
+            >
+           <mi xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0092"
+              mathvariant="normal"
+             >
+           </mi>
+          </mstyle>
+         </math>
+        </mo>
+       </mstyle>
+      </math>
+      <?MarkedContent page="1" ?>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0093"
+        >
+       <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0094"
+          displaystyle="false"
+          scriptlevel="1"
+         >
+        <mrow xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0095"
+          >
+         <mi xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0096"
+           >
+         </mi>
+         <mi xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0097"
+           >
+         </mi>
+         <mi xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0098"
+           >
+         </mi>
+        </mrow>
+        <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0099"
+           width="2.222em"
+          >
+        </mspace>
+       </mstyle>
+      </math>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0100"
+        >
+       <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0101"
+          displaystyle="false"
+          scriptlevel="1"
+         >
+        <mrow xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0102"
+          >
+         <mi xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0103"
+           >
+         </mi>
+         <mi xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0104"
+           >
+         </mi>
+         <mi xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0105"
+           >
+         </mi>
+        </mrow>
+        <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0106"
+           width="2.222em"
+          >
+        </mspace>
+       </mstyle>
+      </math>
+      <?MarkedContent page="1" ?>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0107"
+        >
+       <munderover xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0108"
+         >
+        <mo xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0109"
+           lspace="0"
+           movablelimits="false"
+           rspace="0"
+          >
+         <math xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0110"
+           >
+          <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0111"
+             displaystyle="true"
+             scriptlevel="0"
+            >
+           <mo xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0112"
+              lspace="0"
+              rspace="0"
+              stretchy="false"
+             >
+           </mo>
+           <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0113"
+              width="-0.389em"
+             >
+           </mspace>
+           <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0114"
+              width="-0.389em"
+             >
+           </mspace>
+           <mo xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0115"
+              lspace="0"
+              rspace="0"
+             >
+            <math xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0116"
+              >
+             <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+                id="ID.0117"
+                displaystyle="true"
+                scriptlevel="0"
+               >
+              <mi xmlns="http://www.w3.org/1998/Math/MathML"
+                 id="ID.0118"
+                 mathvariant="normal"
+                >
+              </mi>
+             </mstyle>
+            </math>
+           </mo>
+          </mstyle>
+         </math>
+        </mo>
+        <mrow xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0119"
+          >
+         <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0120"
+            width="0.278em"
+           >
+         </mspace>
+         <mi xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0121"
+           >
+          <?MarkedContent page="1" ?>𝑠
+         </mi>
+         <mi xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0122"
+           >
+          <?MarkedContent page="1" ?>𝑢
+         </mi>
+         <mi xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0123"
+           >
+          <?MarkedContent page="1" ?>𝑏
+         </mi>
+        </mrow>
+        <mrow xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0124"
+          >
+         <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0125"
+            width="0.278em"
+           >
+         </mspace>
+         <mi xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0126"
+           >
+          <?MarkedContent page="1" ?>𝑠
+         </mi>
+         <mi xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0127"
+           >
+          <?MarkedContent page="1" ?>𝑢
+         </mi>
+         <mi xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0128"
+           >
+          <?MarkedContent page="1" ?>𝑝
+         </mi>
+        </mrow>
+       </munderover>
+      </math>
+      <?MarkedContent page="1" ?>
+     </Formula>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.0129"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0130"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.0131"
+        title="math"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+      <?MarkedContent page="1" ?>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0132"
+        >
+       <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0133"
+          displaystyle="true"
+          scriptlevel="0"
+         >
+        <mi xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0134"
+           mathvariant="normal"
+          >
+         <?MarkedContent page="1" ?>−
+        </mi>
+       </mstyle>
+      </math>
+      <?MarkedContent page="1" ?>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0135"
+        >
+       <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0136"
+          displaystyle="true"
+          scriptlevel="0"
+         >
+        <mi xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0137"
+           mathvariant="normal"
+          >
+        </mi>
+       </mstyle>
+      </math>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0138"
+        >
+       <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0139"
+          displaystyle="true"
+          scriptlevel="0"
+         >
+        <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0140"
+           width="-0.111em"
+          >
+        </mspace>
+        <mo xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0141"
+           lspace="0"
+           rspace="0"
+          >
+         <math xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0142"
+           >
+          <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0143"
+             displaystyle="true"
+             scriptlevel="0"
+            >
+           <mi xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0144"
+              mathvariant="normal"
+             >
+           </mi>
+          </mstyle>
+         </math>
+        </mo>
+        <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0145"
+           width="-0.111em"
+          >
+        </mspace>
+       </mstyle>
+      </math>
+      <?MarkedContent page="1" ?>
+      <?MarkedContent page="1" ?>−−−
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0146"
+        >
+       <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0147"
+          displaystyle="true"
+          scriptlevel="0"
+         >
+        <mo xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0148"
+           lspace="0"
+           rspace="0"
+          >
+         <math xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0149"
+           >
+          <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0150"
+             displaystyle="true"
+             scriptlevel="0"
+            >
+           <mi xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0151"
+              mathvariant="normal"
+             >
+           </mi>
+          </mstyle>
+         </math>
+        </mo>
+        <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0152"
+           width="-0.389em"
+          >
+        </mspace>
+        <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0153"
+           width="-0.389em"
+          >
+        </mspace>
+        <mo xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0154"
+           lspace="0"
+           rspace="0"
+           stretchy="false"
+          >
+         <?MarkedContent page="1" ?>↠
+        </mo>
+       </mstyle>
+      </math>
+      <?MarkedContent page="1" ?>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0155"
+        >
+       <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0156"
+          displaystyle="false"
+          scriptlevel="1"
+         >
+        <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0157"
+           width="2.222em"
+          >
+        </mspace>
+        <mrow xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0158"
+          >
+         <mi xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0159"
+           >
+         </mi>
+         <mi xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0160"
+           >
+         </mi>
+         <mi xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0161"
+           >
+         </mi>
+        </mrow>
+       </mstyle>
+      </math>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0162"
+        >
+       <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0163"
+          displaystyle="false"
+          scriptlevel="1"
+         >
+        <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0164"
+           width="2.222em"
+          >
+        </mspace>
+        <mrow xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0165"
+          >
+         <mi xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0166"
+           >
+         </mi>
+         <mi xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0167"
+           >
+         </mi>
+         <mi xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0168"
+           >
+         </mi>
+        </mrow>
+       </mstyle>
+      </math>
+      <?MarkedContent page="1" ?>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0169"
+        >
+       <munderover xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0170"
+         >
+        <mo xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0171"
+           lspace="0"
+           movablelimits="false"
+           rspace="0"
+          >
+         <math xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0172"
+           >
+          <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0173"
+             displaystyle="true"
+             scriptlevel="0"
+            >
+           <mo xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0174"
+              lspace="0"
+              rspace="0"
+             >
+            <math xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0175"
+              >
+             <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+                id="ID.0176"
+                displaystyle="true"
+                scriptlevel="0"
+               >
+              <mi xmlns="http://www.w3.org/1998/Math/MathML"
+                 id="ID.0177"
+                 mathvariant="normal"
+                >
+              </mi>
+             </mstyle>
+            </math>
+           </mo>
+           <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0178"
+              width="-0.389em"
+             >
+           </mspace>
+           <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0179"
+              width="-0.389em"
+             >
+           </mspace>
+           <mo xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0180"
+              lspace="0"
+              rspace="0"
+              stretchy="false"
+             >
+           </mo>
+          </mstyle>
+         </math>
+        </mo>
+        <mrow xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0181"
+          >
+         <mi xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0182"
+           >
+          <?MarkedContent page="1" ?>𝑠
+         </mi>
+         <mi xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0183"
+           >
+          <?MarkedContent page="1" ?>𝑢
+         </mi>
+         <mi xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0184"
+           >
+          <?MarkedContent page="1" ?>𝑏
+         </mi>
+         <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0185"
+            width="0.278em"
+           >
+         </mspace>
+        </mrow>
+        <mrow xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0186"
+          >
+         <mi xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0187"
+           >
+          <?MarkedContent page="1" ?>𝑠
+         </mi>
+         <mi xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0188"
+           >
+          <?MarkedContent page="1" ?>𝑢
+         </mi>
+         <mi xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0189"
+           >
+          <?MarkedContent page="1" ?>𝑝
+         </mi>
+         <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0190"
+            width="0.278em"
+           >
+         </mspace>
+        </mrow>
+       </munderover>
+      </math>
+      <?MarkedContent page="1" ?>
+     </Formula>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.0191"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0192"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.0193"
+        title="math"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+      <?MarkedContent page="1" ?>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0194"
+        >
+       <mi xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0195"
+          mathvariant="normal"
+         >
+        <?MarkedContent page="1" ?>−
+       </mi>
+      </math>
+      <?MarkedContent page="1" ?>
+      <?MarkedContent page="1" ?>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0196"
+        >
+       <mo xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0197"
+          lspace="0"
+          rspace="0"
+         >
+        <math xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0198"
+          >
+         <mi xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0199"
+            mathvariant="normal"
+           >
+         </mi>
+        </math>
+       </mo>
+      </math>
+      <?MarkedContent page="1" ?>
+      <?MarkedContent page="1" ?>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0200"
+        >
+       <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0201"
+          displaystyle="true"
+          scriptlevel="0"
+         >
+        <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0202"
+          >
+         <math xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0203"
+           >
+          <mo xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0204"
+             lspace="0"
+             rspace="0"
+            >
+           <math xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0205"
+             >
+            <mi xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0206"
+               mathvariant="normal"
+              >
+            </mi>
+           </math>
+          </mo>
+         </math>
+        </mtext>
+       </mstyle>
+      </math>
+      <?MarkedContent page="1" ?>
+      <?MarkedContent page="1" ?>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0207"
+        >
+       <mo xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0208"
+          lspace="0"
+          rspace="0"
+         >
+        <?MarkedContent page="1" ?>[NULL]
+       </mo>
+      </math>
+      <?MarkedContent page="1" ?>
+      <?MarkedContent page="1" ?>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0209"
+        >
+       <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0210"
+          displaystyle="true"
+          scriptlevel="0"
+         >
+        <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0211"
+          >
+         <math xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0212"
+           >
+          <mo xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0213"
+             lspace="0"
+             rspace="0"
+            >
+          </mo>
+         </math>
+        </mtext>
+       </mstyle>
+      </math>
+      <?MarkedContent page="1" ?>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0214"
+        >
+       <mi xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0215"
+          mathvariant="normal"
+         >
+       </mi>
+      </math>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0216"
+        >
+       <mo xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0217"
+          lspace="0"
+          rspace="0"
+         >
+        <math xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0218"
+          >
+         <mi xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0219"
+            mathvariant="normal"
+           >
+         </mi>
+        </math>
+       </mo>
+      </math>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0220"
+        >
+       <mo xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0221"
+          lspace="0"
+          rspace="0"
+         >
+       </mo>
+      </math>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0225"
+        >
+       <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0226"
+          displaystyle="true"
+          scriptlevel="0"
+         >
+        <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0227"
+           width="-0.111em"
+          >
+        </mspace>
+        <mo xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0228"
+           lspace="0"
+           rspace="0"
+          >
+        </mo>
+        <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0229"
+           width="-0.111em"
+          >
+        </mspace>
+       </mstyle>
+      </math>
+      <?MarkedContent page="1" ?>===
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0230"
+        >
+       <mo xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0231"
+          lspace="0"
+          rspace="0"
+         >
+       </mo>
+      </math>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0232"
+        >
+       <mi xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0233"
+          mathvariant="normal"
+         >
+       </mi>
+      </math>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0234"
+        >
+       <mo xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0235"
+          lspace="0"
+          rspace="0"
+         >
+        <math xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0236"
+          >
+         <mi xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0237"
+            mathvariant="normal"
+           >
+         </mi>
+        </math>
+       </mo>
+      </math>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0241"
+        >
+       <mo xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0242"
+          lspace="0"
+          rspace="0"
+         >
+        <?MarkedContent page="1" ?>[CTRL]
+       </mo>
+      </math>
+      <?MarkedContent page="1" ?>
+      <?MarkedContent page="1" ?>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0243"
+        >
+       <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0244"
+          displaystyle="true"
+          scriptlevel="0"
+         >
+        <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0245"
+          >
+         <math xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0246"
+           >
+          <mo xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0247"
+             lspace="0"
+             rspace="0"
+            >
+          </mo>
+         </math>
+        </mtext>
+       </mstyle>
+      </math>
+      <?MarkedContent page="1" ?>
+      <?MarkedContent page="1" ?>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0248"
+        >
+       <mi xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0249"
+          mathvariant="normal"
+         >
+        <?MarkedContent page="1" ?>−
+       </mi>
+      </math>
+      <?MarkedContent page="1" ?>
+      <?MarkedContent page="1" ?>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0250"
+        >
+       <mo xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0251"
+          lspace="0"
+          rspace="0"
+         >
+        <math xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0252"
+          >
+         <mi xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0253"
+            mathvariant="normal"
+           >
+         </mi>
+        </math>
+       </mo>
+      </math>
+      <?MarkedContent page="1" ?>
+      <?MarkedContent page="1" ?>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0254"
+        >
+       <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0255"
+          displaystyle="true"
+          scriptlevel="0"
+         >
+        <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0256"
+          >
+         <math xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0257"
+           >
+          <mo xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0258"
+             lspace="0"
+             rspace="0"
+            >
+           <math xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0259"
+             >
+            <mi xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0260"
+               mathvariant="normal"
+              >
+            </mi>
+           </math>
+          </mo>
+         </math>
+        </mtext>
+       </mstyle>
+      </math>
+      <?MarkedContent page="1" ?>
+      <?MarkedContent page="1" ?>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0261"
+        >
+       <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0262"
+          displaystyle="true"
+          scriptlevel="0"
+         >
+        <mrow xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0263"
+          >
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0264"
+           >
+          <math xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0265"
+            >
+           <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0266"
+              displaystyle="true"
+              scriptlevel="0"
+             >
+            <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0267"
+              >
+             <math xmlns="http://www.w3.org/1998/Math/MathML"
+                id="ID.0268"
+               >
+              <mo xmlns="http://www.w3.org/1998/Math/MathML"
+                 id="ID.0269"
+                 lspace="0"
+                 rspace="0"
+                >
+               <math xmlns="http://www.w3.org/1998/Math/MathML"
+                  id="ID.0270"
+                 >
+                <mi xmlns="http://www.w3.org/1998/Math/MathML"
+                   id="ID.0271"
+                   mathvariant="normal"
+                  >
+                </mi>
+               </math>
+              </mo>
+             </math>
+            </mtext>
+           </mstyle>
+          </math>
+         </mtext>
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0272"
+           >
+          <math xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0273"
+            >
+           <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0274"
+              displaystyle="true"
+              scriptlevel="0"
+             >
+            <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0275"
+              >
+             <math xmlns="http://www.w3.org/1998/Math/MathML"
+                id="ID.0276"
+               >
+              <mo xmlns="http://www.w3.org/1998/Math/MathML"
+                 id="ID.0277"
+                 lspace="0"
+                 rspace="0"
+                >
+              </mo>
+             </math>
+            </mtext>
+           </mstyle>
+          </math>
+         </mtext>
+         <mpadded xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0278"
+            depth="0"
+            height="0"
+           >
+          <mphantom xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0222"
+            >
+           <mi xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0223"
+             >
+            <mglyph xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0224"
+              >
+            </mglyph>
+           </mi>
+          </mphantom>
+         </mpadded>
+        </mrow>
+        <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0279"
+           width="-0.389em"
+          >
+        </mspace>
+        <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0280"
+           width="-0.389em"
+          >
+        </mspace>
+        <mrow xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0281"
+          >
+         <mpadded xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0282"
+            depth="0"
+            height="0"
+           >
+          <mphantom xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0238"
+            >
+           <mi xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0239"
+             >
+            <mglyph xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0240"
+              >
+            </mglyph>
+           </mi>
+          </mphantom>
+         </mpadded>
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0283"
+           >
+          <math xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0284"
+            >
+           <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0285"
+              displaystyle="true"
+              scriptlevel="0"
+             >
+            <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0286"
+              >
+             <math xmlns="http://www.w3.org/1998/Math/MathML"
+                id="ID.0287"
+               >
+              <mo xmlns="http://www.w3.org/1998/Math/MathML"
+                 id="ID.0288"
+                 lspace="0"
+                 rspace="0"
+                >
+              </mo>
+             </math>
+            </mtext>
+           </mstyle>
+          </math>
+         </mtext>
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0289"
+           >
+          <math xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0290"
+            >
+           <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0291"
+              displaystyle="true"
+              scriptlevel="0"
+             >
+            <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0292"
+              >
+             <math xmlns="http://www.w3.org/1998/Math/MathML"
+                id="ID.0293"
+               >
+              <mo xmlns="http://www.w3.org/1998/Math/MathML"
+                 id="ID.0294"
+                 lspace="0"
+                 rspace="0"
+                >
+               <math xmlns="http://www.w3.org/1998/Math/MathML"
+                  id="ID.0295"
+                 >
+                <mi xmlns="http://www.w3.org/1998/Math/MathML"
+                   id="ID.0296"
+                   mathvariant="normal"
+                  >
+                </mi>
+               </math>
+              </mo>
+             </math>
+            </mtext>
+           </mstyle>
+          </math>
+         </mtext>
+        </mrow>
+       </mstyle>
+      </math>
+      <?MarkedContent page="1" ?>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0297"
+        >
+       <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0298"
+          displaystyle="false"
+          scriptlevel="1"
+         >
+        <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0299"
+           width="2.222em"
+          >
+        </mspace>
+        <mrow xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0300"
+          >
+         <mi xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0301"
+           >
+         </mi>
+         <mi xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0302"
+           >
+         </mi>
+         <mi xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0303"
+           >
+         </mi>
+        </mrow>
+       </mstyle>
+      </math>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0304"
+        >
+       <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0305"
+          displaystyle="false"
+          scriptlevel="1"
+         >
+        <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0306"
+           width="2.222em"
+          >
+        </mspace>
+        <mrow xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0307"
+          >
+         <mi xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0308"
+           >
+         </mi>
+         <mi xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0309"
+           >
+         </mi>
+         <mi xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0310"
+           >
+         </mi>
+        </mrow>
+       </mstyle>
+      </math>
+      <?MarkedContent page="1" ?>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0311"
+        >
+       <munderover xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0312"
+         >
+        <mo xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0313"
+           lspace="0"
+           movablelimits="false"
+           rspace="0"
+          >
+         <math xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0314"
+           >
+          <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0315"
+             displaystyle="true"
+             scriptlevel="0"
+            >
+           <mrow xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0316"
+             >
+            <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0317"
+              >
+             <math xmlns="http://www.w3.org/1998/Math/MathML"
+                id="ID.0318"
+               >
+              <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+                 id="ID.0319"
+                 displaystyle="true"
+                 scriptlevel="0"
+                >
+               <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+                  id="ID.0320"
+                 >
+                <math xmlns="http://www.w3.org/1998/Math/MathML"
+                   id="ID.0321"
+                  >
+                 <mo xmlns="http://www.w3.org/1998/Math/MathML"
+                    id="ID.0322"
+                    lspace="0"
+                    rspace="0"
+                   >
+                  <math xmlns="http://www.w3.org/1998/Math/MathML"
+                     id="ID.0323"
+                    >
+                   <mi xmlns="http://www.w3.org/1998/Math/MathML"
+                      id="ID.0324"
+                      mathvariant="normal"
+                     >
+                   </mi>
+                  </math>
+                 </mo>
+                </math>
+               </mtext>
+              </mstyle>
+             </math>
+            </mtext>
+            <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0325"
+              >
+             <math xmlns="http://www.w3.org/1998/Math/MathML"
+                id="ID.0326"
+               >
+              <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+                 id="ID.0327"
+                 displaystyle="true"
+                 scriptlevel="0"
+                >
+               <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+                  id="ID.0328"
+                 >
+                <math xmlns="http://www.w3.org/1998/Math/MathML"
+                   id="ID.0329"
+                  >
+                 <mo xmlns="http://www.w3.org/1998/Math/MathML"
+                    id="ID.0330"
+                    lspace="0"
+                    rspace="0"
+                   >
+                 </mo>
+                </math>
+               </mtext>
+              </mstyle>
+             </math>
+            </mtext>
+            <mpadded xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0331"
+               depth="0"
+               height="0"
+              >
+             <mphantom xmlns="http://www.w3.org/1998/Math/MathML"
+                id="ID.0222"
+               >
+              <mi xmlns="http://www.w3.org/1998/Math/MathML"
+                 id="ID.0223"
+                >
+               <mglyph xmlns="http://www.w3.org/1998/Math/MathML"
+                  id="ID.0224"
+                 >
+               </mglyph>
+              </mi>
+             </mphantom>
+            </mpadded>
+           </mrow>
+           <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0332"
+              width="-0.389em"
+             >
+           </mspace>
+           <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0333"
+              width="-0.389em"
+             >
+           </mspace>
+           <mrow xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0334"
+             >
+            <mpadded xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0335"
+               depth="0"
+               height="0"
+              >
+             <mphantom xmlns="http://www.w3.org/1998/Math/MathML"
+                id="ID.0238"
+               >
+              <mi xmlns="http://www.w3.org/1998/Math/MathML"
+                 id="ID.0239"
+                >
+               <mglyph xmlns="http://www.w3.org/1998/Math/MathML"
+                  id="ID.0240"
+                 >
+               </mglyph>
+              </mi>
+             </mphantom>
+            </mpadded>
+            <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0336"
+              >
+             <math xmlns="http://www.w3.org/1998/Math/MathML"
+                id="ID.0337"
+               >
+              <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+                 id="ID.0338"
+                 displaystyle="true"
+                 scriptlevel="0"
+                >
+               <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+                  id="ID.0339"
+                 >
+                <math xmlns="http://www.w3.org/1998/Math/MathML"
+                   id="ID.0340"
+                  >
+                 <mo xmlns="http://www.w3.org/1998/Math/MathML"
+                    id="ID.0341"
+                    lspace="0"
+                    rspace="0"
+                   >
+                 </mo>
+                </math>
+               </mtext>
+              </mstyle>
+             </math>
+            </mtext>
+            <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0342"
+              >
+             <math xmlns="http://www.w3.org/1998/Math/MathML"
+                id="ID.0343"
+               >
+              <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+                 id="ID.0344"
+                 displaystyle="true"
+                 scriptlevel="0"
+                >
+               <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+                  id="ID.0345"
+                 >
+                <math xmlns="http://www.w3.org/1998/Math/MathML"
+                   id="ID.0346"
+                  >
+                 <mo xmlns="http://www.w3.org/1998/Math/MathML"
+                    id="ID.0347"
+                    lspace="0"
+                    rspace="0"
+                   >
+                  <math xmlns="http://www.w3.org/1998/Math/MathML"
+                     id="ID.0348"
+                    >
+                   <mi xmlns="http://www.w3.org/1998/Math/MathML"
+                      id="ID.0349"
+                      mathvariant="normal"
+                     >
+                   </mi>
+                  </math>
+                 </mo>
+                </math>
+               </mtext>
+              </mstyle>
+             </math>
+            </mtext>
+           </mrow>
+          </mstyle>
+         </math>
+        </mo>
+        <mrow xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0350"
+          >
+         <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0351"
+            width="0.278em"
+           >
+         </mspace>
+         <mi xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0352"
+           >
+          <?MarkedContent page="1" ?>𝑠
+         </mi>
+         <mi xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0353"
+           >
+          <?MarkedContent page="1" ?>𝑢
+         </mi>
+         <mi xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0354"
+           >
+          <?MarkedContent page="1" ?>𝑏
+         </mi>
+         <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0355"
+            width="0.278em"
+           >
+         </mspace>
+        </mrow>
+        <mrow xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0356"
+          >
+         <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0357"
+            width="0.278em"
+           >
+         </mspace>
+         <mi xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0358"
+           >
+          <?MarkedContent page="1" ?>𝑠
+         </mi>
+         <mi xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0359"
+           >
+          <?MarkedContent page="1" ?>𝑢
+         </mi>
+         <mi xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0360"
+           >
+          <?MarkedContent page="1" ?>𝑝
+         </mi>
+         <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0361"
+            width="0.278em"
+           >
+         </mspace>
+        </mrow>
+       </munderover>
+      </math>
+      <?MarkedContent page="1" ?>
+     </Formula>
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-partial-mathml/extpfeil/extpfeil-02-BAD.tex
+++ b/tagging-status/testfiles-partial-mathml/extpfeil/extpfeil-02-BAD.tex
@@ -1,0 +1,30 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on,
+    tagging-setup={math/setup=mathml-SE},
+  }
+\documentclass{article}
+
+\usepackage{extpfeil}
+\UseName{sys_if_engine_opentype:T}{\usepackage{unicode-math}}
+
+\title{extpfeil tagging test -- mathml-SE}
+
+\begin{document}
+
+$\shortleftarrow$
+
+$\shortrightarrow$
+
+$\xlongequal[sub]{sup}$
+
+$\xtwoheadleftarrow[sub]{sup}$
+
+$\xtwoheadrightarrow[sub]{sup}$
+
+$\xtofrom[sub]{sup}$
+
+\end{document}

--- a/tagging-status/testfiles-partial-mathml/mathtools/mathtools-13-BAD.pdftex.struct.xml
+++ b/tagging-status/testfiles-partial-mathml/mathtools/mathtools-13-BAD.pdftex.struct.xml
@@ -1,0 +1,87 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.005"
+      rolemaps-to="Part"
+     >
+    <Formula xmlns="http://iso.org/pdf2/ssn"
+       id="ID.006"
+       title="align"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:Placement="Block"
+      >
+     <?MarkedContent page="1" ?>a =a
+     <Lbl xmlns="http://iso.org/pdf2/ssn"
+        id="ID.007"
+       >
+      <?MarkedContent page="1" ?>[1]
+     </Lbl>
+     <?MarkedContent page="1" ?>b =b
+    </Formula>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.008"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>This should refer to the equation containing
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.009"
+        title="math"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+      <?MarkedContent page="1" ?>a =a
+     </Formula>
+     <?MarkedContent page="1" ?>:
+     <Lbl xmlns="http://iso.org/pdf2/ssn"
+        id="ID.010"
+       >
+      <?MarkedContent page="1" ?>[1]
+     </Lbl>
+     <?MarkedContent page="1" ?>. Then a switch of tagforms.
+    </text>
+    <Formula xmlns="http://iso.org/pdf2/ssn"
+       id="ID.011"
+       title="align"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:Placement="Block"
+      >
+     <?MarkedContent page="1" ?>c =cd =d
+     <Lbl xmlns="http://iso.org/pdf2/ssn"
+        id="ID.012"
+       >
+      <?MarkedContent page="1" ?>(2)
+     </Lbl>
+     <?MarkedContent page="1" ?>
+    </Formula>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.013"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>This should refer to the equation containing
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.014"
+        title="math"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+      <?MarkedContent page="1" ?>d =d
+     </Formula>
+     <?MarkedContent page="1" ?>:
+     <Lbl xmlns="http://iso.org/pdf2/ssn"
+        id="ID.015"
+       >
+      <?MarkedContent page="1" ?>(2)
+     </Lbl>
+     <?MarkedContent page="1" ?>.
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-partial-mathml/mathtools/mathtools-13-BAD.struct.xml
+++ b/tagging-status/testfiles-partial-mathml/mathtools/mathtools-13-BAD.struct.xml
@@ -1,0 +1,292 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.006"
+      rolemaps-to="Part"
+     >
+    <Formula xmlns="http://iso.org/pdf2/ssn"
+       id="ID.007"
+       title="align"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:Placement="Block"
+      >
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <math xmlns="http://www.w3.org/1998/Math/MathML"
+        id="ID.019"
+        display="block"
+       >
+      <mtable xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.020"
+         class="align"
+         columnalign="left right left"
+         columnspacing="0 0"
+         displaystyle="true"
+         intent=":system-of-equations"
+        >
+       <mtr xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.021"
+         >
+        <mtd xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.022"
+           intent=":equation-label"
+          >
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.013"
+           >
+          <?MarkedContent page="1" ?>[1]
+         </mtext>
+        </mtd>
+        <mtd xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.008"
+           intent=":pause-medium"
+          >
+         <mi xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.009"
+           >
+          <?MarkedContent page="1" ?>𝑎
+         </mi>
+         <mo xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.010"
+            lspace="0.278em"
+            rspace="0.278em"
+           >
+          <?MarkedContent page="1" ?>=
+         </mo>
+         <mi xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.011"
+           >
+          <?MarkedContent page="1" ?>𝑎
+         </mi>
+        </mtd>
+        <mtd xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.012"
+          >
+        </mtd>
+       </mtr>
+       <mtr xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.023"
+         >
+        <mtd xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.024"
+           intent=":no-equation-label"
+          >
+        </mtd>
+        <mtd xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.014"
+           intent=":pause-medium"
+          >
+         <mi xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.015"
+           >
+          <?MarkedContent page="1" ?>𝑏
+         </mi>
+         <mo xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.016"
+            lspace="0.278em"
+            rspace="0.278em"
+           >
+          <?MarkedContent page="1" ?>=
+         </mo>
+         <mi xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.017"
+           >
+          <?MarkedContent page="1" ?>𝑏
+         </mi>
+        </mtd>
+        <mtd xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.018"
+          >
+        </mtd>
+       </mtr>
+      </mtable>
+     </math>
+    </Formula>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.025"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>This should refer to the equation containing 
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.026"
+        title="math"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+      <?MarkedContent page="1" ?>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.027"
+        >
+       <mi xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.028"
+         >
+        <?MarkedContent page="1" ?>𝑎
+       </mi>
+       <mo xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.029"
+          lspace="0.278em"
+          rspace="0.278em"
+         >
+        <?MarkedContent page="1" ?>=
+       </mo>
+       <mi xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.030"
+         >
+        <?MarkedContent page="1" ?>𝑎
+       </mi>
+      </math>
+      <?MarkedContent page="1" ?>
+     </Formula>
+     <?MarkedContent page="1" ?>: 
+     <?MarkedContent page="1" ?>[1]
+     <?MarkedContent page="1" ?>. Then a switch of tag forms.
+    </text>
+    <Formula xmlns="http://iso.org/pdf2/ssn"
+       id="ID.031"
+       title="align"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:Placement="Block"
+      >
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <math xmlns="http://www.w3.org/1998/Math/MathML"
+        id="ID.043"
+        display="block"
+       >
+      <mtable xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.044"
+         class="align"
+         columnalign="left right left"
+         columnspacing="0 0"
+         displaystyle="true"
+         intent=":system-of-equations"
+        >
+       <mtr xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.045"
+         >
+        <mtd xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.046"
+           intent=":equation-label"
+          >
+        </mtd>
+        <mtd xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.032"
+           intent=":pause-medium"
+          >
+         <mi xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.033"
+           >
+          <?MarkedContent page="1" ?>𝑐
+         </mi>
+        </mtd>
+        <mtd xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.034"
+          >
+         <mo xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.035"
+            lspace="0.278em"
+            rspace="0.278em"
+           >
+          <?MarkedContent page="1" ?>=
+         </mo>
+         <mi xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.036"
+           >
+          <?MarkedContent page="1" ?>𝑐
+         </mi>
+        </mtd>
+       </mtr>
+       <mtr xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.047"
+         >
+        <mtd xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.048"
+           intent=":equation-label"
+          >
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.042"
+           >
+          <?MarkedContent page="1" ?>(2)
+         </mtext>
+        </mtd>
+        <mtd xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.037"
+           intent=":pause-medium"
+          >
+         <mi xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.038"
+           >
+          <?MarkedContent page="1" ?>𝑑
+         </mi>
+        </mtd>
+        <mtd xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.039"
+          >
+         <mo xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.040"
+            lspace="0.278em"
+            rspace="0.278em"
+           >
+          <?MarkedContent page="1" ?>=
+         </mo>
+         <mi xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.041"
+           >
+          <?MarkedContent page="1" ?>𝑑
+         </mi>
+        </mtd>
+       </mtr>
+      </mtable>
+     </math>
+    </Formula>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.049"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>This should refer to the equation containing 
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.050"
+        title="math"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+      <?MarkedContent page="1" ?>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.051"
+        >
+       <mi xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.052"
+         >
+        <?MarkedContent page="1" ?>𝑑
+       </mi>
+       <mo xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.053"
+          lspace="0.278em"
+          rspace="0.278em"
+         >
+        <?MarkedContent page="1" ?>=
+       </mo>
+       <mi xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.054"
+         >
+        <?MarkedContent page="1" ?>𝑑
+       </mi>
+      </math>
+      <?MarkedContent page="1" ?>
+     </Formula>
+     <?MarkedContent page="1" ?>: 
+     <?MarkedContent page="1" ?>(2)
+     <?MarkedContent page="1" ?>.
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-partial-mathml/mathtools/mathtools-13-BAD.tex
+++ b/tagging-status/testfiles-partial-mathml/mathtools/mathtools-13-BAD.tex
@@ -1,0 +1,33 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on,
+    tagging-setup={math/setup=mathml-SE},
+  }
+\documentclass{article}
+
+\usepackage{mathtools}
+\ifdefined\Uchar\usepackage{unicode-math}\fi
+
+\newtagform{brackets}{[}{]}
+
+\begin{document}
+
+\mathtoolsset{showonlyrefs}
+\usetagform{brackets}
+\begin{align}
+a=a \label{eq:a} \\
+b=b \label{eq:b} %\tag{**}
+\end{align}
+This should refer to the equation containing $a=a$: \eqref{eq:a}.
+Then a switch of tag forms.
+\usetagform{default}
+\begin{align}
+c&=c \label{eq:c} \\
+d&=d \label{eq:d}
+\end{align}
+This should refer to the equation containing $d=d$: \eqref{eq:d}.
+
+\end{document}

--- a/tagging-status/testfiles-partial-mathml/mathtools/mathtools-14-BAD.pdftex.struct.xml
+++ b/tagging-status/testfiles-partial-mathml/mathtools/mathtools-14-BAD.pdftex.struct.xml
@@ -1,0 +1,29 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.02"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.05"
+      rolemaps-to="Part"
+     >
+    <Formula xmlns="http://iso.org/pdf2/ssn"
+       id="ID.06"
+       title="equation*"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:Placement="Block"
+      >
+     <?MarkedContent page="1" ?>412C5+2
+    </Formula>
+    <Formula xmlns="http://iso.org/pdf2/ssn"
+       id="ID.07"
+       title="equation*"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:Placement="Block"
+      >
+     <?MarkedContent page="1" ?>412C5+2
+    </Formula>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-partial-mathml/mathtools/mathtools-14-BAD.struct.xml
+++ b/tagging-status/testfiles-partial-mathml/mathtools/mathtools-14-BAD.struct.xml
@@ -1,0 +1,300 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.006"
+      rolemaps-to="Part"
+     >
+    <Formula xmlns="http://iso.org/pdf2/ssn"
+       id="ID.007"
+       title="equation*"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:Placement="Block"
+      >
+     <math xmlns="http://www.w3.org/1998/Math/MathML"
+        id="ID.008"
+        display="block"
+       >
+      <msubsup xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.009"
+        >
+       <mrow xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.010"
+         >
+       </mrow>
+       <mn xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.011"
+         >
+        <?MarkedContent page="1" ?>12
+       </mn>
+       <mn xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.012"
+         >
+        <?MarkedContent page="1" ?>4
+       </mn>
+      </msubsup>
+      <msubsup xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.013"
+        >
+       <mi xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.014"
+          mathvariant="normal"
+         >
+        <?MarkedContent page="1" ?>C
+       </mi>
+       <mn xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.015"
+         >
+        <?MarkedContent page="1" ?>2
+       </mn>
+       <mrow xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.016"
+         >
+        <mn xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.017"
+          >
+         <?MarkedContent page="1" ?>5
+        </mn>
+        <mo xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.018"
+           lspace="0"
+           rspace="0"
+          >
+         <?MarkedContent page="1" ?>+
+        </mo>
+       </mrow>
+      </msubsup>
+     </math>
+    </Formula>
+    <Formula xmlns="http://iso.org/pdf2/ssn"
+       id="ID.019"
+       title="equation*"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:Placement="Block"
+      >
+     <?MarkedContent page="1" ?>
+     <math xmlns="http://www.w3.org/1998/Math/MathML"
+        id="ID.020"
+       >
+      <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.021"
+         displaystyle="false"
+         scriptlevel="1"
+        >
+       <mn xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.022"
+         >
+        <?MarkedContent page="1" ?>4
+       </mn>
+      </mstyle>
+     </math>
+     <?MarkedContent page="1" ?>
+     <math xmlns="http://www.w3.org/1998/Math/MathML"
+        id="ID.023"
+       >
+      <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.024"
+         displaystyle="false"
+         scriptlevel="1"
+        >
+       <mn xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.025"
+         >
+        <?MarkedContent page="1" ?>12
+       </mn>
+      </mstyle>
+     </math>
+     <?MarkedContent page="1" ?>
+     <math xmlns="http://www.w3.org/1998/Math/MathML"
+        id="ID.028"
+       >
+      <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.029"
+         displaystyle="false"
+         scriptlevel="1"
+        >
+       <mn xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.030"
+         >
+       </mn>
+      </mstyle>
+     </math>
+     <math xmlns="http://www.w3.org/1998/Math/MathML"
+        id="ID.031"
+       >
+      <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.032"
+         displaystyle="false"
+         scriptlevel="1"
+        >
+       <mn xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.033"
+         >
+       </mn>
+      </mstyle>
+     </math>
+     <math xmlns="http://www.w3.org/1998/Math/MathML"
+        id="ID.036"
+       >
+      <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.037"
+         displaystyle="false"
+         scriptlevel="2"
+        >
+       <mn xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.038"
+         >
+       </mn>
+      </mstyle>
+     </math>
+     <math xmlns="http://www.w3.org/1998/Math/MathML"
+        id="ID.039"
+       >
+      <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.040"
+         displaystyle="false"
+         scriptlevel="2"
+        >
+       <mn xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.041"
+         >
+       </mn>
+      </mstyle>
+     </math>
+     <math xmlns="http://www.w3.org/1998/Math/MathML"
+        id="ID.044"
+       >
+      <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.045"
+         displaystyle="false"
+         scriptlevel="2"
+        >
+       <mn xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.046"
+         >
+       </mn>
+      </mstyle>
+     </math>
+     <math xmlns="http://www.w3.org/1998/Math/MathML"
+        id="ID.047"
+       >
+      <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.048"
+         displaystyle="false"
+         scriptlevel="2"
+        >
+       <mn xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.049"
+         >
+       </mn>
+      </mstyle>
+     </math>
+     <math xmlns="http://www.w3.org/1998/Math/MathML"
+        id="ID.052"
+        display="block"
+       >
+      <mrow xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.053"
+        >
+       <mrow xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.054"
+         >
+       </mrow>
+       <msubsup xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.055"
+         >
+        <mpadded xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.056"
+           width="0"
+          >
+         <mphantom xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.026"
+           >
+          <mi xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.027"
+             mathvariant="normal"
+            >
+          </mi>
+         </mphantom>
+        </mpadded>
+        <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.057"
+          >
+         <math xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.058"
+           >
+          <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.059"
+             displaystyle="false"
+             scriptlevel="1"
+            >
+           <mn xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.060"
+             >
+           </mn>
+          </mstyle>
+         </math>
+        </mtext>
+        <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.061"
+          >
+         <math xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.062"
+           >
+          <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.063"
+             displaystyle="false"
+             scriptlevel="1"
+            >
+           <mn xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.064"
+             >
+           </mn>
+          </mstyle>
+         </math>
+        </mtext>
+       </msubsup>
+       <mi xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.065"
+          mathvariant="normal"
+         >
+        <?MarkedContent page="1" ?>C
+       </mi>
+      </mrow>
+      <msubsup xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.066"
+        >
+       <mrow xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.067"
+         >
+       </mrow>
+       <mn xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.068"
+         >
+        <?MarkedContent page="1" ?>2
+       </mn>
+       <mrow xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.069"
+         >
+        <mn xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.070"
+          >
+         <?MarkedContent page="1" ?>5
+        </mn>
+        <mo xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.071"
+           lspace="0"
+           rspace="0"
+          >
+         <?MarkedContent page="1" ?>+
+        </mo>
+       </mrow>
+      </msubsup>
+     </math>
+    </Formula>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-partial-mathml/mathtools/mathtools-14-BAD.tex
+++ b/tagging-status/testfiles-partial-mathml/mathtools/mathtools-14-BAD.tex
@@ -1,0 +1,23 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on,
+    tagging-setup={math/setup=mathml-SE},
+  }
+\documentclass{article}
+
+\usepackage{mathtools}
+\UseName{sys_if_engine_opentype:T}{\usepackage{unicode-math}}
+
+\begin{document}
+
+\[
+{}^{4}_{12}\mathbf{C}^{5+}_{2}
+\]
+\[
+\prescript{4}{12}{\mathbf{C}}^{5+}_{2}
+\]
+
+\end{document}

--- a/tagging-status/testfiles-partial-mathml/turnstile/turnstile-02-BAD.pdftex.struct.xml
+++ b/tagging-status/testfiles-partial-mathml/turnstile/turnstile-02-BAD.pdftex.struct.xml
@@ -1,0 +1,43 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.02"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.05"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.06"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.07"
+        title="math"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+      <?MarkedContent page="1" ?>ΓLPDx,yP
+     </Formula>
+     <?MarkedContent page="1" ?>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.08"
+      rolemaps-to="Part"
+     >
+    <Formula xmlns="http://iso.org/pdf2/ssn"
+       id="ID.09"
+       title="equation*"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:Placement="Block"
+      >
+     <?MarkedContent page="1" ?>ΓLCx,y,z,wP
+    </Formula>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-partial-mathml/turnstile/turnstile-02-BAD.struct.xml
+++ b/tagging-status/testfiles-partial-mathml/turnstile/turnstile-02-BAD.struct.xml
@@ -1,0 +1,588 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.0002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.0006"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0007"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.0008"
+        title="math"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+      <?MarkedContent page="1" ?>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0009"
+        >
+       <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0010"
+          displaystyle="false"
+          scriptlevel="1"
+         >
+        <mi xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0011"
+           mathvariant="normal"
+          >
+         <?MarkedContent page="1" ?>LPD
+        </mi>
+       </mstyle>
+      </math>
+      <?MarkedContent page="1" ?>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0012"
+        >
+       <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0013"
+          displaystyle="false"
+          scriptlevel="1"
+         >
+        <mrow xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0014"
+          >
+         <mi xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0015"
+           >
+          <?MarkedContent page="1" ?>𝑥
+         </mi>
+         <mo xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0016"
+            lspace="0"
+            rspace="0"
+           >
+          <?MarkedContent page="1" ?>,
+         </mo>
+         <mi xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0017"
+           >
+          <?MarkedContent page="1" ?>𝑦
+         </mi>
+        </mrow>
+       </mstyle>
+      </math>
+      <?MarkedContent page="1" ?>
+      <?MarkedContent page="1" ?>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0018"
+        >
+       <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0019"
+         >
+       </mtext>
+       <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0020"
+         >
+       </mtext>
+       <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0021"
+          width="-20.262pt"
+         >
+       </mspace>
+       <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0022"
+         >
+        <math xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0023"
+          >
+         <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0024"
+            displaystyle="false"
+            scriptlevel="1"
+           >
+          <mi xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0025"
+             mathvariant="normal"
+            >
+          </mi>
+         </mstyle>
+        </math>
+       </mtext>
+       <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0026"
+          width="-20.262pt"
+         >
+       </mspace>
+       <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0027"
+         >
+        <math xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0028"
+          >
+         <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0029"
+            displaystyle="false"
+            scriptlevel="1"
+           >
+          <mrow xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0030"
+            >
+           <mi xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0031"
+             >
+           </mi>
+           <mo xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0032"
+              lspace="0"
+              rspace="0"
+             >
+           </mo>
+           <mi xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0033"
+             >
+           </mi>
+          </mrow>
+         </mstyle>
+        </math>
+       </mtext>
+      </math>
+      <?MarkedContent page="1" ?>
+      <?MarkedContent page="1" ?>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0034"
+        >
+       <mi xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0035"
+          mathvariant="normal"
+         >
+        <?MarkedContent page="1" ?>Γ
+       </mi>
+       <mo xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0036"
+          lspace="0.278em"
+          rspace="0.278em"
+         >
+        <math xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0037"
+          >
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0038"
+           >
+         </mtext>
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0039"
+           >
+         </mtext>
+         <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0040"
+            width="-20.262pt"
+           >
+         </mspace>
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0041"
+           >
+          <math xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0042"
+            >
+           <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0043"
+              displaystyle="false"
+              scriptlevel="1"
+             >
+            <mi xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0044"
+               mathvariant="normal"
+              >
+            </mi>
+           </mstyle>
+          </math>
+         </mtext>
+         <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0045"
+            width="-20.262pt"
+           >
+         </mspace>
+         <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0046"
+           >
+          <math xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0047"
+            >
+           <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0048"
+              displaystyle="false"
+              scriptlevel="1"
+             >
+            <mrow xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0049"
+              >
+             <mi xmlns="http://www.w3.org/1998/Math/MathML"
+                id="ID.0050"
+               >
+             </mi>
+             <mo xmlns="http://www.w3.org/1998/Math/MathML"
+                id="ID.0051"
+                lspace="0"
+                rspace="0"
+               >
+             </mo>
+             <mi xmlns="http://www.w3.org/1998/Math/MathML"
+                id="ID.0052"
+               >
+             </mi>
+            </mrow>
+           </mstyle>
+          </math>
+         </mtext>
+        </math>
+       </mo>
+       <mi xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0053"
+         >
+        <?MarkedContent page="1" ?>𝑃
+       </mi>
+      </math>
+      <?MarkedContent page="1" ?>
+     </Formula>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.0054"
+      rolemaps-to="Part"
+     >
+    <Formula xmlns="http://iso.org/pdf2/ssn"
+       id="ID.0055"
+       title="equation*"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:Placement="Block"
+      >
+     <?MarkedContent page="1" ?>
+     <math xmlns="http://www.w3.org/1998/Math/MathML"
+        id="ID.0056"
+       >
+      <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0057"
+         displaystyle="false"
+         scriptlevel="1"
+        >
+       <mi xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0058"
+          mathvariant="normal"
+         >
+        <?MarkedContent page="1" ?>LC
+       </mi>
+      </mstyle>
+     </math>
+     <?MarkedContent page="1" ?>
+     <math xmlns="http://www.w3.org/1998/Math/MathML"
+        id="ID.0059"
+       >
+      <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0060"
+         displaystyle="false"
+         scriptlevel="1"
+        >
+       <mrow xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0061"
+         >
+        <mi xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0062"
+          >
+         <?MarkedContent page="1" ?>𝑥
+        </mi>
+        <mo xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0063"
+           lspace="0"
+           rspace="0"
+          >
+         <?MarkedContent page="1" ?>,
+        </mo>
+        <mi xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0064"
+          >
+         <?MarkedContent page="1" ?>𝑦
+        </mi>
+        <mo xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0065"
+           lspace="0"
+           rspace="0"
+          >
+         <?MarkedContent page="1" ?>,
+        </mo>
+        <mi xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0066"
+          >
+         <?MarkedContent page="1" ?>𝑧
+        </mi>
+        <mo xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0067"
+           lspace="0"
+           rspace="0"
+          >
+         <?MarkedContent page="1" ?>,
+        </mo>
+        <mi xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0068"
+          >
+         <?MarkedContent page="1" ?>𝑤
+        </mi>
+       </mrow>
+      </mstyle>
+     </math>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <math xmlns="http://www.w3.org/1998/Math/MathML"
+        id="ID.0069"
+       >
+      <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0070"
+        >
+      </mtext>
+      <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0071"
+        >
+      </mtext>
+      <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0072"
+         width="-29.286pt"
+        >
+      </mspace>
+      <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0073"
+        >
+      </mtext>
+      <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0074"
+         width="-29.286pt"
+        >
+      </mspace>
+      <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0075"
+        >
+      </mtext>
+      <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0076"
+         width="-29.286pt"
+        >
+      </mspace>
+      <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0077"
+        >
+       <math xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0078"
+         >
+        <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0079"
+           displaystyle="false"
+           scriptlevel="1"
+          >
+         <mi xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0080"
+            mathvariant="normal"
+           >
+         </mi>
+        </mstyle>
+       </math>
+      </mtext>
+      <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0081"
+         width="-29.286pt"
+        >
+      </mspace>
+      <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0082"
+        >
+       <math xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0083"
+         >
+        <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0084"
+           displaystyle="false"
+           scriptlevel="1"
+          >
+         <mrow xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0085"
+           >
+          <mi xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0086"
+            >
+          </mi>
+          <mo xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0087"
+             lspace="0"
+             rspace="0"
+            >
+          </mo>
+          <mi xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0088"
+            >
+          </mi>
+          <mo xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0089"
+             lspace="0"
+             rspace="0"
+            >
+          </mo>
+          <mi xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0090"
+            >
+          </mi>
+          <mo xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0091"
+             lspace="0"
+             rspace="0"
+            >
+          </mo>
+          <mi xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0092"
+            >
+          </mi>
+         </mrow>
+        </mstyle>
+       </math>
+      </mtext>
+      <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0093"
+        >
+      </mtext>
+     </math>
+     <?MarkedContent page="1" ?>
+     <math xmlns="http://www.w3.org/1998/Math/MathML"
+        id="ID.0094"
+        display="block"
+       >
+      <mi xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0095"
+         mathvariant="normal"
+        >
+       <?MarkedContent page="1" ?>Γ
+      </mi>
+      <mo xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0096"
+         lspace="0.278em"
+         rspace="0.278em"
+        >
+       <math xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0097"
+         >
+        <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0098"
+          >
+        </mtext>
+        <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0099"
+          >
+        </mtext>
+        <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0100"
+           width="-29.286pt"
+          >
+        </mspace>
+        <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0101"
+          >
+        </mtext>
+        <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0102"
+           width="-29.286pt"
+          >
+        </mspace>
+        <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0103"
+          >
+        </mtext>
+        <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0104"
+           width="-29.286pt"
+          >
+        </mspace>
+        <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0105"
+          >
+         <math xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0106"
+           >
+          <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0107"
+             displaystyle="false"
+             scriptlevel="1"
+            >
+           <mi xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0108"
+              mathvariant="normal"
+             >
+           </mi>
+          </mstyle>
+         </math>
+        </mtext>
+        <mspace xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0109"
+           width="-29.286pt"
+          >
+        </mspace>
+        <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0110"
+          >
+         <math xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0111"
+           >
+          <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0112"
+             displaystyle="false"
+             scriptlevel="1"
+            >
+           <mrow xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0113"
+             >
+            <mi xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0114"
+              >
+            </mi>
+            <mo xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0115"
+               lspace="0"
+               rspace="0"
+              >
+            </mo>
+            <mi xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0116"
+              >
+            </mi>
+            <mo xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0117"
+               lspace="0"
+               rspace="0"
+              >
+            </mo>
+            <mi xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0118"
+              >
+            </mi>
+            <mo xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0119"
+               lspace="0"
+               rspace="0"
+              >
+            </mo>
+            <mi xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0120"
+              >
+            </mi>
+           </mrow>
+          </mstyle>
+         </math>
+        </mtext>
+        <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0121"
+          >
+        </mtext>
+       </math>
+      </mo>
+      <mi xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0122"
+        >
+       <?MarkedContent page="1" ?>𝑃
+      </mi>
+     </math>
+    </Formula>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-partial-mathml/turnstile/turnstile-02-BAD.tex
+++ b/tagging-status/testfiles-partial-mathml/turnstile/turnstile-02-BAD.tex
@@ -1,0 +1,22 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on,
+    tagging-setup={math/setup=mathml-SE},
+  }
+\documentclass{article}
+
+\UseName{sys_if_engine_opentype:T}{\usepackage{unicode-math}}
+\usepackage{turnstile}
+
+\title{turnstile tagging test}
+
+\begin{document}
+
+$\Gamma \sststile{\mathrm{LPD}}{x,y} P$
+
+\[\Gamma \stststile{\mathrm{LC}}{x,y,z,w} P\]
+
+\end{document}

--- a/tagging-status/testfiles-partial-mathml/underoverlap/underoverlap-02-BAD.pdftex.struct.xml
+++ b/tagging-status/testfiles-partial-mathml/underoverlap/underoverlap-02-BAD.pdftex.struct.xml
@@ -1,0 +1,34 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.02"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.05"
+      rolemaps-to="Part"
+     >
+    <Formula xmlns="http://iso.org/pdf2/ssn"
+       id="ID.06"
+       title="equation*"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:Placement="Block"
+      >
+     <?MarkedContent page="1" ?>a +x⏟⏞⏞⏟b +⏞⏟⏟⏞yc +d +e +f
+    </Formula>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.07"
+      rolemaps-to="Part"
+     >
+    <Formula xmlns="http://iso.org/pdf2/ssn"
+       id="ID.08"
+       title="equation*"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:Placement="Block"
+      >
+     <?MarkedContent page="1" ?>a +x⏟⏞⏞⏟b +⏞⏟⏟⏞yc +z⏟⏞⏞⏟d +e +f
+    </Formula>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-partial-mathml/underoverlap/underoverlap-02-BAD.struct.xml
+++ b/tagging-status/testfiles-partial-mathml/underoverlap/underoverlap-02-BAD.struct.xml
@@ -1,0 +1,1212 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.0002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.0006"
+      rolemaps-to="Part"
+     >
+    <Formula xmlns="http://iso.org/pdf2/ssn"
+       id="ID.0007"
+       title="equation*"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:Placement="Block"
+      >
+     <math xmlns="http://www.w3.org/1998/Math/MathML"
+        id="ID.0016"
+       >
+      <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0017"
+         displaystyle="false"
+         scriptlevel="1"
+        >
+       <mi xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0018"
+         >
+        <?MarkedContent page="1" ?>𝑥
+       </mi>
+      </mstyle>
+     </math>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <math xmlns="http://www.w3.org/1998/Math/MathML"
+        id="ID.0019"
+       >
+      <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0020"
+         displaystyle="false"
+         scriptlevel="1"
+        >
+      </mstyle>
+     </math>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <math xmlns="http://www.w3.org/1998/Math/MathML"
+        id="ID.0021"
+       >
+      <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0022"
+         displaystyle="true"
+         scriptlevel="0"
+        >
+       <munderover xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0023"
+         >
+        <mover xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0024"
+          >
+         <mpadded xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0025"
+           >
+          <mphantom xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0008"
+            >
+           <mrow xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0009"
+             >
+            <mi xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0010"
+              >
+            </mi>
+            <mo xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0011"
+               lspace="0.222em"
+               rspace="0.222em"
+              >
+            </mo>
+           </mrow>
+           <mrow xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0012"
+             >
+            <mi xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0013"
+              >
+            </mi>
+            <mo xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0014"
+               lspace="0.222em"
+               rspace="0.222em"
+              >
+            </mo>
+            <mi xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0015"
+              >
+            </mi>
+           </mrow>
+          </mphantom>
+         </mpadded>
+         <mo xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0026"
+           >
+          <?MarkedContent page="1" ?>⏞
+         </mo>
+        </mover>
+        <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0027"
+          >
+         <math xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0028"
+           >
+          <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0029"
+             displaystyle="false"
+             scriptlevel="1"
+            >
+          </mstyle>
+         </math>
+        </mtext>
+        <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0030"
+          >
+         <math xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0031"
+           >
+          <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0032"
+             displaystyle="false"
+             scriptlevel="1"
+            >
+           <mi xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0033"
+             >
+           </mi>
+          </mstyle>
+         </math>
+        </mtext>
+       </munderover>
+      </mstyle>
+     </math>
+     <?MarkedContent page="1" ?>
+     <math xmlns="http://www.w3.org/1998/Math/MathML"
+        id="ID.0042"
+       >
+      <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0043"
+         displaystyle="false"
+         scriptlevel="1"
+        >
+      </mstyle>
+     </math>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <math xmlns="http://www.w3.org/1998/Math/MathML"
+        id="ID.0044"
+       >
+      <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0045"
+         displaystyle="false"
+         scriptlevel="1"
+        >
+       <mi xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0046"
+         >
+        <?MarkedContent page="1" ?>𝑦
+       </mi>
+      </mstyle>
+     </math>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <math xmlns="http://www.w3.org/1998/Math/MathML"
+        id="ID.0047"
+       >
+      <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0048"
+         displaystyle="true"
+         scriptlevel="0"
+        >
+       <munderover xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0049"
+         >
+        <munder xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0050"
+          >
+         <mpadded xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0051"
+           >
+          <mphantom xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0034"
+            >
+           <mrow xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0035"
+             >
+            <mi xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0036"
+              >
+            </mi>
+            <mo xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0037"
+               lspace="0.222em"
+               rspace="0.222em"
+              >
+            </mo>
+            <mi xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0038"
+              >
+            </mi>
+           </mrow>
+           <mrow xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0039"
+             >
+            <mo xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0040"
+               lspace="0.222em"
+               rspace="0.222em"
+              >
+            </mo>
+            <mi xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0041"
+              >
+            </mi>
+           </mrow>
+          </mphantom>
+         </mpadded>
+         <mo xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0052"
+           >
+          <?MarkedContent page="1" ?>⏟
+         </mo>
+        </munder>
+        <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0053"
+          >
+         <math xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0054"
+           >
+          <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0055"
+             displaystyle="false"
+             scriptlevel="1"
+            >
+           <mi xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0056"
+             >
+           </mi>
+          </mstyle>
+         </math>
+        </mtext>
+        <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0057"
+          >
+         <math xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0058"
+           >
+          <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0059"
+             displaystyle="false"
+             scriptlevel="1"
+            >
+          </mstyle>
+         </math>
+        </mtext>
+       </munderover>
+      </mstyle>
+     </math>
+     <?MarkedContent page="1" ?>
+     <math xmlns="http://www.w3.org/1998/Math/MathML"
+        id="ID.0060"
+        display="block"
+       >
+      <mi xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0061"
+        >
+       <?MarkedContent page="1" ?>𝑎
+      </mi>
+      <mo xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0062"
+         lspace="0.222em"
+         rspace="0.222em"
+        >
+       <?MarkedContent page="1" ?>+
+      </mo>
+      <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0063"
+        >
+       <math xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0064"
+         >
+        <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0065"
+           displaystyle="true"
+           scriptlevel="0"
+          >
+         <munderover xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0066"
+           >
+          <mover xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0067"
+            >
+           <mpadded xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0068"
+             >
+            <mphantom xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0008"
+              >
+             <mrow xmlns="http://www.w3.org/1998/Math/MathML"
+                id="ID.0009"
+               >
+              <mi xmlns="http://www.w3.org/1998/Math/MathML"
+                 id="ID.0010"
+                >
+              </mi>
+              <mo xmlns="http://www.w3.org/1998/Math/MathML"
+                 id="ID.0011"
+                 lspace="0.222em"
+                 rspace="0.222em"
+                >
+              </mo>
+             </mrow>
+             <mrow xmlns="http://www.w3.org/1998/Math/MathML"
+                id="ID.0012"
+               >
+              <mi xmlns="http://www.w3.org/1998/Math/MathML"
+                 id="ID.0013"
+                >
+              </mi>
+              <mo xmlns="http://www.w3.org/1998/Math/MathML"
+                 id="ID.0014"
+                 lspace="0.222em"
+                 rspace="0.222em"
+                >
+              </mo>
+              <mi xmlns="http://www.w3.org/1998/Math/MathML"
+                 id="ID.0015"
+                >
+              </mi>
+             </mrow>
+            </mphantom>
+           </mpadded>
+           <mo xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0069"
+             >
+           </mo>
+          </mover>
+          <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0070"
+            >
+           <math xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0071"
+             >
+            <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0072"
+               displaystyle="false"
+               scriptlevel="1"
+              >
+            </mstyle>
+           </math>
+          </mtext>
+          <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0073"
+            >
+           <math xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0074"
+             >
+            <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0075"
+               displaystyle="false"
+               scriptlevel="1"
+              >
+             <mi xmlns="http://www.w3.org/1998/Math/MathML"
+                id="ID.0076"
+               >
+             </mi>
+            </mstyle>
+           </math>
+          </mtext>
+         </munderover>
+        </mstyle>
+       </math>
+      </mtext>
+      <mrow xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0077"
+        >
+       <mi xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0078"
+         >
+        <?MarkedContent page="1" ?>𝑏
+       </mi>
+       <mo xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0079"
+          lspace="0.222em"
+          rspace="0.222em"
+         >
+        <?MarkedContent page="1" ?>+
+       </mo>
+      </mrow>
+      <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0080"
+        >
+       <math xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0081"
+         >
+        <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0082"
+           displaystyle="true"
+           scriptlevel="0"
+          >
+         <munderover xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0083"
+           >
+          <munder xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0084"
+            >
+           <mpadded xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0085"
+             >
+            <mphantom xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0034"
+              >
+             <mrow xmlns="http://www.w3.org/1998/Math/MathML"
+                id="ID.0035"
+               >
+              <mi xmlns="http://www.w3.org/1998/Math/MathML"
+                 id="ID.0036"
+                >
+              </mi>
+              <mo xmlns="http://www.w3.org/1998/Math/MathML"
+                 id="ID.0037"
+                 lspace="0.222em"
+                 rspace="0.222em"
+                >
+              </mo>
+              <mi xmlns="http://www.w3.org/1998/Math/MathML"
+                 id="ID.0038"
+                >
+              </mi>
+             </mrow>
+             <mrow xmlns="http://www.w3.org/1998/Math/MathML"
+                id="ID.0039"
+               >
+              <mo xmlns="http://www.w3.org/1998/Math/MathML"
+                 id="ID.0040"
+                 lspace="0.222em"
+                 rspace="0.222em"
+                >
+              </mo>
+              <mi xmlns="http://www.w3.org/1998/Math/MathML"
+                 id="ID.0041"
+                >
+              </mi>
+             </mrow>
+            </mphantom>
+           </mpadded>
+           <mo xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0086"
+             >
+           </mo>
+          </munder>
+          <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0087"
+            >
+           <math xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0088"
+             >
+            <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0089"
+               displaystyle="false"
+               scriptlevel="1"
+              >
+             <mi xmlns="http://www.w3.org/1998/Math/MathML"
+                id="ID.0090"
+               >
+             </mi>
+            </mstyle>
+           </math>
+          </mtext>
+          <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0091"
+            >
+           <math xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0092"
+             >
+            <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0093"
+               displaystyle="false"
+               scriptlevel="1"
+              >
+            </mstyle>
+           </math>
+          </mtext>
+         </munderover>
+        </mstyle>
+       </math>
+      </mtext>
+      <mrow xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0094"
+        >
+       <mi xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0095"
+         >
+        <?MarkedContent page="1" ?>𝑐
+       </mi>
+       <mo xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0096"
+          lspace="0.222em"
+          rspace="0.222em"
+         >
+        <?MarkedContent page="1" ?>+
+       </mo>
+       <mi xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0097"
+         >
+        <?MarkedContent page="1" ?>𝑑
+       </mi>
+      </mrow>
+      <mrow xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0098"
+        >
+       <mo xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0099"
+          lspace="0.222em"
+          rspace="0.222em"
+         >
+        <?MarkedContent page="1" ?>+
+       </mo>
+       <mi xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0100"
+         >
+        <?MarkedContent page="1" ?>𝑒
+       </mi>
+      </mrow>
+      <mo xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0101"
+         lspace="0.222em"
+         rspace="0.222em"
+        >
+       <?MarkedContent page="1" ?>+
+      </mo>
+      <mi xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0102"
+        >
+       <?MarkedContent page="1" ?>𝑓
+      </mi>
+     </math>
+    </Formula>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.0103"
+      rolemaps-to="Part"
+     >
+    <Formula xmlns="http://iso.org/pdf2/ssn"
+       id="ID.0104"
+       title="equation*"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:Placement="Block"
+      >
+     <math xmlns="http://www.w3.org/1998/Math/MathML"
+        id="ID.0110"
+       >
+      <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0111"
+         displaystyle="false"
+         scriptlevel="1"
+        >
+       <mi xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0112"
+         >
+        <?MarkedContent page="1" ?>𝑥
+       </mi>
+      </mstyle>
+     </math>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <math xmlns="http://www.w3.org/1998/Math/MathML"
+        id="ID.0113"
+       >
+      <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0114"
+         displaystyle="false"
+         scriptlevel="1"
+        >
+      </mstyle>
+     </math>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <math xmlns="http://www.w3.org/1998/Math/MathML"
+        id="ID.0115"
+       >
+      <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0116"
+         displaystyle="true"
+         scriptlevel="0"
+        >
+       <munderover xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0117"
+         >
+        <mover xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0118"
+          >
+         <mpadded xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0119"
+           >
+          <mphantom xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0105"
+            >
+           <mrow xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0106"
+             >
+            <mi xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0107"
+              >
+            </mi>
+            <mo xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0108"
+               lspace="0.222em"
+               rspace="0.222em"
+              >
+            </mo>
+           </mrow>
+           <mi xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0109"
+             >
+           </mi>
+          </mphantom>
+         </mpadded>
+         <mo xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0120"
+           >
+          <?MarkedContent page="1" ?>⏞
+         </mo>
+        </mover>
+        <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0121"
+          >
+         <math xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0122"
+           >
+          <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0123"
+             displaystyle="false"
+             scriptlevel="1"
+            >
+          </mstyle>
+         </math>
+        </mtext>
+        <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0124"
+          >
+         <math xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0125"
+           >
+          <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0126"
+             displaystyle="false"
+             scriptlevel="1"
+            >
+           <mi xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0127"
+             >
+           </mi>
+          </mstyle>
+         </math>
+        </mtext>
+       </munderover>
+      </mstyle>
+     </math>
+     <?MarkedContent page="1" ?>
+     <math xmlns="http://www.w3.org/1998/Math/MathML"
+        id="ID.0132"
+       >
+      <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0133"
+         displaystyle="false"
+         scriptlevel="1"
+        >
+      </mstyle>
+     </math>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <math xmlns="http://www.w3.org/1998/Math/MathML"
+        id="ID.0134"
+       >
+      <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0135"
+         displaystyle="false"
+         scriptlevel="1"
+        >
+       <mi xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0136"
+         >
+        <?MarkedContent page="1" ?>𝑦
+       </mi>
+      </mstyle>
+     </math>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <math xmlns="http://www.w3.org/1998/Math/MathML"
+        id="ID.0137"
+       >
+      <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0138"
+         displaystyle="true"
+         scriptlevel="0"
+        >
+       <munderover xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0139"
+         >
+        <munder xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0140"
+          >
+         <mpadded xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0141"
+           >
+          <mphantom xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0128"
+            >
+           <mi xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0129"
+             >
+           </mi>
+           <mi xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0130"
+              mathvariant="normal"
+             >
+           </mi>
+           <mi xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0131"
+             >
+           </mi>
+          </mphantom>
+         </mpadded>
+         <mo xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0142"
+           >
+          <?MarkedContent page="1" ?>⏟
+         </mo>
+        </munder>
+        <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0143"
+          >
+         <math xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0144"
+           >
+          <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0145"
+             displaystyle="false"
+             scriptlevel="1"
+            >
+           <mi xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0146"
+             >
+           </mi>
+          </mstyle>
+         </math>
+        </mtext>
+        <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0147"
+          >
+         <math xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0148"
+           >
+          <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0149"
+             displaystyle="false"
+             scriptlevel="1"
+            >
+          </mstyle>
+         </math>
+        </mtext>
+       </munderover>
+      </mstyle>
+     </math>
+     <?MarkedContent page="1" ?>
+     <math xmlns="http://www.w3.org/1998/Math/MathML"
+        id="ID.0155"
+       >
+      <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0156"
+         displaystyle="false"
+         scriptlevel="1"
+        >
+       <mi xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0157"
+         >
+        <?MarkedContent page="1" ?>𝑧
+       </mi>
+      </mstyle>
+     </math>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <math xmlns="http://www.w3.org/1998/Math/MathML"
+        id="ID.0158"
+       >
+      <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0159"
+         displaystyle="false"
+         scriptlevel="1"
+        >
+      </mstyle>
+     </math>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <math xmlns="http://www.w3.org/1998/Math/MathML"
+        id="ID.0160"
+       >
+      <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0161"
+         displaystyle="true"
+         scriptlevel="0"
+        >
+       <munderover xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0162"
+         >
+        <mover xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0163"
+          >
+         <mpadded xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0164"
+           >
+          <mphantom xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0150"
+            >
+           <mi xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0151"
+             >
+           </mi>
+           <mrow xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0152"
+             >
+            <mo xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0153"
+               lspace="0.222em"
+               rspace="0.222em"
+              >
+            </mo>
+            <mi xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0154"
+              >
+            </mi>
+           </mrow>
+          </mphantom>
+         </mpadded>
+         <mo xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0165"
+           >
+          <?MarkedContent page="1" ?>⏞
+         </mo>
+        </mover>
+        <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0166"
+          >
+         <math xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0167"
+           >
+          <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0168"
+             displaystyle="false"
+             scriptlevel="1"
+            >
+          </mstyle>
+         </math>
+        </mtext>
+        <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0169"
+          >
+         <math xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0170"
+           >
+          <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0171"
+             displaystyle="false"
+             scriptlevel="1"
+            >
+           <mi xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0172"
+             >
+           </mi>
+          </mstyle>
+         </math>
+        </mtext>
+       </munderover>
+      </mstyle>
+     </math>
+     <?MarkedContent page="1" ?>
+     <math xmlns="http://www.w3.org/1998/Math/MathML"
+        id="ID.0173"
+        display="block"
+       >
+      <mi xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0174"
+        >
+       <?MarkedContent page="1" ?>𝑎
+      </mi>
+      <mo xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0175"
+         lspace="0.222em"
+         rspace="0.222em"
+        >
+       <?MarkedContent page="1" ?>+
+      </mo>
+      <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0176"
+        >
+       <math xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0177"
+         >
+        <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0178"
+           displaystyle="true"
+           scriptlevel="0"
+          >
+         <munderover xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0179"
+           >
+          <mover xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0180"
+            >
+           <mpadded xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0181"
+             >
+            <mphantom xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0105"
+              >
+             <mrow xmlns="http://www.w3.org/1998/Math/MathML"
+                id="ID.0106"
+               >
+              <mi xmlns="http://www.w3.org/1998/Math/MathML"
+                 id="ID.0107"
+                >
+              </mi>
+              <mo xmlns="http://www.w3.org/1998/Math/MathML"
+                 id="ID.0108"
+                 lspace="0.222em"
+                 rspace="0.222em"
+                >
+              </mo>
+             </mrow>
+             <mi xmlns="http://www.w3.org/1998/Math/MathML"
+                id="ID.0109"
+               >
+             </mi>
+            </mphantom>
+           </mpadded>
+           <mo xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0182"
+             >
+           </mo>
+          </mover>
+          <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0183"
+            >
+           <math xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0184"
+             >
+            <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0185"
+               displaystyle="false"
+               scriptlevel="1"
+              >
+            </mstyle>
+           </math>
+          </mtext>
+          <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0186"
+            >
+           <math xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0187"
+             >
+            <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0188"
+               displaystyle="false"
+               scriptlevel="1"
+              >
+             <mi xmlns="http://www.w3.org/1998/Math/MathML"
+                id="ID.0189"
+               >
+             </mi>
+            </mstyle>
+           </math>
+          </mtext>
+         </munderover>
+        </mstyle>
+       </math>
+      </mtext>
+      <mrow xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0190"
+        >
+       <mi xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0191"
+         >
+        <?MarkedContent page="1" ?>𝑏
+       </mi>
+       <mo xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0192"
+          lspace="0.222em"
+          rspace="0.222em"
+         >
+        <?MarkedContent page="1" ?>+
+       </mo>
+      </mrow>
+      <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0193"
+        >
+       <math xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0194"
+         >
+        <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0195"
+           displaystyle="true"
+           scriptlevel="0"
+          >
+         <munderover xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0196"
+           >
+          <munder xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0197"
+            >
+           <mpadded xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0198"
+             >
+            <mphantom xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0128"
+              >
+             <mi xmlns="http://www.w3.org/1998/Math/MathML"
+                id="ID.0129"
+               >
+             </mi>
+             <mi xmlns="http://www.w3.org/1998/Math/MathML"
+                id="ID.0130"
+                mathvariant="normal"
+               >
+             </mi>
+             <mi xmlns="http://www.w3.org/1998/Math/MathML"
+                id="ID.0131"
+               >
+             </mi>
+            </mphantom>
+           </mpadded>
+           <mo xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0199"
+             >
+           </mo>
+          </munder>
+          <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0200"
+            >
+           <math xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0201"
+             >
+            <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0202"
+               displaystyle="false"
+               scriptlevel="1"
+              >
+             <mi xmlns="http://www.w3.org/1998/Math/MathML"
+                id="ID.0203"
+               >
+             </mi>
+            </mstyle>
+           </math>
+          </mtext>
+          <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0204"
+            >
+           <math xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0205"
+             >
+            <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0206"
+               displaystyle="false"
+               scriptlevel="1"
+              >
+            </mstyle>
+           </math>
+          </mtext>
+         </munderover>
+        </mstyle>
+       </math>
+      </mtext>
+      <mi xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0207"
+        >
+       <?MarkedContent page="1" ?>𝑐
+      </mi>
+      <mi xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0208"
+         mathvariant="normal"
+        >
+       <?MarkedContent page="1" ?>+
+      </mi>
+      <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0209"
+        >
+       <math xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0210"
+         >
+        <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+           id="ID.0211"
+           displaystyle="true"
+           scriptlevel="0"
+          >
+         <munderover xmlns="http://www.w3.org/1998/Math/MathML"
+            id="ID.0212"
+           >
+          <mover xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0213"
+            >
+           <mpadded xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0214"
+             >
+            <mphantom xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0150"
+              >
+             <mi xmlns="http://www.w3.org/1998/Math/MathML"
+                id="ID.0151"
+               >
+             </mi>
+             <mrow xmlns="http://www.w3.org/1998/Math/MathML"
+                id="ID.0152"
+               >
+              <mo xmlns="http://www.w3.org/1998/Math/MathML"
+                 id="ID.0153"
+                 lspace="0.222em"
+                 rspace="0.222em"
+                >
+              </mo>
+              <mi xmlns="http://www.w3.org/1998/Math/MathML"
+                 id="ID.0154"
+                >
+              </mi>
+             </mrow>
+            </mphantom>
+           </mpadded>
+           <mo xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0215"
+             >
+           </mo>
+          </mover>
+          <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0216"
+            >
+           <math xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0217"
+             >
+            <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0218"
+               displaystyle="false"
+               scriptlevel="1"
+              >
+            </mstyle>
+           </math>
+          </mtext>
+          <mtext xmlns="http://www.w3.org/1998/Math/MathML"
+             id="ID.0219"
+            >
+           <math xmlns="http://www.w3.org/1998/Math/MathML"
+              id="ID.0220"
+             >
+            <mstyle xmlns="http://www.w3.org/1998/Math/MathML"
+               id="ID.0221"
+               displaystyle="false"
+               scriptlevel="1"
+              >
+             <mi xmlns="http://www.w3.org/1998/Math/MathML"
+                id="ID.0222"
+               >
+             </mi>
+            </mstyle>
+           </math>
+          </mtext>
+         </munderover>
+        </mstyle>
+       </math>
+      </mtext>
+      <mi xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0223"
+        >
+       <?MarkedContent page="1" ?>𝑑
+      </mi>
+      <mrow xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0224"
+        >
+       <mo xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0225"
+          lspace="0.222em"
+          rspace="0.222em"
+         >
+        <?MarkedContent page="1" ?>+
+       </mo>
+       <mi xmlns="http://www.w3.org/1998/Math/MathML"
+          id="ID.0226"
+         >
+        <?MarkedContent page="1" ?>𝑒
+       </mi>
+      </mrow>
+      <mo xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0227"
+         lspace="0.222em"
+         rspace="0.222em"
+        >
+       <?MarkedContent page="1" ?>+
+      </mo>
+      <mi xmlns="http://www.w3.org/1998/Math/MathML"
+         id="ID.0228"
+        >
+       <?MarkedContent page="1" ?>𝑓
+      </mi>
+     </math>
+    </Formula>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-partial-mathml/underoverlap/underoverlap-02-BAD.tex
+++ b/tagging-status/testfiles-partial-mathml/underoverlap/underoverlap-02-BAD.tex
@@ -1,0 +1,22 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on,
+    tagging-setup={math/setup=mathml-SE},
+  }
+\documentclass{article}
+
+\UseName{sys_if_engine_opentype:T}{\usepackage{unicode-math}}
+\usepackage{underoverlap}
+
+\title{underoverlap tagging test -- mathml-SE}
+
+\begin{document}
+
+\[ a + \UOLoverbrace{b +}[c + d]^x \UOLunderbrace{+ e}_y + f \]
+
+\[ a + \UOLoverbrace{b +}[c]^x \UOLunderbrace{+}[d]_y \UOLoverbrace{+ e}^z + f \]
+
+\end{document}


### PR DESCRIPTION
See several recent issues. The test chemarr-03-BAD is producing `<run-error err="assertion failed!" />` with luatex which I can't account for because it seems to run fine individually. I guess something is wrong with the PDF so that show-pdf-tags fails.