### PR TITLE
List lualineno as compatible

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -8195,8 +8195,8 @@
   status: compatible
   priority: 9
   luatex-only: true
-  comments: "Tagged content in line numbers must have tagging suspended. Regular
-             line numbers are automatically tagged as artifacts."
+  comments: "Content with tagged structure in line numbers must have tagging suspended.
+             Regular line numbers are automatically tagged as artifacts."
   tests: true
   updated: 2026-06-29
 

--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -7816,7 +7816,8 @@
   priority: 2
   issues: [162,210]
   tests: true
-  comments: "loses linenumbers and doesn't tag line numbers"
+  comments: "Loses line numbers and line numbers are not tagged correctly.
+             See lualineno for a compatible alternative."
   tasks: needs more tests
   updated: 2024-07-19
 

--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -8189,6 +8189,16 @@
   tests: true
   updated: 2026-04-01
 
+- name: lualineno
+  type: package
+  status: compatible
+  priority: 9
+  luatex-only: true
+  comments: "Tagged content in line numbers must have tagging suspended. Regular
+             line numbers are automatically tagged as artifacts."
+  tests: true
+  updated: 2026-06-29
+
 - name: luamathalign
   type: package
   status: currently-incompatible

--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -8197,6 +8197,7 @@
   luatex-only: true
   comments: "Content with tagged structure in line numbers must have tagging suspended.
              Regular line numbers are automatically tagged as artifacts."
+  related-issues: [210]
   tests: true
   updated: 2026-06-29
 

--- a/tagging-status/testfiles-compatible-luatex/lualineno/lualineno-01.struct.xml
+++ b/tagging-status/testfiles-compatible-luatex/lualineno/lualineno-01.struct.xml
@@ -1,0 +1,235 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.013"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.014"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>As any dedicated reader can clearly see, the Ideal 
+     <?MarkedContent page="1" ?>of practical reason is a representation of, as far as I 
+     <?MarkedContent page="1" ?>know, the things in themselves; as I have shown else
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>where, the phenomena should only be used as a canon 
+     <?MarkedContent page="1" ?>for our understanding. The paralogisms of practical 
+     <?MarkedContent page="1" ?>reason are what first give rise to the architectonic of 
+     <?MarkedContent page="1" ?>practical reason. As will easily be shown in the next 
+     <?MarkedContent page="1" ?>section, reason would thereby be made to contradict, 
+     <?MarkedContent page="1" ?>in view of these considerations, the Ideal of practical 
+     <?MarkedContent page="1" ?>reason, yet the manifold depends on the phenomena. 
+     <?MarkedContent page="1" ?>Necessity depends on, when thus treated as the prac
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>tical employment of the never-ending regress in the 
+     <?MarkedContent page="1" ?>series of empirical conditions, time. Human reason 
+     <?MarkedContent page="1" ?>depends on our sense perceptions, by means of ana
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>lytic unity. There can be no doubt that the objects 
+     <?MarkedContent page="1" ?>in space and time are what first give rise to human 
+     <?MarkedContent page="1" ?>reason.
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.015"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.016"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Let us suppose that the noumena have nothing to 
+     <?MarkedContent page="1" ?>do with necessity, since knowledge of the Categories 
+     <?MarkedContent page="1" ?>is a posteriori. Hume tells us that the transcendental 
+     <?MarkedContent page="1" ?>unity of apperception can not take account of the dis
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>cipline of natural reason, by means of analytic unity. 
+     <?MarkedContent page="1" ?>As is proven in the ontological manuals, it is obvious 
+     <?MarkedContent page="1" ?>that the transcendental unity of apperception proves 
+     <?MarkedContent page="1" ?>the validity of the Antinomies; what we have alone 
+     <?MarkedContent page="1" ?>been able to show is that, our understanding depends 
+     <?MarkedContent page="1" ?>on the Categories. It remains a mystery why the Ideal 
+     <?MarkedContent page="1" ?>stands in need of reason. It must not be supposed 
+     <?MarkedContent page="1" ?>that our faculties have lying before them, in the case 
+     <?MarkedContent page="1" ?>of the Ideal, the Antinomies; so, the transcendental 
+     <?MarkedContent page="1" ?>aesthetic is just as necessary as our experience. By 
+     <?MarkedContent page="1" ?>means of the Ideal, our sense perceptions are by their 
+     <?MarkedContent page="1" ?>very nature contradictory.
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.017"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.018"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>As is shown in the writings of Aristotle, the things 
+     <?MarkedContent page="1" ?>in themselves (and it remains a mystery why this is 
+     <?MarkedContent page="1" ?>the case) are a representation of time. Our concepts 
+     <?MarkedContent page="1" ?>have lying before them the paralogisms of natural rea
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>son, but our a posteriori concepts have lying before 
+     <?MarkedContent page="1" ?>them the practical employment of our experience. 
+     <?MarkedContent page="1" ?>Because of our necessary ignorance of the conditions, 
+     <?MarkedContent page="1" ?>the paralogisms would thereby be made to contradict, 
+     <?MarkedContent page="1" ?>indeed, space; for these reasons, the Transcendental 
+     <?MarkedContent page="1" ?>Deduction has lying before it our sense perceptions. 
+     <?MarkedContent page="1" ?>(Our a posteriori knowledge can never furnish a true 
+     <?MarkedContent page="1" ?>and demonstrated science, because, like time, it de
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>pends on analytic principles.) So, it must not be sup
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>posed that our experience depends on, so, our sense 
+     <?MarkedContent page="1" ?>perceptions, by means of analysis. Space constitutes 
+     <?MarkedContent page="1" ?>the whole content for our sense perceptions, and time 
+     <?MarkedContent page="1" ?>occupies part of the sphere of the Ideal concerning the 
+     <?MarkedContent page="1" ?>existence of the objects in space and time in general.
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.019"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.020"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>As we have already seen, what we have alone been 
+     <?MarkedContent page="1" ?>able to show is that the objects in space and time 
+     <?MarkedContent page="1" ?>would be falsified; what we have alone been able to 
+     <?MarkedContent page="1" ?>show is that, our judgements are what first give rise 
+     <?MarkedContent page="1" ?>to metaphysics. As I have shown elsewhere, Aris
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>totle tells us that the objects in space and time, in 
+     <?MarkedContent page="1" ?>the full sense of these terms, would be falsified. Let 
+     <?MarkedContent page="1" ?>us suppose that, indeed, our problematic judgements, 
+     <?MarkedContent page="1" ?>indeed, can be treated like our concepts. As any ded
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>icated reader can clearly see, our knowledge can be 
+     <?MarkedContent page="1" ?>treated like the transcendental unity of apperception, 
+     <?MarkedContent page="1" ?>but the phenomena occupy part of the sphere of the 
+     <?MarkedContent page="1" ?>manifold concerning the existence of natural causes in 
+     <?MarkedContent page="1" ?>general. Whence comes the architectonic of natural 
+     <?MarkedContent page="1" ?>reason, the solution of which involves the relation be
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>tween necessity and the Categories? Natural causes 
+     <?MarkedContent page="1" ?>(and it is not at all certain that this is the case) con
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>stitute the whole content for the paralogisms. This 
+     <?MarkedContent page="1" ?>could not be passed over in a complete system of tran
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>scendental philosophy, but in a merely critical essay 
+     <?MarkedContent page="1" ?>the simple mention of the fact may suffice.
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.021"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.022"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Therefore, we can deduce that the objects in space 
+     <?MarkedContent page="1" ?>and time (and I assert, however, that this is the case) 
+     <?MarkedContent page="1" ?>have lying before them the objects in space and time. 
+     <?MarkedContent page="1" ?>Because of our necessary ignorance of the conditions, 
+     <?MarkedContent page="1" ?>it must not be supposed that, then, formal logic (and 
+     <?MarkedContent page="1" ?>what we have alone been able to show is that this is 
+     <?MarkedContent page="2" ?>true) is a representation of the never-ending regress 
+     <?MarkedContent page="2" ?>in the series of empirical conditions, but the discipline 
+     <?MarkedContent page="2" ?>of pure reason, in so far as this expounds the contra
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>dictory rules of metaphysics, depends on the Anti
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>nomies. By means of analytic unity, our faculties, 
+     <?MarkedContent page="2" ?>therefore, can never, as a whole, furnish a true and 
+     <?MarkedContent page="2" ?>demonstrated science, because, like the transcenden
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>tal unity of apperception, they constitute the whole 
+     <?MarkedContent page="2" ?>content for a priori principles; for these reasons, our 
+     <?MarkedContent page="2" ?>experience is just as necessary as, in accordance with 
+     <?MarkedContent page="2" ?>the principles of our a priori knowledge, philosophy. 
+     <?MarkedContent page="2" ?>The objects in space and time abstract from all con
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>tent of knowledge. Has it ever been suggested that 
+     <?MarkedContent page="2" ?>it remains a mystery why there is no relation be
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>tween the Antinomies and the phenomena? It must 
+     <?MarkedContent page="2" ?>not be supposed that the Antinomies (and it is not 
+     <?MarkedContent page="2" ?>at all certain that this is the case) are the clue to 
+     <?MarkedContent page="2" ?>the discovery of philosophy, because of our necessary 
+     <?MarkedContent page="2" ?>ignorance of the conditions. As I have shown else
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>where, to avoid all misapprehension, it is necessary 
+     <?MarkedContent page="2" ?>to explain that our understanding (and it must not 
+     <?MarkedContent page="2" ?>be supposed that this is true) is what first gives rise 
+     <?MarkedContent page="2" ?>to the architectonic of pure reason, as is evident upon 
+     <?MarkedContent page="2" ?>close examination.
+    </text>
+   </text-unit>
+   <figures xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.004"
+      rolemaps-to="Sect"
+     >
+    <float xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.006"
+       rolemaps-to="Aside"
+      >
+     <Caption xmlns="http://iso.org/pdf2/ssn"
+        id="ID.010"
+       >
+      <Lbl xmlns="http://iso.org/pdf2/ssn"
+         id="ID.011"
+        >
+       <?MarkedContent page="1" ?>Figure 1: 
+      </Lbl>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.012"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Center"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>Look, a duck!
+      </text>
+     </Caption>
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.007"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.008"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Center"
+         rolemaps-to="P"
+        >
+       <Figure xmlns="http://iso.org/pdf2/ssn"
+          id="ID.009"
+          alt="A duck!"
+          xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+          Layout:BBox="{ 94.39102, 553.41429, 278.25157, 667.19801 }"
+         >
+        <?MarkedContent page="1" ?>
+       </Figure>
+      </text>
+     </text-unit>
+    </float>
+   </figures>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-compatible-luatex/lualineno/lualineno-01.struct.xml
+++ b/tagging-status/testfiles-compatible-luatex/lualineno/lualineno-01.struct.xml
@@ -4,11 +4,44 @@
      id="ID.002"
     >
    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
-      id="ID.013"
+      id="ID.006"
+      rolemaps-to="Part"
+     >
+    <Title xmlns="http://iso.org/pdf2/ssn"
+       id="ID.007"
+      >
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.008"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextAlign="Center"
+        rolemaps-to="P"
+       >
+      <?MarkedContent page="1" ?>lualineno tagging test
+     </text>
+    </Title>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.009"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Center"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?> Some author
+    </text>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.010"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Center"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Some date
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.018"
       rolemaps-to="Part"
      >
     <text xmlns="https://www.latex-project.org/ns/dflt"
-       id="ID.014"
+       id="ID.019"
        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
        Layout:TextAlign="Justify"
        rolemaps-to="P"
@@ -36,11 +69,11 @@
     </text>
    </text-unit>
    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
-      id="ID.015"
+      id="ID.020"
       rolemaps-to="Part"
      >
     <text xmlns="https://www.latex-project.org/ns/dflt"
-       id="ID.016"
+       id="ID.021"
        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
        Layout:TextAlign="Justify"
        rolemaps-to="P"
@@ -65,11 +98,11 @@
     </text>
    </text-unit>
    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
-      id="ID.017"
+      id="ID.022"
       rolemaps-to="Part"
      >
     <text xmlns="https://www.latex-project.org/ns/dflt"
-       id="ID.018"
+       id="ID.023"
        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
        Layout:TextAlign="Justify"
        rolemaps-to="P"
@@ -98,11 +131,11 @@
     </text>
    </text-unit>
    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
-      id="ID.019"
+      id="ID.024"
       rolemaps-to="Part"
      >
     <text xmlns="https://www.latex-project.org/ns/dflt"
-       id="ID.020"
+       id="ID.025"
        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
        Layout:TextAlign="Justify"
        rolemaps-to="P"
@@ -115,42 +148,42 @@
      <?MarkedContent page="1" ?>
      <?MarkedContent page="1" ?>totle tells us that the objects in space and time, in 
      <?MarkedContent page="1" ?>the full sense of these terms, would be falsified. Let 
-     <?MarkedContent page="1" ?>us suppose that, indeed, our problematic judgements, 
-     <?MarkedContent page="1" ?>indeed, can be treated like our concepts. As any ded
-     <?MarkedContent page="1" ?>
-     <?MarkedContent page="1" ?>icated reader can clearly see, our knowledge can be 
-     <?MarkedContent page="1" ?>treated like the transcendental unity of apperception, 
-     <?MarkedContent page="1" ?>but the phenomena occupy part of the sphere of the 
-     <?MarkedContent page="1" ?>manifold concerning the existence of natural causes in 
-     <?MarkedContent page="1" ?>general. Whence comes the architectonic of natural 
-     <?MarkedContent page="1" ?>reason, the solution of which involves the relation be
-     <?MarkedContent page="1" ?>
-     <?MarkedContent page="1" ?>tween necessity and the Categories? Natural causes 
-     <?MarkedContent page="1" ?>(and it is not at all certain that this is the case) con
-     <?MarkedContent page="1" ?>
-     <?MarkedContent page="1" ?>stitute the whole content for the paralogisms. This 
-     <?MarkedContent page="1" ?>could not be passed over in a complete system of tran
-     <?MarkedContent page="1" ?>
-     <?MarkedContent page="1" ?>scendental philosophy, but in a merely critical essay 
-     <?MarkedContent page="1" ?>the simple mention of the fact may suffice.
+     <?MarkedContent page="2" ?>us suppose that, indeed, our problematic judgements, 
+     <?MarkedContent page="2" ?>indeed, can be treated like our concepts. As any ded
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>icated reader can clearly see, our knowledge can be 
+     <?MarkedContent page="2" ?>treated like the transcendental unity of apperception, 
+     <?MarkedContent page="2" ?>but the phenomena occupy part of the sphere of the 
+     <?MarkedContent page="2" ?>manifold concerning the existence of natural causes in 
+     <?MarkedContent page="2" ?>general. Whence comes the architectonic of natural 
+     <?MarkedContent page="2" ?>reason, the solution of which involves the relation be
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>tween necessity and the Categories? Natural causes 
+     <?MarkedContent page="2" ?>(and it is not at all certain that this is the case) con
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>stitute the whole content for the paralogisms. This 
+     <?MarkedContent page="2" ?>could not be passed over in a complete system of tran
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>scendental philosophy, but in a merely critical essay 
+     <?MarkedContent page="2" ?>the simple mention of the fact may suffice.
     </text>
    </text-unit>
    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
-      id="ID.021"
+      id="ID.026"
       rolemaps-to="Part"
      >
     <text xmlns="https://www.latex-project.org/ns/dflt"
-       id="ID.022"
+       id="ID.027"
        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
        Layout:TextAlign="Justify"
        rolemaps-to="P"
       >
-     <?MarkedContent page="1" ?>Therefore, we can deduce that the objects in space 
-     <?MarkedContent page="1" ?>and time (and I assert, however, that this is the case) 
-     <?MarkedContent page="1" ?>have lying before them the objects in space and time. 
-     <?MarkedContent page="1" ?>Because of our necessary ignorance of the conditions, 
-     <?MarkedContent page="1" ?>it must not be supposed that, then, formal logic (and 
-     <?MarkedContent page="1" ?>what we have alone been able to show is that this is 
+     <?MarkedContent page="2" ?>Therefore, we can deduce that the objects in space 
+     <?MarkedContent page="2" ?>and time (and I assert, however, that this is the case) 
+     <?MarkedContent page="2" ?>have lying before them the objects in space and time. 
+     <?MarkedContent page="2" ?>Because of our necessary ignorance of the conditions, 
+     <?MarkedContent page="2" ?>it must not be supposed that, then, formal logic (and 
+     <?MarkedContent page="2" ?>what we have alone been able to show is that this is 
      <?MarkedContent page="2" ?>true) is a representation of the never-ending regress 
      <?MarkedContent page="2" ?>in the series of empirical conditions, but the discipline 
      <?MarkedContent page="2" ?>of pure reason, in so far as this expounds the contra
@@ -188,19 +221,19 @@
       rolemaps-to="Sect"
      >
     <float xmlns="https://www.latex-project.org/ns/dflt"
-       id="ID.006"
+       id="ID.011"
        rolemaps-to="Aside"
       >
      <Caption xmlns="http://iso.org/pdf2/ssn"
-        id="ID.010"
+        id="ID.015"
        >
       <Lbl xmlns="http://iso.org/pdf2/ssn"
-         id="ID.011"
+         id="ID.016"
         >
        <?MarkedContent page="1" ?>Figure 1: 
       </Lbl>
       <text xmlns="https://www.latex-project.org/ns/dflt"
-         id="ID.012"
+         id="ID.017"
          xmlns:Layout="http://iso.org/pdf/ssn/Layout"
          Layout:TextAlign="Center"
          rolemaps-to="P"
@@ -209,20 +242,20 @@
       </text>
      </Caption>
      <text-unit xmlns="https://www.latex-project.org/ns/dflt"
-        id="ID.007"
+        id="ID.012"
         rolemaps-to="Part"
        >
       <text xmlns="https://www.latex-project.org/ns/dflt"
-         id="ID.008"
+         id="ID.013"
          xmlns:Layout="http://iso.org/pdf/ssn/Layout"
          Layout:TextAlign="Center"
          rolemaps-to="P"
         >
        <Figure xmlns="http://iso.org/pdf2/ssn"
-          id="ID.009"
+          id="ID.014"
           alt="A duck!"
           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
-          Layout:BBox="{ 94.39102, 553.41429, 278.25157, 667.19801 }"
+          Layout:BBox="{ 94.39102, 433.9622, 278.25157, 547.74592 }"
          >
         <?MarkedContent page="1" ?>
        </Figure>

--- a/tagging-status/testfiles-compatible-luatex/lualineno/lualineno-01.tex
+++ b/tagging-status/testfiles-compatible-luatex/lualineno/lualineno-01.tex
@@ -1,0 +1,47 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on,
+  }
+\documentclass[twocolumn]{article}
+
+\usepackage{lualineno}
+\usepackage{graphicx}
+\usepackage{kantlipsum}
+
+\newcounter{lineno}
+\lualineno
+{
+define =
+{
+name = default
+toks = {\stepcounter{lineno}}
+left = {\tiny\thelineno
+\kern.8em}
+}
+define =
+{
+name = default
+column = 2
+toks = {\stepcounter{lineno}}
+right = {\kern.8em\tiny
+\thelineno}
+}
+set = default
+}
+
+\title{lualineno tagging test}
+
+\begin{document}
+
+\begin{figure}
+\centering
+\includegraphics[alt=A duck!]{example-image-duck}
+\caption{Look, a duck!}
+\end{figure}
+
+\kant[1-5]
+
+\end{document}

--- a/tagging-status/testfiles-compatible-luatex/lualineno/lualineno-01.tex
+++ b/tagging-status/testfiles-compatible-luatex/lualineno/lualineno-01.tex
@@ -33,8 +33,12 @@ set = default
 }
 
 \title{lualineno tagging test}
+\author{Some author}
+\date{Some date}
 
 \begin{document}
+
+\maketitle
 
 \begin{figure}
 \centering

--- a/tagging-status/testfiles-compatible-luatex/lualineno/lualineno-02.struct.xml
+++ b/tagging-status/testfiles-compatible-luatex/lualineno/lualineno-02.struct.xml
@@ -1,0 +1,159 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.013"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.014"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>As any dedicated reader can clearly see, the Ideal of practical reason is a 
+     <?MarkedContent page="1" ?>representation of, as far as I know, the things in themselves; as I have shown 
+     <?MarkedContent page="1" ?>elsewhere, the phenomena should only be used as a canon for our understanding. 
+     <?MarkedContent page="1" ?>The paralogisms of practical reason are what first give rise to the architectonic 
+     <?MarkedContent page="1" ?>of practical reason. As will easily be shown in the next section, reason would 
+     <?MarkedContent page="1" ?>thereby be made to contradict, in view of these considerations, the Ideal of prac
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>tical reason, yet the manifold depends on the phenomena. Necessity depends 
+     <?MarkedContent page="1" ?>on, when thus treated as the practical employment of the never-ending regress 
+     <?MarkedContent page="1" ?>in the series of empirical conditions, time. Human reason depends on our sense 
+     <?MarkedContent page="1" ?>perceptions, by means of analytic unity. There can be no doubt that the objects 
+     <?MarkedContent page="1" ?>in space and time are what first give rise to human reason.
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.015"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.016"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Let us suppose that the noumena have nothing to do with necessity, since 
+     <?MarkedContent page="1" ?>knowledge of the Categories is a posteriori. Hume tells us that the transcen
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>dental unity of apperception can not take account of the discipline of natural 
+     <?MarkedContent page="1" ?>reason, by means of analytic unity. As is proven in the ontological manuals, it is 
+     <?MarkedContent page="1" ?>obvious that the transcendental unity of apperception proves the validity of the 
+     <?MarkedContent page="1" ?>Antinomies; what we have alone been able to show is that, our understanding 
+     <?MarkedContent page="1" ?>depends on the Categories. It remains a mystery why the Ideal stands in need 
+     <?MarkedContent page="1" ?>of reason. It must not be supposed that our faculties have lying before them, in 
+     <?MarkedContent page="1" ?>the case of the Ideal, the Antinomies; so, the transcendental aesthetic is just as 
+     <?MarkedContent page="1" ?>necessary as our experience. By means of the Ideal, our sense perceptions are 
+     <?MarkedContent page="1" ?>by their very nature contradictory.
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.017"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.018"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>As is shown in the writings of Aristotle, the things in themselves (and it re
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>mains a mystery why this is the case) are a representation of time. Our concepts 
+     <?MarkedContent page="1" ?>have lying before them the paralogisms of natural reason, but our a posteriori 
+     <?MarkedContent page="1" ?>concepts have lying before them the practical employment of our experience. 
+     <?MarkedContent page="1" ?>Because of our necessary ignorance of the conditions, the paralogisms would 
+     <?MarkedContent page="1" ?>thereby be made to contradict, indeed, space; for these reasons, the Transcen
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>dental Deduction has lying before it our sense perceptions. (Our a posteriori 
+     <?MarkedContent page="1" ?>knowledge can never furnish a true and demonstrated science, because, like 
+     <?MarkedContent page="1" ?>time, it depends on analytic principles.) So, it must not be supposed that our 
+     <?MarkedContent page="1" ?>experience depends on, so, our sense perceptions, by means of analysis. Space 
+     <?MarkedContent page="2" ?>constitutes the whole content for our sense perceptions, and time occupies part 
+     <?MarkedContent page="2" ?>of the sphere of the Ideal concerning the existence of the objects in space and 
+     <?MarkedContent page="2" ?>time in general.
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.019"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.020"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="2" ?>As we have already seen, what we have alone been able to show is that 
+     <?MarkedContent page="2" ?>the objects in space and time would be falsified; what we have alone been able 
+     <?MarkedContent page="2" ?>to show is that, our judgements are what first give rise to metaphysics. As I 
+     <?MarkedContent page="2" ?>have shown elsewhere, Aristotle tells us that the objects in space and time, in 
+     <?MarkedContent page="2" ?>the full sense of these terms, would be falsified. Let us suppose that, indeed, 
+     <?MarkedContent page="2" ?>our problematic judgements, indeed, can be treated like our concepts. As any 
+     <?MarkedContent page="2" ?>dedicated reader can clearly see, our knowledge can be treated like the tran
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>scendental unity of apperception, but the phenomena occupy part of the sphere 
+     <?MarkedContent page="2" ?>of the manifold concerning the existence of natural causes in general. Whence 
+     <?MarkedContent page="2" ?>comes the architectonic of natural reason, the solution of which involves the 
+     <?MarkedContent page="2" ?>relation between necessity and the Categories? Natural causes (and it is not 
+     <?MarkedContent page="2" ?>at all certain that this is the case) constitute the whole content for the paral
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>ogisms. This could not be passed over in a complete system of transcendental 
+     <?MarkedContent page="2" ?>philosophy, but in a merely critical essay the simple mention of the fact may 
+     <?MarkedContent page="2" ?>suffice.
+    </text>
+   </text-unit>
+   <figures xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.004"
+      rolemaps-to="Sect"
+     >
+    <float xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.006"
+       rolemaps-to="Aside"
+      >
+     <Caption xmlns="http://iso.org/pdf2/ssn"
+        id="ID.010"
+       >
+      <Lbl xmlns="http://iso.org/pdf2/ssn"
+         id="ID.011"
+        >
+       <?MarkedContent page="1" ?>Figure 1: 
+      </Lbl>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.012"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Center"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>Look, a duck!
+      </text>
+     </Caption>
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.007"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.008"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Center"
+         rolemaps-to="P"
+        >
+       <Figure xmlns="http://iso.org/pdf2/ssn"
+          id="ID.009"
+          alt="A duck!"
+          xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+          Layout:BBox="{ 213.69363, 553.41429, 397.55418, 667.19801 }"
+         >
+        <?MarkedContent page="1" ?>
+       </Figure>
+      </text>
+     </text-unit>
+    </float>
+   </figures>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-compatible-luatex/lualineno/lualineno-02.struct.xml
+++ b/tagging-status/testfiles-compatible-luatex/lualineno/lualineno-02.struct.xml
@@ -4,11 +4,44 @@
      id="ID.002"
     >
    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
-      id="ID.013"
+      id="ID.006"
+      rolemaps-to="Part"
+     >
+    <Title xmlns="http://iso.org/pdf2/ssn"
+       id="ID.007"
+      >
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.008"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextAlign="Center"
+        rolemaps-to="P"
+       >
+      <?MarkedContent page="1" ?>lualineno tagging test – 2
+     </text>
+    </Title>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.009"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Center"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?> Some author
+    </text>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.010"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Center"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Some date
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.018"
       rolemaps-to="Part"
      >
     <text xmlns="https://www.latex-project.org/ns/dflt"
-       id="ID.014"
+       id="ID.019"
        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
        Layout:TextAlign="Justify"
        rolemaps-to="P"
@@ -28,11 +61,11 @@
     </text>
    </text-unit>
    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
-      id="ID.015"
+      id="ID.020"
       rolemaps-to="Part"
      >
     <text xmlns="https://www.latex-project.org/ns/dflt"
-       id="ID.016"
+       id="ID.021"
        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
        Layout:TextAlign="Justify"
        rolemaps-to="P"
@@ -52,38 +85,38 @@
     </text>
    </text-unit>
    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
-      id="ID.017"
+      id="ID.022"
       rolemaps-to="Part"
      >
     <text xmlns="https://www.latex-project.org/ns/dflt"
-       id="ID.018"
+       id="ID.023"
        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
        Layout:TextAlign="Justify"
        rolemaps-to="P"
       >
-     <?MarkedContent page="1" ?>As is shown in the writings of Aristotle, the things in themselves (and it re
-     <?MarkedContent page="1" ?>
-     <?MarkedContent page="1" ?>mains a mystery why this is the case) are a representation of time. Our concepts 
-     <?MarkedContent page="1" ?>have lying before them the paralogisms of natural reason, but our a posteriori 
-     <?MarkedContent page="1" ?>concepts have lying before them the practical employment of our experience. 
-     <?MarkedContent page="1" ?>Because of our necessary ignorance of the conditions, the paralogisms would 
-     <?MarkedContent page="1" ?>thereby be made to contradict, indeed, space; for these reasons, the Transcen
-     <?MarkedContent page="1" ?>
-     <?MarkedContent page="1" ?>dental Deduction has lying before it our sense perceptions. (Our a posteriori 
-     <?MarkedContent page="1" ?>knowledge can never furnish a true and demonstrated science, because, like 
-     <?MarkedContent page="1" ?>time, it depends on analytic principles.) So, it must not be supposed that our 
-     <?MarkedContent page="1" ?>experience depends on, so, our sense perceptions, by means of analysis. Space 
+     <?MarkedContent page="2" ?>As is shown in the writings of Aristotle, the things in themselves (and it re
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>mains a mystery why this is the case) are a representation of time. Our concepts 
+     <?MarkedContent page="2" ?>have lying before them the paralogisms of natural reason, but our a posteriori 
+     <?MarkedContent page="2" ?>concepts have lying before them the practical employment of our experience. 
+     <?MarkedContent page="2" ?>Because of our necessary ignorance of the conditions, the paralogisms would 
+     <?MarkedContent page="2" ?>thereby be made to contradict, indeed, space; for these reasons, the Transcen
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>dental Deduction has lying before it our sense perceptions. (Our a posteriori 
+     <?MarkedContent page="2" ?>knowledge can never furnish a true and demonstrated science, because, like 
+     <?MarkedContent page="2" ?>time, it depends on analytic principles.) So, it must not be supposed that our 
+     <?MarkedContent page="2" ?>experience depends on, so, our sense perceptions, by means of analysis. Space 
      <?MarkedContent page="2" ?>constitutes the whole content for our sense perceptions, and time occupies part 
      <?MarkedContent page="2" ?>of the sphere of the Ideal concerning the existence of the objects in space and 
      <?MarkedContent page="2" ?>time in general.
     </text>
    </text-unit>
    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
-      id="ID.019"
+      id="ID.024"
       rolemaps-to="Part"
      >
     <text xmlns="https://www.latex-project.org/ns/dflt"
-       id="ID.020"
+       id="ID.025"
        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
        Layout:TextAlign="Justify"
        rolemaps-to="P"
@@ -112,19 +145,19 @@
       rolemaps-to="Sect"
      >
     <float xmlns="https://www.latex-project.org/ns/dflt"
-       id="ID.006"
+       id="ID.011"
        rolemaps-to="Aside"
       >
      <Caption xmlns="http://iso.org/pdf2/ssn"
-        id="ID.010"
+        id="ID.015"
        >
       <Lbl xmlns="http://iso.org/pdf2/ssn"
-         id="ID.011"
+         id="ID.016"
         >
        <?MarkedContent page="1" ?>Figure 1: 
       </Lbl>
       <text xmlns="https://www.latex-project.org/ns/dflt"
-         id="ID.012"
+         id="ID.017"
          xmlns:Layout="http://iso.org/pdf/ssn/Layout"
          Layout:TextAlign="Center"
          rolemaps-to="P"
@@ -133,20 +166,20 @@
       </text>
      </Caption>
      <text-unit xmlns="https://www.latex-project.org/ns/dflt"
-        id="ID.007"
+        id="ID.012"
         rolemaps-to="Part"
        >
       <text xmlns="https://www.latex-project.org/ns/dflt"
-         id="ID.008"
+         id="ID.013"
          xmlns:Layout="http://iso.org/pdf/ssn/Layout"
          Layout:TextAlign="Center"
          rolemaps-to="P"
         >
        <Figure xmlns="http://iso.org/pdf2/ssn"
-          id="ID.009"
+          id="ID.014"
           alt="A duck!"
           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
-          Layout:BBox="{ 213.69363, 553.41429, 397.55418, 667.19801 }"
+          Layout:BBox="{ 213.69363, 143.22292, 397.55418, 257.00664 }"
          >
         <?MarkedContent page="1" ?>
        </Figure>

--- a/tagging-status/testfiles-compatible-luatex/lualineno/lualineno-02.tex
+++ b/tagging-status/testfiles-compatible-luatex/lualineno/lualineno-02.tex
@@ -26,8 +26,12 @@ set = default
 }
 
 \title{lualineno tagging test -- 2}
+\author{Some author}
+\date{Some date}
 
 \begin{document}
+
+\maketitle
 
 \begin{figure}
 \centering

--- a/tagging-status/testfiles-compatible-luatex/lualineno/lualineno-02.tex
+++ b/tagging-status/testfiles-compatible-luatex/lualineno/lualineno-02.tex
@@ -1,0 +1,40 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on,
+  }
+\documentclass{article}
+
+\usepackage{lualineno}
+\usepackage{graphicx}
+\usepackage{tikzducks}
+\usepackage{kantlipsum}
+
+\newcounter{lineno}
+\lualineno{
+define = {
+name = default
+toks = {\stepcounter{lineno}}
+left = {\SuspendTagging{lineno}%
+\tikz[scale=0.1,actualtext=\thelineno,transform shape]
+{\duck[signpost=\thelineno]}%
+\ResumeTagging{lineno}\quad}
+}
+set = default
+}
+
+\title{lualineno tagging test -- 2}
+
+\begin{document}
+
+\begin{figure}
+\centering
+\includegraphics[alt=A duck!]{example-image-duck}
+\caption{Look, a duck!}
+\end{figure}
+
+\kant[1-4]
+
+\end{document}


### PR DESCRIPTION
The line numbers are tagged as artifacts unless they contain content with structure, in which case tagging must be suspended. This is documented by the package and a comment is added in the yml file. I also added a comment in the lineno entry suggesting lualineno as a compatible alternative. See also the discussion in #210.