### PR TITLE
status updates

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -4325,6 +4325,14 @@
   tests: true
   updated: 2024-08-12
 
+- name: duplicat
+  type: package
+  status: compatible
+  priority: 9
+  tests: false
+  package-repository: "https://github.com/LaTeX-Package-Repositories/piff"
+  updated: 2026-06-29
+
 - name: dutchcal
   type: package
   status: partially-compatible
@@ -5949,6 +5957,8 @@
   priority: 2
   comments: "See fancyvrb."
   issues: [1060]
+  package-repository: "https://github.com/gpoore/fvextra"
+  external-issues: ["https://github.com/gpoore/fvextra/issues/29"]
   tests: true
   tasks: needs more tests
   updated: 2025-11-22
@@ -7514,6 +7524,7 @@
 - name: latex2pydata
   type: package
   status: compatible
+  package-repository: "https://github.com/gpoore/latex2pydata"
   priority: 9
   tests: false
   updated: 2025-11-20
@@ -9085,6 +9096,7 @@
   status: currently-incompatible
   included-in: [arxiv01, ol1]
   priority: 4
+  package-repository: "https://github.com/gpoore/minted"
   tests: true
   comments: "Listings not tagged properly. See fvextra and fancyvrb."
   updated: 2025-11-11
@@ -11663,6 +11675,7 @@
   status: currently-incompatible
   included-in: [ol0.02]
   priority: 9
+  package-repository: "https://github.com/gpoore/pythontex"
   tests: true
   comments: "Verbatim environments not tagged correctly. See fvextra."
   updated: 2025-11-06

--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -6340,6 +6340,15 @@
   tasks: needs tests
   updated: 2024-08-23
 
+- name: gobble
+  type: package
+  subpackages: [gobble-user]
+  status: compatible
+  priority: 9
+  package-repository: "https://github.com/MartinScharrer/gobble"
+  tests: false
+  updated: 2026-06-29
+
 - name: grabbox
   type: package
   status: unchecked

--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -3824,12 +3824,12 @@
 
 - name: currvita
   type: package
-  status: unchecked
+  status: currently-incompatible
   included-in: [ol0.02]
   priority: 9
-  tests: false
-  tasks: needs tests
-  updated: 2026-01-23
+  issues: [1459]
+  tests: true
+  updated: 2026-06-29
 
 - name: curve2e
   type: package
@@ -3841,12 +3841,11 @@
 
 - name: curves
   type: package
-  status: unchecked
+  status: compatible
   included-in: [ol0.02]
   priority: 9
   tests: false
-  tasks: needs tests
-  updated: 2026-01-23
+  updated: 2026-06-29
 
 - name: cuted
   type: package

--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -179,12 +179,11 @@
 - name: abntex2abrev
   ctan-pkg: abntex2
   type: package
-  status: unchecked
+  status: compatible
   included-in: [ol0.02]
   priority: 9
   tests: false
-  tasks: needs tests
-  updated: 2026-01-23
+  updated: 2026-06-29
 
 - name: abntex2cite
   ctan-pkg: abntex2
@@ -3790,11 +3789,11 @@
   subpackages: [ctexcap,ctexheading,ctexhook,ctexpatch,ctexsize]
   included-in: [tlc3, ol1]
   priority: 6
-  issues: [673]
+  issues: [673,1458]
   luatex-only: true
   tests: true
   comments: "Option `heading=true` breaks section heading tagging. Same problem
-             with classes ctexart, ctexbook, and ctexrep."
+             with classes ctexart, ctexbook, and ctexrep. Breaks math environments."
   package-repository: "https://github.com/CTeX-org/ctex-kit"
   updated: 2026-01-25
 
@@ -5171,6 +5170,14 @@
   references: [1]
   tests: true
   updated: 2024-10-18
+
+- name: fapapersize
+  ctan-pkg: kotex-oblivoir
+  type: package
+  status: compatible
+  priority: 9
+  tests: false
+  updated: 2026-06-29
 
 - name: fbb
   type: package
@@ -9303,6 +9310,14 @@
   comments: "List is not tagged correctly."
   tests: true
   updated: 2024-08-20
+
+- name: multienv
+  type: package
+  status: compatible
+  priority: 9
+  package-repository: "https://github.com/MartinScharrer/multienv"
+  tests: false
+  updated: 2026-06-29
 
 - name: multiexpand
   type: package
@@ -15510,6 +15525,13 @@
   tests: false
   updated: 2025-12-16
 
+- name: zhlineskip
+  type: package
+  status: compatible
+  priority: 9
+  tests: true
+  updated: 2026-06-29
+
 - name: zhlipsum
   type: package
   status: compatible
@@ -15526,6 +15548,14 @@
   tests: excluded
   comments: Tests excluded because the results are font-dependent.
   updated: 2026-04-20
+
+- name: zhspacing
+  type: package
+  status: no-support
+  priority: 9
+  tests: false
+  comments: "Requires the incompatible xetex engine."
+  updated: 2026-06-29
 
 - name: zi4
   ctan-pkg: inconsolata
@@ -15794,6 +15824,16 @@
 #-------------------------------- class files -----------------------
 
 #------------------------ AAA ----------------------------
+
+- name: abntex2
+  type: class
+  status: currently-incompatible
+  included-in: [ol0.02]
+  priority: 9
+  tests: false
+  tasks: needs tests
+  comments: "Extension of the incompatible memoir class."
+  updated: 2026-06-29
 
 - name: achemso
   type: class
@@ -16319,8 +16359,8 @@
              [bible example](https://github.com/latex3/tagging-project/blob/main/project-examples/ASV/bible.tex)."
   issues: [910]
   closed-issues: [1040]
-  tests: false
-  updated: 2025-11-10
+  tests: true
+  updated: 2026-06-29
 
 - name: minimal
   type: class
@@ -16367,6 +16407,12 @@
 - name: oblivoir
   ctan-pkg: kotex-oblivoir
   type: class
+  subpackages: [memhangul-common,memhangul-patch,memucs-enumerate,memucs-setspace,
+                obchapterstyles,obchaptertoc,ob-koreanappendix,oblivoir-misc,
+                ob-nokoreanappendix,ob-toclof,hfontsel,memhangul-ucs,memucs-gremph,
+                memucs-interword,nanumfontsel,memhangul-x,memucs-interword-x,
+                ob-mathleading,ob-unfontsdefault,xetexko-var,xob-amssymb,xob-dotemph,
+                xob-font,xob-hyper,xob-lwarp,xob-paralist]
   status: currently-incompatible
   priority: 9
   tests: false
@@ -16492,12 +16538,12 @@
 
 - name: simplecv
   type: class
-  status: unchecked
+  status: partially-compatible
   included-in: [ol0.02]
   priority: 9
-  tests: false
-  tasks: needs tests
-  updated: 2026-01-23
+  tests: true
+  comments: "Tagging of title and headers is not ideal."
+  updated: 2026-06-29
 
 - name: standalone
   type: class

--- a/tagging-status/testfiles-compatible-luatex/zhlineskip/zhlineskip-01.struct.xml
+++ b/tagging-status/testfiles-compatible-luatex/zhlineskip/zhlineskip-01.struct.xml
@@ -1,0 +1,160 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.006"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.007"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>人人生而自由，在尊严和权利上一律平等。他们赋有理性和良
+     <?MarkedContent page="1" ?>心，并应以兄弟关系的精神相对待。
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.008"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.009"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>All human beings are born free and equal in dignity and rights. They 
+     <?MarkedContent page="1" ?>are endowed with reason and conscience and should act towards one another 
+     <?MarkedContent page="1" ?>in a spirit of brotherhood.
+     <footnotemark xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.010"
+        rolemaps-to="Lbl"
+        referenced-as="2"
+       >
+       <?References objects="1" ?>
+      <Span xmlns="http://iso.org/pdf2/ssn"
+         id="ID.011"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextPosition="Sup"
+        >
+       <?MarkedContent page="1" ?>1
+      </Span>
+     </footnotemark>
+     <footnote xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.012"
+        rolemaps-to="FENote"
+        referenced-as="1"
+       >
+       <?References objects="2" ?>
+      <footnotelabel xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.015"
+         rolemaps-to="Lbl"
+        >
+       <Span xmlns="http://iso.org/pdf2/ssn"
+          id="ID.016"
+          xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+          Layout:TextPosition="Sup"
+         >
+        <?MarkedContent page="1" ?>1
+       </Span>
+      </footnotelabel>
+      <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.013"
+         rolemaps-to="Part"
+        >
+       <text xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.014"
+          xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+          Layout:TextAlign="Justify"
+          rolemaps-to="P"
+         >
+        <?MarkedContent page="1" ?>Some footnote
+       </text>
+      </text-unit>
+     </footnote>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.017"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.018"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>人人有资格享有本宣言所载的一切权利和自由，
+    </text>
+    <Formula xmlns="http://iso.org/pdf2/ssn"
+       id="ID.019"
+       title="equation"
+       af="mathml-1.xml tag-AFfile1.tex"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:Placement="Block"
+      >
+      <AssociatedFile name="mathml-1.xml" xmlns="">
+      <math display="block" xmlns="http://www.w3.org/1998/Math/MathML"> <mtable displaystyle="true" intent=":system-of-equations"> <mtr> <mtd intent=":equation-label"> <mtext> (1) </mtext> </mtd> <mtd intent=":pause-medium"> <mrow/> <mi>𝐴</mi> <mo lspace="0.278em" rspace="0.278em">=</mo> <mi>𝐵</mi> </mtd> </mtr> </mtable> </math>
+      </AssociatedFile>
+      <AssociatedFile name="tag-AFfile1.tex" xmlns="">
+      \begin {equation}A=B\end {equation}
+      </AssociatedFile>
+     <?MarkedContent page="1" ?>𝐴=𝐵
+     <?MarkedContent page="1" ?>(1)
+    </Formula>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.020"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>不分种族、肤色、性别、语言 
+     <?MarkedContent page="1" ?>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.021"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.022"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Everyone is entitled to all the rights and freedoms set forth in this
+    </text>
+    <Formula xmlns="http://iso.org/pdf2/ssn"
+       id="ID.023"
+       title="equation"
+       af="mathml-1.xml tag-AFfile2.tex"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:Placement="Block"
+      >
+      <AssociatedFile name="mathml-1.xml" xmlns="">
+      <math display="block" xmlns="http://www.w3.org/1998/Math/MathML"> <mtable displaystyle="true" intent=":system-of-equations"> <mtr> <mtd intent=":equation-label"> <mtext> (1) </mtext> </mtd> <mtd intent=":pause-medium"> <mrow/> <mi>𝐴</mi> <mo lspace="0.278em" rspace="0.278em">=</mo> <mi>𝐵</mi> </mtd> </mtr> </mtable> </math>
+      </AssociatedFile>
+      <AssociatedFile name="tag-AFfile2.tex" xmlns="">
+      \begin {equation}A=B\end {equation}
+      </AssociatedFile>
+     <?MarkedContent page="1" ?>𝐴=𝐵
+     <?MarkedContent page="1" ?>(2)
+    </Formula>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.024"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Declaration, without distinction of any kind, such as race, colour, sex, lan
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>guage…
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-compatible-luatex/zhlineskip/zhlineskip-01.tex
+++ b/tagging-status/testfiles-compatible-luatex/zhlineskip/zhlineskip-01.tex
@@ -1,0 +1,46 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on,
+  }
+\documentclass{article}
+\usepackage[fontset=fandol]{ctex}
+\usepackage{unicode-math}
+\usepackage[
+  bodytextleadingratio = 3,
+  footnoteleadingratio = 2,
+  ]{zhlineskip}
+\newenvironment{english} % 新建“英文”段落环境
+{\addvspace\medskipamount} % 段前间距，上文段落需结束
+{\par\addvspace\medskipamount}
+\begin{document}
+
+\setlength\parindent{2cm}
+\RestoreTextEnvironmentLeading{english}
+人人生而自由，在尊严和权利上一律平等。他们
+赋有理性和良心，并应以兄弟关系的精神相对待。
+\begin{english}
+All human beings are born free and equal in
+dignity and rights. They are endowed with
+reason and conscience and should act towards
+one another in a spirit of brotherhood.\footnote{Some footnote}
+\end{english}
+人人有资格享有本宣言所载的一切权利和自由，
+\begin{equation}
+A=B
+\end{equation}
+不分种族、肤色、性别、语言⋯⋯
+\begin{english}
+Everyone is entitled to all the rights and
+freedoms set forth in this
+\begin{equation}
+A=B
+\end{equation}
+Declaration,
+without distinction of any kind, such as
+race, colour, sex, language\dots
+\end{english}
+
+\end{document}

--- a/tagging-status/testfiles-incompatible-luatex/ctex/ctex-02-BAD.struct.xml
+++ b/tagging-status/testfiles-incompatible-luatex/ctex/ctex-02-BAD.struct.xml
@@ -1,0 +1,1 @@
+<run-error code="1" />

--- a/tagging-status/testfiles-incompatible-luatex/ctex/ctex-02-BAD.tex
+++ b/tagging-status/testfiles-incompatible-luatex/ctex/ctex-02-BAD.tex
@@ -1,0 +1,20 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on,
+  }
+\documentclass{article}
+\usepackage{unicode-math}
+\usepackage[fontset=fandol]{ctex}
+
+\title{ctex tagging test -- math envs}
+\begin{document}
+
+\begin{align}
+A &= B\\
+C &= D
+\end{align}
+
+\end{document}

--- a/tagging-status/testfiles-incompatible/currvita/currvita-01-BAD.pdftex.struct.xml
+++ b/tagging-status/testfiles-incompatible/currvita/currvita-01-BAD.pdftex.struct.xml
@@ -1,0 +1,882 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.0002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.0005"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0006"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Lebenslauf
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.0007"
+      rolemaps-to="Part"
+     >
+    <list xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0008"
+       xmlns:List="http://iso.org/pdf/ssn/List"
+       List:ListNumbering="Unordered"
+       rolemaps-to="L"
+      >
+     <item xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.0009"
+        rolemaps-to="LI"
+       >
+      <itemlabel xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0010"
+         rolemaps-to="Lbl"
+        >
+       <?MarkedContent page="1" ?>
+      </itemlabel>
+      <Div xmlns="http://iso.org/pdf2/ssn"
+         id="ID.0011"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.0012"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0013"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="1" ?>Persönliche Daten
+        </text>
+       </text-unit>
+      </Div>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0014"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>
+      </text>
+      <itembody xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0015"
+         rolemaps-to="LBody"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.0016"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0017"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="1" ?>Axel ReichertBeethovenstr. 2540233 Düsseldorf
+        </text>
+       </text-unit>
+      </itembody>
+     </item>
+     <item xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.0018"
+        rolemaps-to="LI"
+       >
+      <itemlabel xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0019"
+         rolemaps-to="Lbl"
+        >
+       <?MarkedContent page="1" ?>
+      </itemlabel>
+      <itembody xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0020"
+         rolemaps-to="LBody"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.0021"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0022"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="1" ?>Tel.: (0211) 6912415E-Mail: axel.reichert@gmx.de
+        </text>
+       </text-unit>
+      </itembody>
+     </item>
+     <item xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.0023"
+        rolemaps-to="LI"
+       >
+      <itemlabel xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0024"
+         rolemaps-to="Lbl"
+        >
+       <?MarkedContent page="1" ?>
+      </itemlabel>
+      <itembody xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0025"
+         rolemaps-to="LBody"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.0026"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0027"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="1" ?>Geb. am 03.08. 1970 in DüsseldorfLedig, deutsch
+        </text>
+       </text-unit>
+      </itembody>
+     </item>
+    </list>
+    <list xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0028"
+       xmlns:List="http://iso.org/pdf/ssn/List"
+       List:ListNumbering="Unordered"
+       rolemaps-to="L"
+      >
+     <item xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.0029"
+        rolemaps-to="LI"
+       >
+      <itemlabel xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0030"
+         rolemaps-to="Lbl"
+        >
+       <?MarkedContent page="1" ?>
+      </itemlabel>
+      <Div xmlns="http://iso.org/pdf2/ssn"
+         id="ID.0031"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.0032"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0033"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="1" ?>Schulbildung
+        </text>
+       </text-unit>
+      </Div>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0034"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>08/1976–05/1989
+      </text>
+      <itembody xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0035"
+         rolemaps-to="LBody"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.0036"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0037"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="1" ?>Grundschule und Gymnasium in Mettmann (Leistungs-kurse Mathematik und Physik)
+        </text>
+       </text-unit>
+      </itembody>
+     </item>
+    </list>
+    <list xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0038"
+       xmlns:List="http://iso.org/pdf/ssn/List"
+       List:ListNumbering="Unordered"
+       rolemaps-to="L"
+      >
+     <item xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.0039"
+        rolemaps-to="LI"
+       >
+      <itemlabel xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0040"
+         rolemaps-to="Lbl"
+        >
+       <?MarkedContent page="1" ?>
+      </itemlabel>
+      <Div xmlns="http://iso.org/pdf2/ssn"
+         id="ID.0041"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.0042"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0043"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="1" ?>Wehrdienst
+        </text>
+       </text-unit>
+      </Div>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0044"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>10/1989–09/1990
+      </text>
+      <itembody xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0045"
+         rolemaps-to="LBody"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.0046"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0047"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="1" ?>Fernmeldeaufklärer in Clausthal-Zellerfeld und Roten-burg/Wümme
+        </text>
+       </text-unit>
+      </itembody>
+     </item>
+    </list>
+    <list xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0048"
+       xmlns:List="http://iso.org/pdf/ssn/List"
+       List:ListNumbering="Unordered"
+       rolemaps-to="L"
+      >
+     <item xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.0049"
+        rolemaps-to="LI"
+       >
+      <itemlabel xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0050"
+         rolemaps-to="Lbl"
+        >
+       <?MarkedContent page="1" ?>
+      </itemlabel>
+      <Div xmlns="http://iso.org/pdf2/ssn"
+         id="ID.0051"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.0052"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0053"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="1" ?>Studium
+        </text>
+       </text-unit>
+      </Div>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0054"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>10/1990–09/1992
+      </text>
+      <itembody xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0055"
+         rolemaps-to="LBody"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.0056"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0057"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="1" ?>Maschinenbauvordiplom an der Universität Hannover
+        </text>
+       </text-unit>
+      </itembody>
+     </item>
+     <item xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.0058"
+        rolemaps-to="LI"
+       >
+      <itemlabel xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0059"
+         rolemaps-to="Lbl"
+        >
+       <?MarkedContent page="1" ?>10/1992–06/1993
+      </itemlabel>
+      <itembody xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0060"
+         rolemaps-to="LBody"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.0061"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0062"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="1" ?>Wissenschaftliche Hilfskraft am Institut für Umform-technik und Umformmaschinen, Hannover; Mitarbeit anDFG-Projekt: Implementation eines Stoffgesetzes in dasFEM-Programm ABAQUS
+        </text>
+       </text-unit>
+      </itembody>
+     </item>
+     <item xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.0063"
+        rolemaps-to="LI"
+       >
+      <itemlabel xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0064"
+         rolemaps-to="Lbl"
+        >
+       <?MarkedContent page="1" ?>10/1992–08/1996
+      </itemlabel>
+      <itembody xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0065"
+         rolemaps-to="LBody"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.0066"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0067"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="1" ?>Maschinenbaudiplom an der Universität Hannover, Ent-wicklungs- und Konstruktionstechnik (Schwerpunkte Fi-nite Elemente, Schwingungstechnik und Elasto-/Plasto-mechanik)
+        </text>
+       </text-unit>
+      </itembody>
+     </item>
+     <item xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.0068"
+        rolemaps-to="LI"
+       >
+      <itemlabel xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0069"
+         rolemaps-to="Lbl"
+        >
+       <?MarkedContent page="1" ?>10/1994–04/1996
+      </itemlabel>
+      <itembody xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0070"
+         rolemaps-to="LBody"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.0071"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0072"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="1" ?>Mathematikvordiplom an der Universität Hannover
+        </text>
+       </text-unit>
+      </itembody>
+     </item>
+    </list>
+    <list xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0073"
+       xmlns:List="http://iso.org/pdf/ssn/List"
+       List:ListNumbering="Unordered"
+       rolemaps-to="L"
+      >
+     <item xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.0074"
+        rolemaps-to="LI"
+       >
+      <itemlabel xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0075"
+         rolemaps-to="Lbl"
+        >
+       <?MarkedContent page="1" ?>
+      </itemlabel>
+      <Div xmlns="http://iso.org/pdf2/ssn"
+         id="ID.0076"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.0077"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0078"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="1" ?>Praktikum
+        </text>
+       </text-unit>
+      </Div>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0079"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>08/1994–09/1994
+      </text>
+      <itembody xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0080"
+         rolemaps-to="LBody"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.0081"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0082"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="1" ?>Brüninghaus &amp; Drissner GmbH, Hilden (mittelständi-sches Preß-, Stanz- und Ziehwerk); Konstruktion eineskombinierten Roll- und Zudrückwerkzeuges für Klemm-schellen
+        </text>
+       </text-unit>
+      </itembody>
+     </item>
+    </list>
+    <list xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0083"
+       xmlns:List="http://iso.org/pdf/ssn/List"
+       List:ListNumbering="Unordered"
+       rolemaps-to="L"
+      >
+     <item xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.0084"
+        rolemaps-to="LI"
+       >
+      <itemlabel xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0085"
+         rolemaps-to="Lbl"
+        >
+       <?MarkedContent page="2" ?>
+      </itemlabel>
+      <Div xmlns="http://iso.org/pdf2/ssn"
+         id="ID.0086"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.0087"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0088"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="2" ?>Berufserfahrung
+        </text>
+       </text-unit>
+      </Div>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0089"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="2" ?>seit 08/1996
+      </text>
+      <itembody xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0090"
+         rolemaps-to="LBody"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.0091"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0092"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="2" ?>Max-Planck-Institut für Eisenforschung GmbH, Düssel-dorf; wissenschaftlicher Mitarbeiter der Abteilung Metall-urgie
+        </text>
+       </text-unit>
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.0093"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0094"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="2" ?>Promotion über „Soft Reduction beim Stranggießen undihr Einfluß auf die Produktqualität“ im Rahmen einesProjektes der Europäischen Gemeinschaft für Kohle undStahl in Zusammenarbeit mit British Steel, den DillingerHüttenwerken und der TU Clausthal
+        </text>
+       </text-unit>
+      </itembody>
+     </item>
+    </list>
+    <list xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0095"
+       xmlns:List="http://iso.org/pdf/ssn/List"
+       List:ListNumbering="Unordered"
+       rolemaps-to="L"
+      >
+     <item xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.0096"
+        rolemaps-to="LI"
+       >
+      <itemlabel xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0097"
+         rolemaps-to="Lbl"
+        >
+       <?MarkedContent page="2" ?>
+      </itemlabel>
+      <Div xmlns="http://iso.org/pdf2/ssn"
+         id="ID.0098"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.0099"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0100"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="2" ?>Fremdsprachen
+        </text>
+       </text-unit>
+      </Div>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0101"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="2" ?>
+      </text>
+      <itembody xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0102"
+         rolemaps-to="LBody"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.0103"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0104"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="2" ?>Englisch, Französisch
+        </text>
+       </text-unit>
+      </itembody>
+     </item>
+    </list>
+    <list xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0105"
+       xmlns:List="http://iso.org/pdf/ssn/List"
+       List:ListNumbering="Unordered"
+       rolemaps-to="L"
+      >
+     <item xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.0106"
+        rolemaps-to="LI"
+       >
+      <itemlabel xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0107"
+         rolemaps-to="Lbl"
+        >
+       <?MarkedContent page="2" ?>
+      </itemlabel>
+      <Div xmlns="http://iso.org/pdf2/ssn"
+         id="ID.0108"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.0109"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0110"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="2" ?>EDV
+        </text>
+       </text-unit>
+      </Div>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0111"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="2" ?>Betriebssysteme
+      </text>
+      <itembody xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0112"
+         rolemaps-to="LBody"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.0113"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0114"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="2" ?>UNIX (Linux, IRIX), Windows, Novell Netware, DOS
+        </text>
+       </text-unit>
+      </itembody>
+     </item>
+     <item xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.0115"
+        rolemaps-to="LI"
+       >
+      <itemlabel xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0116"
+         rolemaps-to="Lbl"
+        >
+       <?MarkedContent page="2" ?>Sprachen
+      </itemlabel>
+      <itembody xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0117"
+         rolemaps-to="LBody"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.0118"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0119"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="2" ?>Perl, Shell-Skripte, HTML, Fortran 77, Pascal, BASIC
+        </text>
+       </text-unit>
+      </itembody>
+     </item>
+     <item xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.0120"
+        rolemaps-to="LI"
+       >
+      <itemlabel xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0121"
+         rolemaps-to="Lbl"
+        >
+       <?MarkedContent page="2" ?>Anwendungen
+      </itemlabel>
+      <itembody xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0122"
+         rolemaps-to="LBody"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.0123"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0124"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="2" ?>ANSYS, MARC, Word, Excel, CorelDRAW, Designer,LaTeX, XEmacs
+        </text>
+       </text-unit>
+      </itembody>
+     </item>
+    </list>
+    <list xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0125"
+       xmlns:List="http://iso.org/pdf/ssn/List"
+       List:ListNumbering="Unordered"
+       rolemaps-to="L"
+      >
+     <item xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.0126"
+        rolemaps-to="LI"
+       >
+      <itemlabel xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0127"
+         rolemaps-to="Lbl"
+        >
+       <?MarkedContent page="2" ?>
+      </itemlabel>
+      <Div xmlns="http://iso.org/pdf2/ssn"
+         id="ID.0128"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.0129"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0130"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="2" ?>Interessen
+        </text>
+       </text-unit>
+      </Div>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0131"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="2" ?>
+      </text>
+      <itembody xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0132"
+         rolemaps-to="LBody"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.0133"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0134"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="2" ?>Klassische Musik, Typographie, Tischtennis, Fotografie
+        </text>
+       </text-unit>
+      </itembody>
+     </item>
+    </list>
+    <list xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0135"
+       xmlns:List="http://iso.org/pdf/ssn/List"
+       List:ListNumbering="Unordered"
+       rolemaps-to="L"
+      >
+     <item xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.0136"
+        rolemaps-to="LI"
+       >
+      <itemlabel xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0137"
+         rolemaps-to="Lbl"
+        >
+       <?MarkedContent page="2" ?>
+      </itemlabel>
+      <Div xmlns="http://iso.org/pdf2/ssn"
+         id="ID.0138"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.0139"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0140"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="2" ?>Sonstiges
+        </text>
+       </text-unit>
+      </Div>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0141"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="2" ?>04/1992–10/1995
+      </text>
+      <itembody xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0142"
+         rolemaps-to="LBody"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.0143"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0144"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="2" ?>Ehrenamtliche Mitarbeit als Rechnerwart bei der Saalge-meinschaft „Exzenter“ (unter studentischer Selbstverwal-tung stehender Arbeits- und Zeichensaal für Ingenieur-studenten)
+        </text>
+       </text-unit>
+      </itembody>
+     </item>
+     <item xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.0145"
+        rolemaps-to="LI"
+       >
+      <itemlabel xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0146"
+         rolemaps-to="Lbl"
+        >
+       <?MarkedContent page="2" ?>seit 01/1997
+      </itemlabel>
+      <itembody xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0147"
+         rolemaps-to="LBody"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.0148"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0149"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="2" ?>Aktives Mitglied der Deutschen AnwendervereinigungTeX, Vorträge und Tutorien auf Konferenzen
+        </text>
+       </text-unit>
+      </itembody>
+     </item>
+    </list>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0150"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="2" ?>Düsseldorf, 13. September 1999
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.0151"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0152"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="2" ?>
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-incompatible/currvita/currvita-01-BAD.struct.xml
+++ b/tagging-status/testfiles-incompatible/currvita/currvita-01-BAD.struct.xml
@@ -1,0 +1,869 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.0002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.0006"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0007"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Lebenslauf
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.0008"
+      rolemaps-to="Part"
+     >
+    <list xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0009"
+       xmlns:List="http://iso.org/pdf/ssn/List"
+       List:ListNumbering="Unordered"
+       rolemaps-to="L"
+      >
+     <item xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.0010"
+        rolemaps-to="LI"
+       >
+      <itemlabel xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0011"
+         rolemaps-to="Lbl"
+        >
+      </itemlabel>
+      <Div xmlns="http://iso.org/pdf2/ssn"
+         id="ID.0012"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.0013"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0014"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+        </text>
+       </text-unit>
+      </Div>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0015"
+         rolemaps-to="P"
+        >
+      </text>
+      <itembody xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0016"
+         rolemaps-to="LBody"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.0017"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0018"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="1" ?>Axel ReichertBeethovenstr. 2540233 Düsseldorf
+        </text>
+       </text-unit>
+      </itembody>
+     </item>
+     <item xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.0019"
+        rolemaps-to="LI"
+       >
+      <itemlabel xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0020"
+         rolemaps-to="Lbl"
+        >
+      </itemlabel>
+      <itembody xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0021"
+         rolemaps-to="LBody"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.0022"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0023"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="1" ?>Tel.: (0211) 6912415E-Mail: axel.reichert@gmx.de
+        </text>
+       </text-unit>
+      </itembody>
+     </item>
+     <item xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.0024"
+        rolemaps-to="LI"
+       >
+      <itemlabel xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0025"
+         rolemaps-to="Lbl"
+        >
+      </itemlabel>
+      <itembody xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0026"
+         rolemaps-to="LBody"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.0027"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0028"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="1" ?>Geb. am 03.08. 1970 in DüsseldorfLedig, deutsch
+        </text>
+       </text-unit>
+      </itembody>
+     </item>
+    </list>
+    <list xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0029"
+       xmlns:List="http://iso.org/pdf/ssn/List"
+       List:ListNumbering="Unordered"
+       rolemaps-to="L"
+      >
+     <item xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.0030"
+        rolemaps-to="LI"
+       >
+      <itemlabel xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0031"
+         rolemaps-to="Lbl"
+        >
+      </itemlabel>
+      <Div xmlns="http://iso.org/pdf2/ssn"
+         id="ID.0032"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.0033"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0034"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+        </text>
+       </text-unit>
+      </Div>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0035"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>08/1976–05/1989
+      </text>
+      <itembody xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0036"
+         rolemaps-to="LBody"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.0037"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0038"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="1" ?>Grundschule und Gymnasium in Mettmann (Leistungs
+         <?MarkedContent page="1" ?>kurse Mathematik und Physik)
+        </text>
+       </text-unit>
+      </itembody>
+     </item>
+    </list>
+    <list xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0039"
+       xmlns:List="http://iso.org/pdf/ssn/List"
+       List:ListNumbering="Unordered"
+       rolemaps-to="L"
+      >
+     <item xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.0040"
+        rolemaps-to="LI"
+       >
+      <itemlabel xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0041"
+         rolemaps-to="Lbl"
+        >
+      </itemlabel>
+      <Div xmlns="http://iso.org/pdf2/ssn"
+         id="ID.0042"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.0043"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0044"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+        </text>
+       </text-unit>
+      </Div>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0045"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>10/1989–09/1990
+      </text>
+      <itembody xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0046"
+         rolemaps-to="LBody"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.0047"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0048"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="1" ?>Fernmeldeaufklärer in Clausthal-Zellerfeld und Roten
+         <?MarkedContent page="1" ?>burg/Wümme
+        </text>
+       </text-unit>
+      </itembody>
+     </item>
+    </list>
+    <list xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0049"
+       xmlns:List="http://iso.org/pdf/ssn/List"
+       List:ListNumbering="Unordered"
+       rolemaps-to="L"
+      >
+     <item xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.0050"
+        rolemaps-to="LI"
+       >
+      <itemlabel xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0051"
+         rolemaps-to="Lbl"
+        >
+      </itemlabel>
+      <Div xmlns="http://iso.org/pdf2/ssn"
+         id="ID.0052"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.0053"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0054"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+        </text>
+       </text-unit>
+      </Div>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0055"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>10/1990–09/1992
+      </text>
+      <itembody xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0056"
+         rolemaps-to="LBody"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.0057"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0058"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="1" ?>Maschinenbauvordiplom an der Universität Hannover
+        </text>
+       </text-unit>
+      </itembody>
+     </item>
+     <item xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.0059"
+        rolemaps-to="LI"
+       >
+      <itemlabel xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0060"
+         rolemaps-to="Lbl"
+        >
+       <?MarkedContent page="1" ?>10/1992–06/1993
+      </itemlabel>
+      <itembody xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0061"
+         rolemaps-to="LBody"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.0062"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0063"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="1" ?>Wissenschaftliche Hilfskraft am Institut für Umform
+         <?MarkedContent page="1" ?>technik und Umformmaschinen, Hannover; Mitarbeit an DFG-Projekt: Implementation eines Stoffgesetzes in das FEM-Programm ABAQUS
+        </text>
+       </text-unit>
+      </itembody>
+     </item>
+     <item xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.0064"
+        rolemaps-to="LI"
+       >
+      <itemlabel xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0065"
+         rolemaps-to="Lbl"
+        >
+       <?MarkedContent page="1" ?>10/1992–08/1996
+      </itemlabel>
+      <itembody xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0066"
+         rolemaps-to="LBody"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.0067"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0068"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="1" ?>Maschinenbaudiplom an der Universität Hannover, Ent
+         <?MarkedContent page="1" ?>wicklungs- und Konstruktionstechnik (Schwerpunkte Fi
+         <?MarkedContent page="1" ?>nite Elemente, Schwingungstechnik und Elasto-/Plasto
+         <?MarkedContent page="1" ?>mechanik)
+        </text>
+       </text-unit>
+      </itembody>
+     </item>
+     <item xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.0069"
+        rolemaps-to="LI"
+       >
+      <itemlabel xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0070"
+         rolemaps-to="Lbl"
+        >
+       <?MarkedContent page="1" ?>10/1994–04/1996
+      </itemlabel>
+      <itembody xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0071"
+         rolemaps-to="LBody"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.0072"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0073"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="1" ?>Mathematikvordiplom an der Universität Hannover
+        </text>
+       </text-unit>
+      </itembody>
+     </item>
+    </list>
+    <list xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0074"
+       xmlns:List="http://iso.org/pdf/ssn/List"
+       List:ListNumbering="Unordered"
+       rolemaps-to="L"
+      >
+     <item xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.0075"
+        rolemaps-to="LI"
+       >
+      <itemlabel xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0076"
+         rolemaps-to="Lbl"
+        >
+      </itemlabel>
+      <Div xmlns="http://iso.org/pdf2/ssn"
+         id="ID.0077"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.0078"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0079"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+        </text>
+       </text-unit>
+      </Div>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0080"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>08/1994–09/1994
+      </text>
+      <itembody xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0081"
+         rolemaps-to="LBody"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.0082"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0083"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="1" ?>Brüninghaus &amp; Drissner GmbH, Hilden (mittelständi
+         <?MarkedContent page="1" ?>sches Preß-, Stanz- und Ziehwerk); Konstruktion eines kombinierten Roll- und Zudrückwerkzeuges für Klemm
+         <?MarkedContent page="1" ?>schellen
+        </text>
+       </text-unit>
+      </itembody>
+     </item>
+    </list>
+    <list xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0084"
+       xmlns:List="http://iso.org/pdf/ssn/List"
+       List:ListNumbering="Unordered"
+       rolemaps-to="L"
+      >
+     <item xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.0085"
+        rolemaps-to="LI"
+       >
+      <itemlabel xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0086"
+         rolemaps-to="Lbl"
+        >
+      </itemlabel>
+      <Div xmlns="http://iso.org/pdf2/ssn"
+         id="ID.0087"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.0088"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0089"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+        </text>
+       </text-unit>
+      </Div>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0090"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="2" ?>seit 08/1996
+      </text>
+      <itembody xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0091"
+         rolemaps-to="LBody"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.0092"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0093"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="2" ?>Max-Planck-Institut für Eisenforschung GmbH, Düssel
+         <?MarkedContent page="2" ?>dorf; wissenschaftlicher Mitarbeiter der Abteilung Me
+         <?MarkedContent page="2" ?>tallurgie
+        </text>
+       </text-unit>
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.0094"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0095"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="2" ?>Promotion über „Soft Reduction beim Stranggießen und ihr Einfluß auf die Produktqualität“ im Rahmen eines Projektes der Europäischen Gemeinschaft für Kohle und Stahl in Zusammenarbeit mit British Steel, den Dillinger Hüttenwerken und der TU Clausthal
+        </text>
+       </text-unit>
+      </itembody>
+     </item>
+    </list>
+    <list xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0096"
+       xmlns:List="http://iso.org/pdf/ssn/List"
+       List:ListNumbering="Unordered"
+       rolemaps-to="L"
+      >
+     <item xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.0097"
+        rolemaps-to="LI"
+       >
+      <itemlabel xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0098"
+         rolemaps-to="Lbl"
+        >
+      </itemlabel>
+      <Div xmlns="http://iso.org/pdf2/ssn"
+         id="ID.0099"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.0100"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0101"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+        </text>
+       </text-unit>
+      </Div>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0102"
+         rolemaps-to="P"
+        >
+      </text>
+      <itembody xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0103"
+         rolemaps-to="LBody"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.0104"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0105"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="2" ?>Englisch, Französisch
+        </text>
+       </text-unit>
+      </itembody>
+     </item>
+    </list>
+    <list xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0106"
+       xmlns:List="http://iso.org/pdf/ssn/List"
+       List:ListNumbering="Unordered"
+       rolemaps-to="L"
+      >
+     <item xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.0107"
+        rolemaps-to="LI"
+       >
+      <itemlabel xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0108"
+         rolemaps-to="Lbl"
+        >
+      </itemlabel>
+      <Div xmlns="http://iso.org/pdf2/ssn"
+         id="ID.0109"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.0110"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0111"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+        </text>
+       </text-unit>
+      </Div>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0112"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="2" ?>Betriebssysteme
+      </text>
+      <itembody xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0113"
+         rolemaps-to="LBody"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.0114"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0115"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="2" ?>UNIX (Linux, IRIX), Windows, Novell Netware, DOS
+        </text>
+       </text-unit>
+      </itembody>
+     </item>
+     <item xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.0116"
+        rolemaps-to="LI"
+       >
+      <itemlabel xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0117"
+         rolemaps-to="Lbl"
+        >
+       <?MarkedContent page="2" ?>Sprachen
+      </itemlabel>
+      <itembody xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0118"
+         rolemaps-to="LBody"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.0119"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0120"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="2" ?>Perl, Shell-Skripte, HTML, Fortran 77, Pascal, BASIC
+        </text>
+       </text-unit>
+      </itembody>
+     </item>
+     <item xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.0121"
+        rolemaps-to="LI"
+       >
+      <itemlabel xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0122"
+         rolemaps-to="Lbl"
+        >
+       <?MarkedContent page="2" ?>Anwendungen
+      </itemlabel>
+      <itembody xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0123"
+         rolemaps-to="LBody"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.0124"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0125"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="2" ?>ANSYS, MARC, Word, Excel, CorelDRAW, Designer, LaTeX, XEmacs
+        </text>
+       </text-unit>
+      </itembody>
+     </item>
+    </list>
+    <list xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0126"
+       xmlns:List="http://iso.org/pdf/ssn/List"
+       List:ListNumbering="Unordered"
+       rolemaps-to="L"
+      >
+     <item xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.0127"
+        rolemaps-to="LI"
+       >
+      <itemlabel xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0128"
+         rolemaps-to="Lbl"
+        >
+      </itemlabel>
+      <Div xmlns="http://iso.org/pdf2/ssn"
+         id="ID.0129"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.0130"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0131"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+        </text>
+       </text-unit>
+      </Div>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0132"
+         rolemaps-to="P"
+        >
+      </text>
+      <itembody xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0133"
+         rolemaps-to="LBody"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.0134"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0135"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="2" ?>Klassische Musik, Typographie, Tischtennis, Fotografie
+        </text>
+       </text-unit>
+      </itembody>
+     </item>
+    </list>
+    <list xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0136"
+       xmlns:List="http://iso.org/pdf/ssn/List"
+       List:ListNumbering="Unordered"
+       rolemaps-to="L"
+      >
+     <item xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.0137"
+        rolemaps-to="LI"
+       >
+      <itemlabel xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0138"
+         rolemaps-to="Lbl"
+        >
+      </itemlabel>
+      <Div xmlns="http://iso.org/pdf2/ssn"
+         id="ID.0139"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.0140"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0141"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+        </text>
+       </text-unit>
+      </Div>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0142"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="2" ?>04/1992–10/1995
+      </text>
+      <itembody xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0143"
+         rolemaps-to="LBody"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.0144"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0145"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="2" ?>Ehrenamtliche Mitarbeit als Rechnerwart bei der Saalge
+         <?MarkedContent page="2" ?>meinschaft „Exzenter“ (unter studentischer Selbstverwal
+         <?MarkedContent page="2" ?>tung stehender Arbeits- und Zeichensaal für Ingenieur
+         <?MarkedContent page="2" ?>studenten)
+        </text>
+       </text-unit>
+      </itembody>
+     </item>
+     <item xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.0146"
+        rolemaps-to="LI"
+       >
+      <itemlabel xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0147"
+         rolemaps-to="Lbl"
+        >
+       <?MarkedContent page="2" ?>seit 01/1997
+      </itemlabel>
+      <itembody xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0148"
+         rolemaps-to="LBody"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.0149"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0150"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="2" ?>Aktives Mitglied der Deutschen Anwendervereinigung TeX, Vorträge und Tutorien auf Konferenzen
+        </text>
+       </text-unit>
+      </itembody>
+     </item>
+    </list>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0151"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="2" ?>Düsseldorf, 13. September 1999
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.0152"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0153"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-incompatible/currvita/currvita-01-BAD.tex
+++ b/tagging-status/testfiles-incompatible/currvita/currvita-01-BAD.tex
@@ -1,0 +1,88 @@
+% from cvtest.tex
+\DocumentMetadata
+  {
+    lang=de,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on,
+  }
+\documentclass[12pt,a4paper]{article}
+\usepackage[german]{babel}
+\usepackage{currvita}
+\newcommand*{\ac}[1]{\mbox{#1}}
+\tolerance=600
+\begin{document}
+\begin{cv}{Lebenslauf}
+  \begin{cvlist}{Pers"onliche Daten}
+  \item Axel Reichert\\
+    Beethovenstr.~25\\
+    40233~D"usseldorf
+  \item Tel.:~(02\,11)~6\,91\,24\,15\\
+    E"~Mail:~axel.reichert@gmx.de
+  \item Geb.~am~03.\,08.~1970 in~D"usseldorf\\
+    Ledig, deutsch
+  \end{cvlist}
+  \begin{cvlist}{Schulbildung}
+  \item[08/1976--05/1989] Grundschule und Gymnasium in Mettmann
+    (Leistungskurse Mathematik und Physik)
+  \end{cvlist}
+  \begin{cvlist}{Wehrdienst}
+  \item[10/1989--09/1990] Fernmeldeaufkl"arer in Clausthal-Zellerfeld
+    und Rotenburg/""W"umme
+  \end{cvlist}
+  \begin{cvlist}{Studium}
+  \item[10/1990--09/1992] Maschinenbauvordiplom an der Universit"at
+    Hannover
+  \item[10/1992--06/1993] Wissenschaftliche Hilfskraft am Institut
+    f"ur Umformtechnik und Umformmaschinen, Hannover; Mitarbeit an
+    DFG-Projekt: Implementation eines Stoffgesetzes in das
+    \ac{FEM}-Programm \ac{ABAQUS}
+  \item[10/1992--08/1996] Maschinenbaudiplom an der Universit"at
+    Hannover, Ent"-wicklungs"~~und Konstruktionstechnik (Schwerpunkte
+    Finite Elemente, Schwingungstechnik und Elasto"~/""Plastomechanik)
+  \item[10/1994--04/1996] Mathematikvordiplom an der Universit"at
+    Hannover
+  \end{cvlist}
+  \begin{cvlist}{Praktikum}
+  \item[08/1994--09/1994] Br"uninghaus~\&~Drissner~GmbH, Hilden
+    (mittelst"andisches Pre"s"~, Stanz"~ und Ziehwerk); Konstruktion
+    eines kombinierten Roll"~ und Zudr"uckwerkzeuges f"ur
+    Klemmschellen
+  \end{cvlist}
+  \begin{cvlist}{Berufserfahrung}
+  \item[seit~08/1996] Max-Planck-Institut f"ur Eisenforschung~GmbH,
+    D"usseldorf; wissenschaftlicher Mitarbeiter der Abteilung
+    Metallurgie
+
+    Promotion "uber "`Soft Reduction beim Stranggie"sen und ihr
+    Einflu"s auf die Produktqualit"at"' im Rahmen eines Projektes der
+    Europ"aischen Gemeinschaft f"ur Kohle und Stahl in Zusammenarbeit
+    mit British Steel, den Dillinger H"uttenwerken und der
+    TU~Clausthal
+  \end{cvlist}
+  \begin{cvlist}{Fremdsprachen}
+  \item Englisch, Franz"osisch
+  \end{cvlist}
+  \begin{cvlist}{\ac{EDV}}
+  \item[Betriebssysteme] \ac{UNIX} (Linux, \ac{IRIX}), Windows, Novell
+    Netware, \ac{DOS}
+  \item[Sprachen] Perl, Shell-Skripte, \ac{HTML}, Fortran~77, Pascal,
+    \ac{BASIC}
+  \item[Anwendungen] \ac{ANSYS}, \ac{MARC}, Word, Excel, Corel"-DRAW,
+    Designer, LaTeX, XEmacs
+  \end{cvlist}
+  \begin{cvlist}{Interessen}
+  \item Klassische Musik, Typographie, Tischtennis, Fotografie
+  \end{cvlist}
+  \begin{cvlist}{Sonstiges}
+  \item[04/1992--10/1995] Ehrenamtliche Mitarbeit als Rechnerwart bei
+    der Saalgemeinschaft~"`Exzenter"' (unter studentischer
+    Selbstverwaltung stehender Arbeits"~~und Zeichensaal f"ur
+    Ingenieurstudenten)
+  \item[seit 01/1997] Aktives Mitglied der Deutschen
+    Anwendervereinigung TeX, Vortr"age und Tutorien auf Konferenzen
+  \end{cvlist}
+  \cvplace{D\"usseldorf}
+  \date{13.~September~1999}
+\end{cv}
+\end{document}

--- a/tagging-status/testfiles-incompatible/memoir/memoir-01-BAD.pdftex.struct.xml
+++ b/tagging-status/testfiles-incompatible/memoir/memoir-01-BAD.pdftex.struct.xml
@@ -1,0 +1,1 @@
+<run-error code="1" />

--- a/tagging-status/testfiles-incompatible/memoir/memoir-01-BAD.struct.xml
+++ b/tagging-status/testfiles-incompatible/memoir/memoir-01-BAD.struct.xml
@@ -1,0 +1,1 @@
+<run-error code="1" />

--- a/tagging-status/testfiles-incompatible/memoir/memoir-01-BAD.tex
+++ b/tagging-status/testfiles-incompatible/memoir/memoir-01-BAD.tex
@@ -1,0 +1,15 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on,
+  }
+\documentclass{memoir}
+\title{memoir tagging test}
+\author{Some author} % or this
+\date{Some date}
+\begin{document}
+\maketitle
+Some text
+\end{document}

--- a/tagging-status/testfiles-incompatible/memoir/memoir-02-BAD.pdftex.struct.xml
+++ b/tagging-status/testfiles-incompatible/memoir/memoir-02-BAD.pdftex.struct.xml
@@ -1,0 +1,146 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+     referenced-as="1"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.005"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.006"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Contents
+    </text>
+   </text-unit>
+   <TOCI xmlns="http://iso.org/pdf/ssn"
+      id="ID.007"
+      title="Contents"
+     >
+     <?References objects="1" ?>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.008"
+       rolemaps-to="Part"
+      >
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.009"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextAlign="Justify"
+        rolemaps-to="P"
+       >
+      <?MarkedContent page="1" ?>Contents 1
+     </text>
+    </text-unit>
+   </TOCI>
+   <TOCI xmlns="http://iso.org/pdf/ssn"
+      id="ID.010"
+      title="to1Some chapter"
+     >
+     <?References objects="2" ?>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.011"
+       rolemaps-to="Part"
+      >
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.012"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextAlign="Justify"
+        rolemaps-to="P"
+       >
+      <?MarkedContent page="1" ?>1 Some chapter 3
+     </text>
+    </text-unit>
+   </TOCI>
+   <TOCI xmlns="http://iso.org/pdf/ssn"
+      id="ID.013"
+      title="Some section"
+     >
+     <?References objects="3" ?>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.014"
+       rolemaps-to="Part"
+      >
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.015"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextAlign="Justify"
+        rolemaps-to="P"
+       >
+      <?MarkedContent page="1" ?>1.1 Some section . . . . . . . . . . . . . . . . . . . . . . . . . . . . 3
+     </text>
+    </text-unit>
+   </TOCI>
+   <TOC xmlns="http://iso.org/pdf/ssn"
+      id="ID.016"
+      referenced-as="2"
+     >
+    <TOCI xmlns="http://iso.org/pdf/ssn"
+       id="ID.017"
+       title="Some subsection"
+      >
+      <?References objects="4" ?>
+    </TOCI>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.018"
+       rolemaps-to="Part"
+      >
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.019"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextAlign="Start"
+        rolemaps-to="P"
+       >
+      <?MarkedContent page="3" ?>Chapter 1
+     </text>
+    </text-unit>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.020"
+       rolemaps-to="Part"
+      >
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.021"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextAlign="Start"
+        rolemaps-to="P"
+       >
+      <?MarkedContent page="3" ?>Some chapter
+     </text>
+    </text-unit>
+    <Sect xmlns="http://iso.org/pdf2/ssn"
+       id="ID.022"
+      >
+     <section xmlns="https://www.latex-project.org/ns/book"
+        id="ID.023"
+        title="Some section"
+        rolemaps-to="H2"
+       >
+      <section-number xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.024"
+         rolemaps-to="Span"
+         referenced-as="3"
+        >
+       <?MarkedContent page="3" ?>1.1
+      </section-number>
+      <?MarkedContent page="3" ?>Some section
+     </section>
+     <Sect xmlns="http://iso.org/pdf2/ssn"
+        id="ID.025"
+       >
+      <subsection xmlns="https://www.latex-project.org/ns/book"
+         id="ID.026"
+         title="Some subsection"
+         rolemaps-to="H3"
+         referenced-as="4"
+        >
+       <?MarkedContent page="3" ?>Some subsection
+      </subsection>
+     </Sect>
+    </Sect>
+   </TOC>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-incompatible/memoir/memoir-02-BAD.struct.xml
+++ b/tagging-status/testfiles-incompatible/memoir/memoir-02-BAD.struct.xml
@@ -1,0 +1,146 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+     referenced-as="1"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.006"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.007"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Contents
+    </text>
+   </text-unit>
+   <TOCI xmlns="http://iso.org/pdf/ssn"
+      id="ID.008"
+      title="Contents"
+     >
+     <?References objects="1" ?>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.009"
+       rolemaps-to="Part"
+      >
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.010"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextAlign="Justify"
+        rolemaps-to="P"
+       >
+      <?MarkedContent page="1" ?>Contents1
+     </text>
+    </text-unit>
+   </TOCI>
+   <TOCI xmlns="http://iso.org/pdf/ssn"
+      id="ID.011"
+      title="to1Some chapter"
+     >
+     <?References objects="2" ?>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.012"
+       rolemaps-to="Part"
+      >
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.013"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextAlign="Justify"
+        rolemaps-to="P"
+       >
+      <?MarkedContent page="1" ?>1Some chapter3
+     </text>
+    </text-unit>
+   </TOCI>
+   <TOCI xmlns="http://iso.org/pdf/ssn"
+      id="ID.014"
+      title="Some section"
+     >
+     <?References objects="3" ?>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.015"
+       rolemaps-to="Part"
+      >
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.016"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextAlign="Justify"
+        rolemaps-to="P"
+       >
+      <?MarkedContent page="1" ?>1.1Some section............................3
+     </text>
+    </text-unit>
+   </TOCI>
+   <TOC xmlns="http://iso.org/pdf/ssn"
+      id="ID.017"
+      referenced-as="2"
+     >
+    <TOCI xmlns="http://iso.org/pdf/ssn"
+       id="ID.018"
+       title="Some subsection"
+      >
+      <?References objects="4" ?>
+    </TOCI>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.019"
+       rolemaps-to="Part"
+      >
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.020"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextAlign="Start"
+        rolemaps-to="P"
+       >
+      <?MarkedContent page="3" ?>Chapter 1
+     </text>
+    </text-unit>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.021"
+       rolemaps-to="Part"
+      >
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.022"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextAlign="Start"
+        rolemaps-to="P"
+       >
+      <?MarkedContent page="3" ?>Some chapter
+     </text>
+    </text-unit>
+    <Sect xmlns="http://iso.org/pdf2/ssn"
+       id="ID.023"
+      >
+     <section xmlns="https://www.latex-project.org/ns/book"
+        id="ID.024"
+        title="Some section"
+        rolemaps-to="H2"
+       >
+      <section-number xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.025"
+         rolemaps-to="Span"
+         referenced-as="3"
+        >
+       <?MarkedContent page="3" ?>1.1 
+      </section-number>
+      <?MarkedContent page="3" ?>Some section
+     </section>
+     <Sect xmlns="http://iso.org/pdf2/ssn"
+        id="ID.026"
+       >
+      <subsection xmlns="https://www.latex-project.org/ns/book"
+         id="ID.027"
+         title="Some subsection"
+         rolemaps-to="H3"
+         referenced-as="4"
+        >
+       <?MarkedContent page="3" ?>Some subsection
+      </subsection>
+     </Sect>
+    </Sect>
+   </TOC>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-incompatible/memoir/memoir-02-BAD.tex
+++ b/tagging-status/testfiles-incompatible/memoir/memoir-02-BAD.tex
@@ -1,0 +1,14 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on,
+  }
+\documentclass{memoir}
+\begin{document}
+\tableofcontents
+\chapter{Some chapter}
+\section{Some section}
+\subsection{Some subsection}
+\end{document}

--- a/tagging-status/testfiles-incompatible/memoir/memoir-03-BAD.pdftex.struct.xml
+++ b/tagging-status/testfiles-incompatible/memoir/memoir-03-BAD.pdftex.struct.xml
@@ -1,0 +1,57 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.005"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.006"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Center"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Abstract
+    </text>
+    <list xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.007"
+       xmlns:List="http://iso.org/pdf/ssn/List"
+       List:ListNumbering="Unordered"
+       rolemaps-to="L"
+      >
+     <item xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.008"
+        rolemaps-to="LI"
+       >
+      <itemlabel xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.009"
+         rolemaps-to="Lbl"
+        >
+       <?MarkedContent page="1" ?>
+      </itemlabel>
+      <itembody xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.010"
+         rolemaps-to="LBody"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.011"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.012"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="1" ?>text
+        </text>
+       </text-unit>
+      </itembody>
+     </item>
+    </list>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-incompatible/memoir/memoir-03-BAD.struct.xml
+++ b/tagging-status/testfiles-incompatible/memoir/memoir-03-BAD.struct.xml
@@ -1,0 +1,56 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.006"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.007"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Center"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Abstract
+    </text>
+    <list xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.008"
+       xmlns:List="http://iso.org/pdf/ssn/List"
+       List:ListNumbering="Unordered"
+       rolemaps-to="L"
+      >
+     <item xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.009"
+        rolemaps-to="LI"
+       >
+      <itemlabel xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.010"
+         rolemaps-to="Lbl"
+        >
+      </itemlabel>
+      <itembody xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.011"
+         rolemaps-to="LBody"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.012"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.013"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="1" ?>text
+        </text>
+       </text-unit>
+      </itembody>
+     </item>
+    </list>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-incompatible/memoir/memoir-03-BAD.tex
+++ b/tagging-status/testfiles-incompatible/memoir/memoir-03-BAD.tex
@@ -1,0 +1,13 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on,
+  }
+\documentclass{memoir}
+\begin{document}
+\begin{abstract}
+text
+\end{abstract}
+\end{document}

--- a/tagging-status/testfiles-incompatible/memoir/memoir-04-BAD.pdftex.struct.xml
+++ b/tagging-status/testfiles-incompatible/memoir/memoir-04-BAD.pdftex.struct.xml
@@ -1,0 +1,1 @@
+<run-error code="1" />

--- a/tagging-status/testfiles-incompatible/memoir/memoir-04-BAD.struct.xml
+++ b/tagging-status/testfiles-incompatible/memoir/memoir-04-BAD.struct.xml
@@ -1,0 +1,1 @@
+<run-error code="1" />

--- a/tagging-status/testfiles-incompatible/memoir/memoir-04-BAD.tex
+++ b/tagging-status/testfiles-incompatible/memoir/memoir-04-BAD.tex
@@ -1,0 +1,16 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on,
+  }
+\documentclass{memoir}
+\newfloat[chapter]{listing}{lol}{Listing}
+\begin{document}
+Some text
+\begin{listing}
+Some listing
+\caption{Some caption}
+\end{listing}
+\end{document}

--- a/tagging-status/testfiles-incompatible/memoir/memoir-05-BAD.pdftex.struct.xml
+++ b/tagging-status/testfiles-incompatible/memoir/memoir-05-BAD.pdftex.struct.xml
@@ -1,0 +1,81 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.005"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.006"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Some text
+    </text>
+   </text-unit>
+  </Document>
+  <Div xmlns="http://iso.org/pdf2/ssn"
+     id="ID.007"
+    >
+   <Caption xmlns="http://iso.org/pdf2/ssn"
+      id="ID.010"
+     >
+    <Lbl xmlns="http://iso.org/pdf2/ssn"
+       id="ID.011"
+      >
+     <?MarkedContent page="1" ?>Figure 0.1:
+    </Lbl>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.012"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Center"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Some caption
+    </text>
+   </Caption>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.008"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.009"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Center"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Some figure
+    </text>
+   </text-unit>
+  </Div>
+  <Div xmlns="http://iso.org/pdf2/ssn"
+     id="ID.013"
+    >
+  </Div>
+  <text xmlns="https://www.latex-project.org/ns/dflt"
+     id="ID.014"
+     rolemaps-to="P"
+    >
+   <Aside xmlns="http://iso.org/pdf2/ssn"
+      id="ID.015"
+     >
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.016"
+       rolemaps-to="Part"
+      >
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.017"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextAlign="Justify"
+        rolemaps-to="P"
+       >
+      <?MarkedContent page="1" ?>Some figureFigure 0.1:Some caption
+     </text>
+    </text-unit>
+   </Aside>
+  </text>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-incompatible/memoir/memoir-05-BAD.struct.xml
+++ b/tagging-status/testfiles-incompatible/memoir/memoir-05-BAD.struct.xml
@@ -1,0 +1,80 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.006"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.007"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Some text
+    </text>
+   </text-unit>
+  </Document>
+  <Div xmlns="http://iso.org/pdf2/ssn"
+     id="ID.008"
+    >
+   <Caption xmlns="http://iso.org/pdf2/ssn"
+      id="ID.011"
+     >
+    <Lbl xmlns="http://iso.org/pdf2/ssn"
+       id="ID.012"
+      >
+     <?MarkedContent page="1" ?>Figure 0.1: 
+    </Lbl>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.013"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Center"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Some caption
+    </text>
+   </Caption>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.009"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.010"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Center"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Some figure
+    </text>
+   </text-unit>
+  </Div>
+  <Div xmlns="http://iso.org/pdf2/ssn"
+     id="ID.014"
+    >
+  </Div>
+  <text xmlns="https://www.latex-project.org/ns/dflt"
+     id="ID.015"
+     rolemaps-to="P"
+    >
+   <Aside xmlns="http://iso.org/pdf2/ssn"
+      id="ID.016"
+     >
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.017"
+       rolemaps-to="Part"
+      >
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.018"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextAlign="Justify"
+        rolemaps-to="P"
+       >
+     </text>
+    </text-unit>
+   </Aside>
+  </text>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-incompatible/memoir/memoir-05-BAD.tex
+++ b/tagging-status/testfiles-incompatible/memoir/memoir-05-BAD.tex
@@ -1,0 +1,15 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on,
+  }
+\documentclass{memoir}
+\begin{document}
+Some text
+\begin{marginfigure}
+Some figure
+\caption{Some caption}
+\end{marginfigure}
+\end{document}

--- a/tagging-status/testfiles-incompatible/memoir/memoir-06-BAD.pdftex.struct.xml
+++ b/tagging-status/testfiles-incompatible/memoir/memoir-06-BAD.pdftex.struct.xml
@@ -1,0 +1,79 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.005"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.006"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Some text
+     <?MarkedContent page="1" ?>
+    </text>
+   </text-unit>
+   <figures xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.003"
+      rolemaps-to="Sect"
+     >
+    <float xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.007"
+       rolemaps-to="Aside"
+      >
+     <Caption xmlns="http://iso.org/pdf2/ssn"
+        id="ID.013"
+       >
+      <Lbl xmlns="http://iso.org/pdf2/ssn"
+         id="ID.014"
+        >
+       <?MarkedContent page="1" ?>:
+      </Lbl>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.015"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Justify"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>The legend
+      </text>
+     </Caption>
+     <Caption xmlns="http://iso.org/pdf2/ssn"
+        id="ID.008"
+       >
+      <Lbl xmlns="http://iso.org/pdf2/ssn"
+         id="ID.009"
+        >
+       <?MarkedContent page="1" ?>Figure 0.1:
+      </Lbl>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.010"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Justify"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>Some caption
+      </text>
+     </Caption>
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.011"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.012"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Justify"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>Some figure
+      </text>
+     </text-unit>
+    </float>
+   </figures>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-incompatible/memoir/memoir-06-BAD.struct.xml
+++ b/tagging-status/testfiles-incompatible/memoir/memoir-06-BAD.struct.xml
@@ -1,0 +1,78 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.006"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.007"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Some text 
+    </text>
+   </text-unit>
+   <figures xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.004"
+      rolemaps-to="Sect"
+     >
+    <float xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.008"
+       rolemaps-to="Aside"
+      >
+     <Caption xmlns="http://iso.org/pdf2/ssn"
+        id="ID.014"
+       >
+      <Lbl xmlns="http://iso.org/pdf2/ssn"
+         id="ID.015"
+        >
+       <?MarkedContent page="1" ?>: 
+      </Lbl>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.016"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Justify"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>The legend
+      </text>
+     </Caption>
+     <Caption xmlns="http://iso.org/pdf2/ssn"
+        id="ID.009"
+       >
+      <Lbl xmlns="http://iso.org/pdf2/ssn"
+         id="ID.010"
+        >
+       <?MarkedContent page="1" ?>Figure 0.1: 
+      </Lbl>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.011"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Justify"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>Some caption
+      </text>
+     </Caption>
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.012"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.013"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Justify"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>Some figure
+      </text>
+     </text-unit>
+    </float>
+   </figures>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-incompatible/memoir/memoir-06-BAD.tex
+++ b/tagging-status/testfiles-incompatible/memoir/memoir-06-BAD.tex
@@ -1,0 +1,16 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on,
+  }
+\documentclass{memoir}
+\begin{document}
+Some text
+\begin{figure}
+\caption{Some caption}
+Some figure
+\legend{The legend}
+\end{figure}
+\end{document}

--- a/tagging-status/testfiles-incompatible/memoir/memoir-07-BAD.pdftex.struct.xml
+++ b/tagging-status/testfiles-incompatible/memoir/memoir-07-BAD.pdftex.struct.xml
@@ -1,0 +1,101 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.005"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.006"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Some text
+     <Div xmlns="http://iso.org/pdf2/ssn"
+        id="ID.008"
+       >
+      <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.009"
+         rolemaps-to="Part"
+        >
+       <text xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.010"
+          xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+          Layout:TextAlign="Justify"
+          rolemaps-to="P"
+         >
+        <?MarkedContent page="1" ?>Some side caption
+       </text>
+      </text-unit>
+     </Div>
+     <Div xmlns="http://iso.org/pdf2/ssn"
+        id="ID.011"
+       >
+     </Div>
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.012"
+        rolemaps-to="P"
+       >
+     </text>
+     <Div xmlns="http://iso.org/pdf2/ssn"
+        id="ID.013"
+       >
+     </Div>
+     <Div xmlns="http://iso.org/pdf2/ssn"
+        id="ID.017"
+       >
+     </Div>
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.018"
+        rolemaps-to="P"
+       >
+      <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.019"
+         rolemaps-to="Part"
+        >
+       <text xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.020"
+          xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+          Layout:TextAlign="Justify"
+          rolemaps-to="P"
+         >
+        <?MarkedContent page="1" ?>Some side captionFigure 0.1:An illustration
+       </text>
+      </text-unit>
+     </text>
+     <?MarkedContent page="1" ?>
+    </text>
+   </text-unit>
+   <figures xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.003"
+      rolemaps-to="Sect"
+     >
+    <float xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.007"
+       rolemaps-to="Aside"
+      >
+     <Caption xmlns="http://iso.org/pdf2/ssn"
+        id="ID.014"
+       >
+      <Lbl xmlns="http://iso.org/pdf2/ssn"
+         id="ID.015"
+        >
+       <?MarkedContent page="1" ?>Figure 0.1:
+      </Lbl>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.016"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Justify"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>An illustration
+      </text>
+     </Caption>
+    </float>
+   </figures>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-incompatible/memoir/memoir-07-BAD.struct.xml
+++ b/tagging-status/testfiles-incompatible/memoir/memoir-07-BAD.struct.xml
@@ -1,0 +1,99 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.006"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.007"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Some text 
+     <Div xmlns="http://iso.org/pdf2/ssn"
+        id="ID.009"
+       >
+      <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.010"
+         rolemaps-to="Part"
+        >
+       <text xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.011"
+          xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+          Layout:TextAlign="Justify"
+          rolemaps-to="P"
+         >
+        <?MarkedContent page="1" ?>Some side caption
+       </text>
+      </text-unit>
+     </Div>
+     <Div xmlns="http://iso.org/pdf2/ssn"
+        id="ID.012"
+       >
+     </Div>
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.013"
+        rolemaps-to="P"
+       >
+     </text>
+     <Div xmlns="http://iso.org/pdf2/ssn"
+        id="ID.014"
+       >
+     </Div>
+     <Div xmlns="http://iso.org/pdf2/ssn"
+        id="ID.018"
+       >
+     </Div>
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.019"
+        rolemaps-to="P"
+       >
+      <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.020"
+         rolemaps-to="Part"
+        >
+       <text xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.021"
+          xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+          Layout:TextAlign="Justify"
+          rolemaps-to="P"
+         >
+       </text>
+      </text-unit>
+     </text>
+    </text>
+   </text-unit>
+   <figures xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.004"
+      rolemaps-to="Sect"
+     >
+    <float xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.008"
+       rolemaps-to="Aside"
+      >
+     <Caption xmlns="http://iso.org/pdf2/ssn"
+        id="ID.015"
+       >
+      <Lbl xmlns="http://iso.org/pdf2/ssn"
+         id="ID.016"
+        >
+       <?MarkedContent page="1" ?>Figure 0.1: 
+      </Lbl>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.017"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Justify"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>An illustration
+      </text>
+     </Caption>
+    </float>
+   </figures>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-incompatible/memoir/memoir-07-BAD.tex
+++ b/tagging-status/testfiles-incompatible/memoir/memoir-07-BAD.tex
@@ -1,0 +1,16 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on,
+  }
+\documentclass{memoir}
+\begin{document}
+Some text
+\begin{figure}
+\begin{sidecaption}{An illustration}
+Some side caption
+\end{sidecaption}
+\end{figure}
+\end{document}

--- a/tagging-status/testfiles-incompatible/memoir/memoir-08-BAD.pdftex.struct.xml
+++ b/tagging-status/testfiles-incompatible/memoir/memoir-08-BAD.pdftex.struct.xml
@@ -1,0 +1,96 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <TD xmlns="http://iso.org/pdf2/ssn"
+      id="ID.005"
+     >
+    <?MarkedContent page="1" ?>LEFT
+   </TD>
+   <TD xmlns="http://iso.org/pdf2/ssn"
+      id="ID.006"
+     >
+    <?MarkedContent page="1" ?>CENTER
+   </TD>
+   <TD xmlns="http://iso.org/pdf2/ssn"
+      id="ID.007"
+     >
+    <?MarkedContent page="1" ?>RIGHT
+   </TD>
+   <TD xmlns="http://iso.org/pdf2/ssn"
+      id="ID.008"
+     >
+    <?MarkedContent page="1" ?>l
+   </TD>
+   <TD xmlns="http://iso.org/pdf2/ssn"
+      id="ID.009"
+     >
+    <?MarkedContent page="1" ?>c
+   </TD>
+   <TD xmlns="http://iso.org/pdf2/ssn"
+      id="ID.010"
+     >
+    <?MarkedContent page="1" ?>r
+   </TD>
+   <TD xmlns="http://iso.org/pdf2/ssn"
+      id="ID.011"
+     >
+    <?MarkedContent page="1" ?>l
+   </TD>
+   <TD xmlns="http://iso.org/pdf2/ssn"
+      id="ID.012"
+     >
+    <?MarkedContent page="1" ?>c
+   </TD>
+   <TD xmlns="http://iso.org/pdf2/ssn"
+      id="ID.013"
+     >
+    <?MarkedContent page="1" ?>r
+   </TD>
+   <TD xmlns="http://iso.org/pdf2/ssn"
+      id="ID.014"
+     >
+    <?MarkedContent page="1" ?>l
+   </TD>
+   <TD xmlns="http://iso.org/pdf2/ssn"
+      id="ID.015"
+     >
+    <?MarkedContent page="1" ?>c
+   </TD>
+   <TD xmlns="http://iso.org/pdf2/ssn"
+      id="ID.016"
+     >
+    <?MarkedContent page="1" ?>r
+   </TD>
+   <TD xmlns="http://iso.org/pdf2/ssn"
+      id="ID.017"
+     >
+    <?MarkedContent page="1" ?>l
+   </TD>
+   <TD xmlns="http://iso.org/pdf2/ssn"
+      id="ID.018"
+     >
+    <?MarkedContent page="1" ?>c
+   </TD>
+   <TD xmlns="http://iso.org/pdf2/ssn"
+      id="ID.019"
+     >
+    <?MarkedContent page="1" ?>r
+   </TD>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.020"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.021"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-incompatible/memoir/memoir-08-BAD.struct.xml
+++ b/tagging-status/testfiles-incompatible/memoir/memoir-08-BAD.struct.xml
@@ -1,0 +1,95 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <TD xmlns="http://iso.org/pdf2/ssn"
+      id="ID.006"
+     >
+    <?MarkedContent page="1" ?>LEFT
+   </TD>
+   <TD xmlns="http://iso.org/pdf2/ssn"
+      id="ID.007"
+     >
+    <?MarkedContent page="1" ?>CENTER
+   </TD>
+   <TD xmlns="http://iso.org/pdf2/ssn"
+      id="ID.008"
+     >
+    <?MarkedContent page="1" ?>RIGHT
+   </TD>
+   <TD xmlns="http://iso.org/pdf2/ssn"
+      id="ID.009"
+     >
+    <?MarkedContent page="1" ?>l
+   </TD>
+   <TD xmlns="http://iso.org/pdf2/ssn"
+      id="ID.010"
+     >
+    <?MarkedContent page="1" ?>c
+   </TD>
+   <TD xmlns="http://iso.org/pdf2/ssn"
+      id="ID.011"
+     >
+    <?MarkedContent page="1" ?>r
+   </TD>
+   <TD xmlns="http://iso.org/pdf2/ssn"
+      id="ID.012"
+     >
+    <?MarkedContent page="1" ?>l
+   </TD>
+   <TD xmlns="http://iso.org/pdf2/ssn"
+      id="ID.013"
+     >
+    <?MarkedContent page="1" ?>c
+   </TD>
+   <TD xmlns="http://iso.org/pdf2/ssn"
+      id="ID.014"
+     >
+    <?MarkedContent page="1" ?>r
+   </TD>
+   <TD xmlns="http://iso.org/pdf2/ssn"
+      id="ID.015"
+     >
+    <?MarkedContent page="1" ?>l
+   </TD>
+   <TD xmlns="http://iso.org/pdf2/ssn"
+      id="ID.016"
+     >
+    <?MarkedContent page="1" ?>c
+   </TD>
+   <TD xmlns="http://iso.org/pdf2/ssn"
+      id="ID.017"
+     >
+    <?MarkedContent page="1" ?>r
+   </TD>
+   <TD xmlns="http://iso.org/pdf2/ssn"
+      id="ID.018"
+     >
+    <?MarkedContent page="1" ?>l
+   </TD>
+   <TD xmlns="http://iso.org/pdf2/ssn"
+      id="ID.019"
+     >
+    <?MarkedContent page="1" ?>c
+   </TD>
+   <TD xmlns="http://iso.org/pdf2/ssn"
+      id="ID.020"
+     >
+    <?MarkedContent page="1" ?>r
+   </TD>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.021"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.022"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-incompatible/memoir/memoir-08-BAD.tex
+++ b/tagging-status/testfiles-incompatible/memoir/memoir-08-BAD.tex
@@ -1,0 +1,17 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on,
+  }
+\documentclass{memoir}
+\begin{document}
+\begin{ctabular}{lcr} \toprule
+LEFT & CENTER & RIGHT \\ \midrule
+l & c & r \\
+l & c & r \\
+l & c & r \\
+l & c & r \\ \bottomrule
+\end{ctabular}
+\end{document}

--- a/tagging-status/testfiles-incompatible/memoir/memoir-09-BAD.pdftex.struct.xml
+++ b/tagging-status/testfiles-incompatible/memoir/memoir-09-BAD.pdftex.struct.xml
@@ -1,0 +1,47 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.005"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.006"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Some before text
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.007"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.008"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.009"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.010"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Some after text
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-incompatible/memoir/memoir-09-BAD.struct.xml
+++ b/tagging-status/testfiles-incompatible/memoir/memoir-09-BAD.struct.xml
@@ -1,0 +1,46 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.006"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.007"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Some before text
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.008"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.009"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.010"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.011"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Some after text
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-incompatible/memoir/memoir-09-BAD.tex
+++ b/tagging-status/testfiles-incompatible/memoir/memoir-09-BAD.tex
@@ -1,0 +1,15 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on,
+  }
+\documentclass{memoir}
+\begin{document}
+Some before text
+\autorows{c}{5}{c}{one, two, three, four, five,
+six, seven, eight, nine, ten,
+eleven, twelve, thirteen, fourteen }
+Some after text
+\end{document}

--- a/tagging-status/testfiles-incompatible/memoir/memoir-10-BAD.pdftex.struct.xml
+++ b/tagging-status/testfiles-incompatible/memoir/memoir-10-BAD.pdftex.struct.xml
@@ -1,0 +1,1 @@
+<run-error code="1" />

--- a/tagging-status/testfiles-incompatible/memoir/memoir-10-BAD.struct.xml
+++ b/tagging-status/testfiles-incompatible/memoir/memoir-10-BAD.struct.xml
@@ -1,0 +1,1 @@
+<run-error code="1" />

--- a/tagging-status/testfiles-incompatible/memoir/memoir-10-BAD.tex
+++ b/tagging-status/testfiles-incompatible/memoir/memoir-10-BAD.tex
@@ -1,0 +1,12 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on,
+  }
+\documentclass{memoir}
+\usepackage{hyperref}
+\begin{document}
+Some text\footnote{blub}
+\end{document}

--- a/tagging-status/testfiles-incompatible/memoir/memoir-11-BAD.pdftex.struct.xml
+++ b/tagging-status/testfiles-incompatible/memoir/memoir-11-BAD.pdftex.struct.xml
@@ -1,0 +1,78 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <footnotelabel xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.011"
+      rolemaps-to="Lbl"
+     >
+    <?MarkedContent page="1" ?>
+    <Span xmlns="http://iso.org/pdf2/ssn"
+       id="ID.012"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextPosition="Sup"
+      >
+     <?MarkedContent page="1" ?>1
+    </Span>
+    <?MarkedContent page="1" ?>
+   </footnotelabel>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.005"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.006"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Some text
+     <footnotemark xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.007"
+        rolemaps-to="Lbl"
+       >
+      <?MarkedContent page="1" ?>
+      <Span xmlns="http://iso.org/pdf2/ssn"
+         id="ID.008"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextPosition="Sup"
+        >
+       <?MarkedContent page="1" ?>1
+      </Span>
+      <?MarkedContent page="1" ?>
+     </footnotemark>
+     <?MarkedContent page="1" ?>
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.009"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.010"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Justify"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>
+       <?MarkedContent page="1" ?>
+       <?MarkedContent page="1" ?>
+       <?MarkedContent page="1" ?>The
+       <Code xmlns="http://iso.org/pdf/ssn"
+          id="ID.013"
+         >
+        <?MarkedContent page="1" ?>\footnote
+       </Code>
+       <?MarkedContent page="1" ?>macro, like all other macros except for
+       <Code xmlns="http://iso.org/pdf/ssn"
+          id="ID.014"
+         >
+        <?MarkedContent page="1" ?>\verbfootnote
+       </Code>
+       <?MarkedContent page="1" ?>, can not containverbatim text in its argument.
+      </text>
+     </text-unit>
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-incompatible/memoir/memoir-11-BAD.struct.xml
+++ b/tagging-status/testfiles-incompatible/memoir/memoir-11-BAD.struct.xml
@@ -1,0 +1,72 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <footnotelabel xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.012"
+      rolemaps-to="Lbl"
+     >
+    <Span xmlns="http://iso.org/pdf2/ssn"
+       id="ID.013"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextPosition="Sup"
+      >
+     <?MarkedContent page="1" ?>1
+    </Span>
+   </footnotelabel>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.006"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.007"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Some text
+     <footnotemark xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.008"
+        rolemaps-to="Lbl"
+       >
+      <Span xmlns="http://iso.org/pdf2/ssn"
+         id="ID.009"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextPosition="Sup"
+        >
+       <?MarkedContent page="1" ?>1
+      </Span>
+     </footnotemark>
+     <?MarkedContent page="1" ?>
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.010"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.011"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Justify"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>
+       <?MarkedContent page="1" ?>The 
+       <Code xmlns="http://iso.org/pdf/ssn"
+          id="ID.014"
+         >
+        <?MarkedContent page="1" ?>\footnote
+       </Code>
+       <?MarkedContent page="1" ?> macro, like all other macros except for 
+       <Code xmlns="http://iso.org/pdf/ssn"
+          id="ID.015"
+         >
+        <?MarkedContent page="1" ?>\verbfootnote
+       </Code>
+       <?MarkedContent page="1" ?>, can not contain verbatim text in its argument.
+      </text>
+     </text-unit>
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-incompatible/memoir/memoir-11-BAD.tex
+++ b/tagging-status/testfiles-incompatible/memoir/memoir-11-BAD.tex
@@ -1,0 +1,14 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on,
+  }
+\documentclass{memoir}
+\begin{document}
+Some text\verbfootnote{The \verb?\footnote? macro, like all
+other macros except for \verb?\verbfootnote?,
+can not contain verbatim text in its
+argument.\label{fn2}}
+\end{document}

--- a/tagging-status/testfiles-incompatible/memoir/memoir-12-BAD.pdftex.struct.xml
+++ b/tagging-status/testfiles-incompatible/memoir/memoir-12-BAD.pdftex.struct.xml
@@ -1,0 +1,94 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.005"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.006"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>text
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.007"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.008"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Justify"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>
+      </text>
+      <Div xmlns="http://iso.org/pdf2/ssn"
+         id="ID.009"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.010"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.011"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="End"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="1" ?>side text
+        </text>
+       </text-unit>
+      </Div>
+      <Div xmlns="http://iso.org/pdf2/ssn"
+         id="ID.012"
+        >
+      </Div>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.013"
+         rolemaps-to="P"
+        >
+      </text>
+     </text-unit>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.014"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.015"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <!-- Referenced marked content sequence not found -->
+     <?MarkedContent page="1" ?>[missing]
+     <!-- Referenced marked content sequence not found -->
+     <?MarkedContent page="1" ?>[missing]
+    </text>
+    <Aside xmlns="http://iso.org/pdf2/ssn"
+       id="ID.016"
+      >
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.017"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.018"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Justify"
+         rolemaps-to="P"
+        >
+       <!-- Referenced marked content sequence not found -->
+       <?MarkedContent page="1" ?>[missing]
+      </text>
+     </text-unit>
+    </Aside>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-incompatible/memoir/memoir-12-BAD.struct.xml
+++ b/tagging-status/testfiles-incompatible/memoir/memoir-12-BAD.struct.xml
@@ -1,0 +1,89 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.006"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.007"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>text
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.008"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.009"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Justify"
+         rolemaps-to="P"
+        >
+      </text>
+      <Div xmlns="http://iso.org/pdf2/ssn"
+         id="ID.010"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.011"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.012"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="End"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="1" ?>side text
+        </text>
+       </text-unit>
+      </Div>
+      <Div xmlns="http://iso.org/pdf2/ssn"
+         id="ID.013"
+        >
+      </Div>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.014"
+         rolemaps-to="P"
+        >
+      </text>
+     </text-unit>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.015"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.016"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>text
+    </text>
+    <Aside xmlns="http://iso.org/pdf2/ssn"
+       id="ID.017"
+      >
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.018"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.019"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Justify"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>margin text
+      </text>
+     </text-unit>
+    </Aside>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-incompatible/memoir/memoir-12-BAD.tex
+++ b/tagging-status/testfiles-incompatible/memoir/memoir-12-BAD.tex
@@ -1,0 +1,14 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on,
+  }
+\documentclass{memoir}
+\begin{document}
+text\sidepar{side text}
+
+% compare with
+text\marginpar{margin text}
+\end{document}

--- a/tagging-status/testfiles-incompatible/memoir/memoir-13-BAD.pdftex.struct.xml
+++ b/tagging-status/testfiles-incompatible/memoir/memoir-13-BAD.pdftex.struct.xml
@@ -1,0 +1,68 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.005"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.006"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>text
+     <Span xmlns="http://iso.org/pdf2/ssn"
+        id="ID.007"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextPosition="Sup"
+       >
+      <?MarkedContent page="1" ?>1
+     </Span>
+     <?MarkedContent page="1" ?>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.008"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.009"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Start"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="3" ?>Chapter 1
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.010"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.011"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Start"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="3" ?>Notes
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.012"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.013"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="3" ?>1. pagenote text
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-incompatible/memoir/memoir-13-BAD.struct.xml
+++ b/tagging-status/testfiles-incompatible/memoir/memoir-13-BAD.struct.xml
@@ -1,0 +1,67 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.006"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.007"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>text
+     <Span xmlns="http://iso.org/pdf2/ssn"
+        id="ID.008"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextPosition="Sup"
+       >
+      <?MarkedContent page="1" ?>1
+     </Span>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.009"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.010"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Start"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="3" ?>Chapter 1
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.011"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.012"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Start"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="3" ?>Notes
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.013"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.014"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="3" ?>1.  pagenote text
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-incompatible/memoir/memoir-13-BAD.tex
+++ b/tagging-status/testfiles-incompatible/memoir/memoir-13-BAD.tex
@@ -1,0 +1,13 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on,
+  }
+\documentclass{memoir}
+\makepagenote
+\begin{document}
+text\pagenote{pagenote text}
+\printpagenotes
+\end{document}

--- a/tagging-status/testfiles-incompatible/memoir/memoir-14-BAD.pdftex.struct.xml
+++ b/tagging-status/testfiles-incompatible/memoir/memoir-14-BAD.pdftex.struct.xml
@@ -1,0 +1,133 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.005"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.006"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>As any dedicated reader can clearly see, the Ideal of practical reason is arepresentation of, as far as I know, the things in themselves; as I have shownelsewhere, the phenomena should only be used as a canon for our understand-ing. The paralogisms of practical reason are what first give rise to the archi-tectonic of practical reason. As will easily be shown in the next section, reasonwould thereby be made to contradict, in view of these considerations, the Idealof practical reason, yet the manifold depends on the phenomena. Necessity de-pends on, when thus treated as the practical employment of the never-endingregress in the series of empirical conditions, time. Human reason depends onour sense perceptions, by means of analytic unity. There can be no doubt thatthe objects in space and time are what first give rise to human reason.
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.007"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.008"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Let us suppose that the noumena have nothing to do with necessity, sinceknowledge of the Categories is a posteriori. Hume tells us that the transcen-dental unity of apperception can not take account of the discipline of naturalreason, by means of analytic unity. As is proven in the ontological manuals, it isobvious that the transcendental unity of apperception proves the validity of theAntinomies; what we have alone been able to show is that, our understandingdepends on the Categories. It remains a mystery why the Ideal stands in needof reason. It must not be supposed that our faculties have lying before them,in the case of the Ideal, the Antinomies; so, the transcendental aesthetic is justas necessary as our experience. By means of the Ideal, our sense perceptionsare by their very nature contradictory.
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.009"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.010"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="End"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="2" ?>
+    </text>
+    <Div xmlns="http://iso.org/pdf2/ssn"
+       id="ID.011"
+      >
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.012"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.013"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="End"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="2" ?>
+      </text>
+      <Div xmlns="http://iso.org/pdf2/ssn"
+         id="ID.014"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.015"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.016"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Start"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="2" ?>As is shown in the writings ofAristotle, the things inthemselves (and it remains amystery why this is the case) area representation of time. Ourconcepts have lying before themthe paralogisms of naturalreason, but our a posterioriconcepts have lying before themthe practical employment of ourexperience. Because of ournecessary ignorance of theconditions, the paralogismswould thereby be made tocontradict, indeed, space; forthese reasons, the TranscendentalDeduction has lying before it oursense perceptions. (Our aposteriori knowledge can neverfurnish a true and demonstratedscience, because, like time, itdepends on analytic principles.)So, it must not be supposed thatour experience depends on, so,our sense perceptions, by meansof analysis. Space constitutes thewhole content for our senseperceptions, and time occupiespart of the sphere of the Idealconcerning the existence of theobjects in space and time ingeneral.
+        </text>
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.017"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Start"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="2" ?>
+        </text>
+       </text-unit>
+      </Div>
+      <Div xmlns="http://iso.org/pdf2/ssn"
+         id="ID.018"
+        >
+      </Div>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.019"
+         rolemaps-to="P"
+        >
+      </text>
+      <Div xmlns="http://iso.org/pdf2/ssn"
+         id="ID.020"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.021"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.022"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="End"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="2" ?>Immanuel Kant
+        </text>
+       </text-unit>
+      </Div>
+      <Div xmlns="http://iso.org/pdf2/ssn"
+         id="ID.023"
+        >
+      </Div>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.024"
+         rolemaps-to="P"
+        >
+      </text>
+     </text-unit>
+    </Div>
+    <Div xmlns="http://iso.org/pdf2/ssn"
+       id="ID.025"
+      >
+    </Div>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.026"
+       rolemaps-to="P"
+      >
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-incompatible/memoir/memoir-14-BAD.struct.xml
+++ b/tagging-status/testfiles-incompatible/memoir/memoir-14-BAD.struct.xml
@@ -1,0 +1,135 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.006"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.007"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>As any dedicated reader can clearly see, the Ideal of practical reason is a representation of, as far as I know, the things in themselves; as I have shown elsewhere, the phenomena should only be used as a canon for our understand
+     <?MarkedContent page="1" ?>ing. The paralogisms of practical reason are what first give rise to the archi
+     <?MarkedContent page="1" ?>tectonic of practical reason. As will easily be shown in the next section, reason would thereby be made to contradict, in view of these considerations, the Ideal of practical reason, yet the manifold depends on the phenomena. Necessity de
+     <?MarkedContent page="1" ?>pends on, when thus treated as the practical employment of the never-ending regress in the series of empirical conditions, time. Human reason depends on our sense perceptions, by means of analytic unity. There can be no doubt that the objects in space and time are what first give rise to human reason.
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.008"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.009"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Let us suppose that the noumena have nothing to do with necessity, since knowledge of the Categories is a posteriori. Hume tells us that the transcen
+     <?MarkedContent page="1" ?>dental unity of apperception can not take account of the discipline of natural reason, by means of analytic unity. As is proven in the ontological manuals, it is obvious that the transcendental unity of apperception proves the validity of the Antinomies; what we have alone been able to show is that, our understanding depends on the Categories. It remains a mystery why the Ideal stands in need of reason. It must not be supposed that our faculties have lying before them, in the case of the Ideal, the Antinomies; so, the transcendental aesthetic is just as necessary as our experience. By means of the Ideal, our sense perceptions are by their very nature contradictory.
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.010"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.011"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="End"
+       rolemaps-to="P"
+      >
+    </text>
+    <Div xmlns="http://iso.org/pdf2/ssn"
+       id="ID.012"
+      >
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.013"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.014"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="End"
+         rolemaps-to="P"
+        >
+      </text>
+      <Div xmlns="http://iso.org/pdf2/ssn"
+         id="ID.015"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.016"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.017"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Start"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="2" ?>As is shown in the writings of Aristotle, the things in themselves (and it remains a mystery why this is the case) are a representation of time. Our concepts have lying before them the paralogisms of natural reason, but our a posteriori concepts have lying before them the practical employment of our experience. Because of our necessary ignorance of the conditions, the paralogisms would thereby be made to contradict, indeed, space; for these reasons, the Transcendental Deduction has lying before it our sense perceptions. (Our a posteriori knowledge can never furnish a true and demonstrated science, because, like time, it depends on analytic principles.) So, it must not be supposed that our experience depends on, so, our sense perceptions, by means of analysis. Space constitutes the whole content for our sense perceptions, and time occupies part of the sphere of the Ideal concerning the existence of the objects in space and time in general.
+        </text>
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.018"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Start"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="2" ?>
+        </text>
+       </text-unit>
+      </Div>
+      <Div xmlns="http://iso.org/pdf2/ssn"
+         id="ID.019"
+        >
+      </Div>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.020"
+         rolemaps-to="P"
+        >
+      </text>
+      <Div xmlns="http://iso.org/pdf2/ssn"
+         id="ID.021"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.022"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.023"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="End"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="2" ?>Immanuel Kant
+        </text>
+       </text-unit>
+      </Div>
+      <Div xmlns="http://iso.org/pdf2/ssn"
+         id="ID.024"
+        >
+      </Div>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.025"
+         rolemaps-to="P"
+        >
+      </text>
+     </text-unit>
+    </Div>
+    <Div xmlns="http://iso.org/pdf2/ssn"
+       id="ID.026"
+      >
+    </Div>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.027"
+       rolemaps-to="P"
+      >
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-incompatible/memoir/memoir-14-BAD.tex
+++ b/tagging-status/testfiles-incompatible/memoir/memoir-14-BAD.tex
@@ -1,0 +1,13 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on,
+  }
+\documentclass{memoir}
+\usepackage{kantlipsum}
+\begin{document}
+\kant[1-2]
+\epigraph{\kant[3]}{Immanuel Kant}
+\end{document}

--- a/tagging-status/testfiles-incompatible/memoir/memoir-15-BAD.pdftex.struct.xml
+++ b/tagging-status/testfiles-incompatible/memoir/memoir-15-BAD.pdftex.struct.xml
@@ -1,0 +1,119 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.005"
+      rolemaps-to="Part"
+     >
+    <quote xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.006"
+       rolemaps-to="BlockQuote"
+      >
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.007"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.008"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Justify"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>There was a young man of Quebec
+      </text>
+     </text-unit>
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.009"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.010"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Justify"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>Who was frozen in snow to his neck.
+      </text>
+     </text-unit>
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.011"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.012"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Justify"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>When asked: ‘Are you friz?’
+      </text>
+     </text-unit>
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.013"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.014"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Justify"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>He replied: ‘Yes, I is,
+      </text>
+     </text-unit>
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.015"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.016"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Justify"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>But we don’t call this cold in Quebec.’
+      </text>
+     </text-unit>
+    </quote>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.017"
+      rolemaps-to="Part"
+     >
+    <quote xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.018"
+       rolemaps-to="BlockQuote"
+      >
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.019"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.020"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Justify"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>Come away with me.
+      </text>
+     </text-unit>
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.021"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.022"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Justify"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>Impossible!
+      </text>
+     </text-unit>
+    </quote>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-incompatible/memoir/memoir-15-BAD.struct.xml
+++ b/tagging-status/testfiles-incompatible/memoir/memoir-15-BAD.struct.xml
@@ -1,0 +1,119 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.006"
+      rolemaps-to="Part"
+     >
+    <quote xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.007"
+       rolemaps-to="BlockQuote"
+      >
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.008"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.009"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Justify"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>There was a young man of Quebec
+      </text>
+     </text-unit>
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.010"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.011"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Justify"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>Who was frozen in snow to his neck.
+      </text>
+     </text-unit>
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.012"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.013"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Justify"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>When asked: ‘Are you friz?’
+      </text>
+     </text-unit>
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.014"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.015"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Justify"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>He replied: ‘Yes, I is,
+      </text>
+     </text-unit>
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.016"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.017"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Justify"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>But we don’t call this cold in Quebec.’
+      </text>
+     </text-unit>
+    </quote>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.018"
+      rolemaps-to="Part"
+     >
+    <quote xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.019"
+       rolemaps-to="BlockQuote"
+      >
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.020"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.021"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Justify"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>Come away with me.
+      </text>
+     </text-unit>
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.022"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.023"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Justify"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?> Impossible!
+      </text>
+     </text-unit>
+    </quote>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-incompatible/memoir/memoir-15-BAD.tex
+++ b/tagging-status/testfiles-incompatible/memoir/memoir-15-BAD.tex
@@ -1,0 +1,25 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on,
+  }
+\documentclass{memoir}
+\begin{document}
+\indentpattern{00110}
+\begin{verse}
+\begin{patverse}
+There was a young man of Quebec \\
+Who was frozen in snow to his neck. \\
+When asked: `Are you friz?' \\
+He replied: `Yes, I is, \\
+But we don't call this cold in Quebec.'
+\end{patverse}
+\end{verse}
+
+\begin{verse}
+Come away with me. \\
+\vinphantom{Come away with me.} Impossible!
+\end{verse}
+\end{document}

--- a/tagging-status/testfiles-incompatible/memoir/memoir-16-BAD.pdftex.struct.xml
+++ b/tagging-status/testfiles-incompatible/memoir/memoir-16-BAD.pdftex.struct.xml
@@ -1,0 +1,1 @@
+<run-error code="1" />

--- a/tagging-status/testfiles-incompatible/memoir/memoir-16-BAD.struct.xml
+++ b/tagging-status/testfiles-incompatible/memoir/memoir-16-BAD.struct.xml
@@ -1,0 +1,1 @@
+<run-error code="1" />

--- a/tagging-status/testfiles-incompatible/memoir/memoir-16-BAD.tex
+++ b/tagging-status/testfiles-incompatible/memoir/memoir-16-BAD.tex
@@ -1,0 +1,15 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on,
+  }
+\documentclass{memoir}
+\begin{document}
+\begin{fboxverbatim}
+&%&%(Y&(&#@!^
+
+AJNKDJIUVDA*&Y
+\end{fboxverbatim}
+\end{document}

--- a/tagging-status/testfiles-incompatible/memoir/memoir-17-BAD.pdftex.struct.xml
+++ b/tagging-status/testfiles-incompatible/memoir/memoir-17-BAD.pdftex.struct.xml
@@ -1,0 +1,75 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.005"
+      rolemaps-to="Part"
+     >
+    <list xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.006"
+       xmlns:List="http://iso.org/pdf/ssn/List"
+       List:ListNumbering="Unordered"
+       rolemaps-to="L"
+      >
+     <item xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.007"
+        rolemaps-to="LI"
+       >
+      <itemlabel xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.008"
+         rolemaps-to="Lbl"
+        >
+       <?MarkedContent page="1" ?>
+      </itemlabel>
+      <itembody xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.009"
+         rolemaps-to="LBody"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.010"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.011"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="1" ?>&amp;%&amp;%(Y&amp;(&amp;#@!^
+        </text>
+       </text-unit>
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.012"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.013"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="1" ?>
+        </text>
+       </text-unit>
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.014"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.015"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="1" ?>AJNKDJIUVDA*&amp;Y
+        </text>
+       </text-unit>
+      </itembody>
+     </item>
+    </list>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-incompatible/memoir/memoir-17-BAD.struct.xml
+++ b/tagging-status/testfiles-incompatible/memoir/memoir-17-BAD.struct.xml
@@ -1,0 +1,77 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.006"
+      rolemaps-to="Part"
+     >
+    <list xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.007"
+       xmlns:List="http://iso.org/pdf/ssn/List"
+       List:ListNumbering="Unordered"
+       rolemaps-to="L"
+      >
+     <item xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.008"
+        rolemaps-to="LI"
+       >
+      <itemlabel xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.009"
+         rolemaps-to="Lbl"
+        >
+      </itemlabel>
+      <itembody xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.010"
+         rolemaps-to="LBody"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.011"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.012"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="1" ?>
+         <?MarkedContent page="1" ?>&amp;%&amp;%(Y&amp;(&amp;#@!^
+        </text>
+       </text-unit>
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.013"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.014"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="1" ?>
+         <?MarkedContent page="1" ?>
+        </text>
+       </text-unit>
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.015"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.016"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="1" ?>
+         <?MarkedContent page="1" ?>AJNKDJIUVDA*&amp;Y
+        </text>
+       </text-unit>
+      </itembody>
+     </item>
+    </list>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-incompatible/memoir/memoir-17-BAD.tex
+++ b/tagging-status/testfiles-incompatible/memoir/memoir-17-BAD.tex
@@ -1,0 +1,15 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on,
+  }
+\documentclass{memoir}
+\begin{document}
+\begin{boxedverbatim}
+&%&%(Y&(&#@!^
+
+AJNKDJIUVDA*&Y
+\end{boxedverbatim}
+\end{document}

--- a/tagging-status/testfiles-incompatible/memoir/memoir-18-BAD.pdftex.struct.xml
+++ b/tagging-status/testfiles-incompatible/memoir/memoir-18-BAD.pdftex.struct.xml
@@ -1,0 +1,85 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.005"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.006"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Some text
+    </text>
+   </text-unit>
+   <Figure xmlns="http://iso.org/pdf2/ssn"
+      id="ID.007"
+      alt="picture environment"
+      xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+      Layout:BBox="{ 0, 792, 0, 792 }"
+     >
+    <?MarkedContent page="1" ?>
+   </Figure>
+   <Figure xmlns="http://iso.org/pdf2/ssn"
+      id="ID.008"
+      alt="picture environment"
+      xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+      Layout:BBox="{ 306.00002, 792, 306.00002, 792 }"
+     >
+    <?MarkedContent page="1" ?>
+   </Figure>
+   <Figure xmlns="http://iso.org/pdf2/ssn"
+      id="ID.009"
+      alt="picture environment"
+      xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+      Layout:BBox="{ 612, 792, 612, 792 }"
+     >
+    <?MarkedContent page="1" ?>
+   </Figure>
+   <Figure xmlns="http://iso.org/pdf2/ssn"
+      id="ID.010"
+      alt="picture environment"
+      xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+      Layout:BBox="{ 0, 396, 0, 396 }"
+     >
+    <?MarkedContent page="1" ?>
+   </Figure>
+   <Figure xmlns="http://iso.org/pdf2/ssn"
+      id="ID.011"
+      alt="picture environment"
+      xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+      Layout:BBox="{ 612, 396, 612, 396 }"
+     >
+    <?MarkedContent page="1" ?>
+   </Figure>
+   <Figure xmlns="http://iso.org/pdf2/ssn"
+      id="ID.012"
+      alt="picture environment"
+      xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+      Layout:BBox="{ 0, 0, 0, 0 }"
+     >
+    <?MarkedContent page="1" ?>
+   </Figure>
+   <Figure xmlns="http://iso.org/pdf2/ssn"
+      id="ID.013"
+      alt="picture environment"
+      xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+      Layout:BBox="{ 306.00002, 0, 306.00002, 0 }"
+     >
+    <?MarkedContent page="1" ?>
+   </Figure>
+   <Figure xmlns="http://iso.org/pdf2/ssn"
+      id="ID.014"
+      alt="picture environment"
+      xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+      Layout:BBox="{ 612, 0, 612, 0 }"
+     >
+    <?MarkedContent page="1" ?>
+   </Figure>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-incompatible/memoir/memoir-18-BAD.struct.xml
+++ b/tagging-status/testfiles-incompatible/memoir/memoir-18-BAD.struct.xml
@@ -1,0 +1,85 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.006"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.007"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Some text
+    </text>
+   </text-unit>
+   <Figure xmlns="http://iso.org/pdf2/ssn"
+      id="ID.008"
+      alt="picture environment"
+      xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+      Layout:BBox="{ 0, 792, 0, 792 }"
+     >
+    <?MarkedContent page="1" ?>
+   </Figure>
+   <Figure xmlns="http://iso.org/pdf2/ssn"
+      id="ID.009"
+      alt="picture environment"
+      xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+      Layout:BBox="{ 306, 792, 306, 792 }"
+     >
+    <?MarkedContent page="1" ?>
+   </Figure>
+   <Figure xmlns="http://iso.org/pdf2/ssn"
+      id="ID.010"
+      alt="picture environment"
+      xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+      Layout:BBox="{ 611.99998, 792, 611.99998, 792 }"
+     >
+    <?MarkedContent page="1" ?>
+   </Figure>
+   <Figure xmlns="http://iso.org/pdf2/ssn"
+      id="ID.011"
+      alt="picture environment"
+      xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+      Layout:BBox="{ 0, 396.00002, 0, 396.00002 }"
+     >
+    <?MarkedContent page="1" ?>
+   </Figure>
+   <Figure xmlns="http://iso.org/pdf2/ssn"
+      id="ID.012"
+      alt="picture environment"
+      xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+      Layout:BBox="{ 611.99998, 396.00002, 611.99998, 396.00002 }"
+     >
+    <?MarkedContent page="1" ?>
+   </Figure>
+   <Figure xmlns="http://iso.org/pdf2/ssn"
+      id="ID.013"
+      alt="picture environment"
+      xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+      Layout:BBox="{ 0, 2e-05, 0, 2e-05 }"
+     >
+    <?MarkedContent page="1" ?>
+   </Figure>
+   <Figure xmlns="http://iso.org/pdf2/ssn"
+      id="ID.014"
+      alt="picture environment"
+      xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+      Layout:BBox="{ 306, 2e-05, 306, 2e-05 }"
+     >
+    <?MarkedContent page="1" ?>
+   </Figure>
+   <Figure xmlns="http://iso.org/pdf2/ssn"
+      id="ID.015"
+      alt="picture environment"
+      xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+      Layout:BBox="{ 611.99998, 2e-05, 611.99998, 2e-05 }"
+     >
+    <?MarkedContent page="1" ?>
+   </Figure>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-incompatible/memoir/memoir-18-BAD.tex
+++ b/tagging-status/testfiles-incompatible/memoir/memoir-18-BAD.tex
@@ -1,0 +1,11 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on,
+  }
+\documentclass[showtrims]{memoir}
+\begin{document}
+Some text
+\end{document}

--- a/tagging-status/testfiles-partial/simplecv/simplecv-01.pdftex.struct.xml
+++ b/tagging-status/testfiles-partial/simplecv/simplecv-01.pdftex.struct.xml
@@ -1,0 +1,367 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.005"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.006"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+    </text>
+    <Table xmlns="http://iso.org/pdf2/ssn"
+       id="ID.007"
+      >
+     <TR xmlns="http://iso.org/pdf2/ssn"
+        id="ID.008"
+       >
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.009"
+        >
+       <?MarkedContent page="1" ?>
+       <Table xmlns="http://iso.org/pdf2/ssn"
+          id="ID.010"
+         >
+        <TR xmlns="http://iso.org/pdf2/ssn"
+           id="ID.011"
+          >
+         <TD xmlns="http://iso.org/pdf2/ssn"
+            id="ID.012"
+           >
+          <?MarkedContent page="1" ?>123 Hamlet Street
+         </TD>
+        </TR>
+        <TR xmlns="http://iso.org/pdf2/ssn"
+           id="ID.013"
+          >
+         <TD xmlns="http://iso.org/pdf2/ssn"
+            id="ID.014"
+           >
+          <?MarkedContent page="1" ?>Stratford-upon-Avon
+         </TD>
+        </TR>
+       </Table>
+       <?MarkedContent page="1" ?>
+      </TD>
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.015"
+        >
+       <?MarkedContent page="1" ?>
+       <Table xmlns="http://iso.org/pdf2/ssn"
+          id="ID.016"
+         >
+        <TR xmlns="http://iso.org/pdf2/ssn"
+           id="ID.017"
+          >
+         <TD xmlns="http://iso.org/pdf2/ssn"
+            id="ID.018"
+           >
+          <?MarkedContent page="1" ?>TEL: 888-PUCK
+         </TD>
+        </TR>
+        <TR xmlns="http://iso.org/pdf2/ssn"
+           id="ID.019"
+          >
+         <TD xmlns="http://iso.org/pdf2/ssn"
+            id="ID.020"
+           >
+          <?MarkedContent page="1" ?>bill@globe.org
+         </TD>
+        </TR>
+       </Table>
+       <?MarkedContent page="1" ?>
+      </TD>
+     </TR>
+    </Table>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.021"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.022"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.023"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Center"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>William Shakespeare
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.024"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.025"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Some people put a summary here. Note: there are many
+     <Span xmlns="http://iso.org/pdf2/ssn"
+        id="ID.026"
+        actualtext="LaTeX"
+        phoneme="[ˈlaːtɛx]"
+       >
+      <?MarkedContent page="1" ?>LATEX
+     </Span>
+     <?MarkedContent page="1" ?>variablesyou can set in the preamble to change the look of the CV.
+    </text>
+   </text-unit>
+   <Sect xmlns="http://iso.org/pdf2/ssn"
+      id="ID.027"
+     >
+    <section xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.028"
+       title="Work Experience"
+       rolemaps-to="H1"
+      >
+     <?MarkedContent page="1" ?>Work Experience
+    </section>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.029"
+       rolemaps-to="Part"
+      >
+     <list xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.030"
+        xmlns:List="http://iso.org/pdf/ssn/List"
+        List:ListNumbering="Unordered"
+        rolemaps-to="L"
+       >
+      <item xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.031"
+         rolemaps-to="LI"
+        >
+       <itemlabel xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.032"
+          rolemaps-to="Lbl"
+         >
+        <?MarkedContent page="1" ?>1593–1609
+       </itemlabel>
+       <itembody xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.033"
+          rolemaps-to="LBody"
+         >
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.034"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.035"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>Wrote and produced plays for the Queen, and then for the King.He really liked them a lot, but they reminded him of plays bythis guy, the Earl of Oxford.
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.036"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.037"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>You can have several paragraphs in the same topic entry
+         </text>
+        </text-unit>
+       </itembody>
+      </item>
+     </list>
+    </text-unit>
+   </Sect>
+   <Sect xmlns="http://iso.org/pdf2/ssn"
+      id="ID.038"
+     >
+    <section xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.039"
+       title="Education"
+       rolemaps-to="H1"
+      >
+     <?MarkedContent page="1" ?>Education
+    </section>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.040"
+       rolemaps-to="Part"
+      >
+     <list xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.041"
+        xmlns:List="http://iso.org/pdf/ssn/List"
+        List:ListNumbering="Unordered"
+        rolemaps-to="L"
+       >
+      <item xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.042"
+         rolemaps-to="LI"
+        >
+       <itemlabel xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.043"
+          rolemaps-to="Lbl"
+         >
+        <?MarkedContent page="1" ?>1577–78
+       </itemlabel>
+       <itembody xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.044"
+          rolemaps-to="LBody"
+         >
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.045"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.046"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>My Dad taught me stuff.
+         </text>
+        </text-unit>
+       </itembody>
+      </item>
+      <item xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.047"
+         rolemaps-to="LI"
+        >
+       <itemlabel xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.048"
+          rolemaps-to="Lbl"
+         >
+        <?MarkedContent page="1" ?>April to May 1581
+       </itemlabel>
+       <itembody xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.049"
+          rolemaps-to="LBody"
+         >
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.050"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.051"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>Tried high school. Hated my English teacher. [note how alinebreak is inserted if your subtitle is too long]
+         </text>
+        </text-unit>
+       </itembody>
+      </item>
+     </list>
+    </text-unit>
+   </Sect>
+   <Sect xmlns="http://iso.org/pdf2/ssn"
+      id="ID.052"
+     >
+    <section xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.053"
+       title="Publications"
+       rolemaps-to="H1"
+      >
+     <?MarkedContent page="1" ?>Publications
+    </section>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.054"
+       rolemaps-to="Part"
+      >
+     <list xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.055"
+        xmlns:List="http://iso.org/pdf/ssn/List"
+        List:ListNumbering="Ordered"
+        rolemaps-to="L"
+       >
+      <item xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.056"
+         rolemaps-to="LI"
+         referenced-as="1"
+        >
+       <itemlabel xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.057"
+          rolemaps-to="Lbl"
+         >
+        <?MarkedContent page="1" ?>[1]
+       </itemlabel>
+       <itembody xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.058"
+          rolemaps-to="LBody"
+         >
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.059"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.060"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>First Folio. Me. 1623.
+         </text>
+        </text-unit>
+       </itembody>
+      </item>
+      <item xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.061"
+         rolemaps-to="LI"
+        >
+       <itemlabel xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.062"
+          rolemaps-to="Lbl"
+         >
+        <?MarkedContent page="1" ?>[2]
+       </itemlabel>
+       <itembody xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.063"
+          rolemaps-to="LBody"
+         >
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.064"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.065"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>These references could have been entered via Bib
+          <Span xmlns="http://iso.org/pdf2/ssn"
+             id="ID.066"
+             actualtext="TeX"
+            >
+           <?MarkedContent page="1" ?>TEX
+          </Span>
+          <?MarkedContent page="1" ?>... In anycase, here I can cite my work of [
+          <Reference xmlns="http://iso.org/pdf/ssn"
+             id="ID.067"
+            >
+            <?References objects="1" ?>
+           <?MarkedContent page="1" ?>1
+          </Reference>
+          <?MarkedContent page="1" ?>].
+         </text>
+        </text-unit>
+       </itembody>
+      </item>
+     </list>
+    </text-unit>
+   </Sect>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-partial/simplecv/simplecv-01.struct.xml
+++ b/tagging-status/testfiles-partial/simplecv/simplecv-01.struct.xml
@@ -1,0 +1,361 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.006"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.007"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+    </text>
+    <Table xmlns="http://iso.org/pdf2/ssn"
+       id="ID.008"
+      >
+     <TR xmlns="http://iso.org/pdf2/ssn"
+        id="ID.009"
+       >
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.010"
+        >
+       <Table xmlns="http://iso.org/pdf2/ssn"
+          id="ID.011"
+         >
+        <TR xmlns="http://iso.org/pdf2/ssn"
+           id="ID.012"
+          >
+         <TD xmlns="http://iso.org/pdf2/ssn"
+            id="ID.013"
+           >
+          <?MarkedContent page="1" ?>123 Hamlet Street
+         </TD>
+        </TR>
+        <TR xmlns="http://iso.org/pdf2/ssn"
+           id="ID.014"
+          >
+         <TD xmlns="http://iso.org/pdf2/ssn"
+            id="ID.015"
+           >
+          <?MarkedContent page="1" ?>Stratford-upon-Avon
+         </TD>
+        </TR>
+       </Table>
+      </TD>
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.016"
+        >
+       <Table xmlns="http://iso.org/pdf2/ssn"
+          id="ID.017"
+         >
+        <TR xmlns="http://iso.org/pdf2/ssn"
+           id="ID.018"
+          >
+         <TD xmlns="http://iso.org/pdf2/ssn"
+            id="ID.019"
+           >
+          <?MarkedContent page="1" ?>TEL: 888-PUCK
+         </TD>
+        </TR>
+        <TR xmlns="http://iso.org/pdf2/ssn"
+           id="ID.020"
+          >
+         <TD xmlns="http://iso.org/pdf2/ssn"
+            id="ID.021"
+           >
+          <?MarkedContent page="1" ?> bill@globe.org
+         </TD>
+        </TR>
+       </Table>
+      </TD>
+     </TR>
+    </Table>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.022"
+       rolemaps-to="P"
+      >
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.023"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.024"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Center"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>William Shakespeare
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.025"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.026"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Some people put a summary here. Note: there are many 
+     <Span xmlns="http://iso.org/pdf2/ssn"
+        id="ID.027"
+        actualtext="LaTeX"
+        phoneme="[ˈlaːtɛx]"
+       >
+      <?MarkedContent page="1" ?>LATEX
+     </Span>
+     <?MarkedContent page="1" ?> variables you can set in the preamble to change the look of the CV.
+    </text>
+   </text-unit>
+   <Sect xmlns="http://iso.org/pdf2/ssn"
+      id="ID.028"
+     >
+    <section xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.029"
+       title="Work Experience"
+       rolemaps-to="H1"
+      >
+     <?MarkedContent page="1" ?>Work Experience
+    </section>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.030"
+       rolemaps-to="Part"
+      >
+     <list xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.031"
+        xmlns:List="http://iso.org/pdf/ssn/List"
+        List:ListNumbering="Unordered"
+        rolemaps-to="L"
+       >
+      <item xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.032"
+         rolemaps-to="LI"
+        >
+       <itemlabel xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.033"
+          rolemaps-to="Lbl"
+         >
+        <?MarkedContent page="1" ?>1593–1609
+       </itemlabel>
+       <itembody xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.034"
+          rolemaps-to="LBody"
+         >
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.035"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.036"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>Wrote and produced plays for the Queen, and then for the King. He really liked them a lot, but they reminded him of plays by this guy, the Earl of Oxford.
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.037"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.038"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>You can have several paragraphs in the same topic entry
+         </text>
+        </text-unit>
+       </itembody>
+      </item>
+     </list>
+    </text-unit>
+   </Sect>
+   <Sect xmlns="http://iso.org/pdf2/ssn"
+      id="ID.039"
+     >
+    <section xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.040"
+       title="Education"
+       rolemaps-to="H1"
+      >
+     <?MarkedContent page="1" ?>Education
+    </section>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.041"
+       rolemaps-to="Part"
+      >
+     <list xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.042"
+        xmlns:List="http://iso.org/pdf/ssn/List"
+        List:ListNumbering="Unordered"
+        rolemaps-to="L"
+       >
+      <item xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.043"
+         rolemaps-to="LI"
+        >
+       <itemlabel xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.044"
+          rolemaps-to="Lbl"
+         >
+        <?MarkedContent page="1" ?>1577–78
+       </itemlabel>
+       <itembody xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.045"
+          rolemaps-to="LBody"
+         >
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.046"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.047"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>My Dad taught me stuff.
+         </text>
+        </text-unit>
+       </itembody>
+      </item>
+      <item xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.048"
+         rolemaps-to="LI"
+        >
+       <itemlabel xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.049"
+          rolemaps-to="Lbl"
+         >
+        <?MarkedContent page="1" ?>April to May 1581
+       </itemlabel>
+       <itembody xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.050"
+          rolemaps-to="LBody"
+         >
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.051"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.052"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>Tried high school. Hated my English teacher. [note how a linebreak is inserted if your subtitle is too long]
+         </text>
+        </text-unit>
+       </itembody>
+      </item>
+     </list>
+    </text-unit>
+   </Sect>
+   <Sect xmlns="http://iso.org/pdf2/ssn"
+      id="ID.053"
+     >
+    <section xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.054"
+       title="Publications"
+       rolemaps-to="H1"
+      >
+     <?MarkedContent page="1" ?>Publications
+    </section>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.055"
+       rolemaps-to="Part"
+      >
+     <list xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.056"
+        xmlns:List="http://iso.org/pdf/ssn/List"
+        List:ListNumbering="Ordered"
+        rolemaps-to="L"
+       >
+      <item xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.057"
+         rolemaps-to="LI"
+         referenced-as="1"
+        >
+       <itemlabel xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.058"
+          rolemaps-to="Lbl"
+         >
+        <?MarkedContent page="1" ?>[1]
+       </itemlabel>
+       <itembody xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.059"
+          rolemaps-to="LBody"
+         >
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.060"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.061"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>First Folio. Me. 1623.
+         </text>
+        </text-unit>
+       </itembody>
+      </item>
+      <item xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.062"
+         rolemaps-to="LI"
+        >
+       <itemlabel xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.063"
+          rolemaps-to="Lbl"
+         >
+        <?MarkedContent page="1" ?>[2]
+       </itemlabel>
+       <itembody xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.064"
+          rolemaps-to="LBody"
+         >
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.065"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.066"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>These references could have been entered via Bib
+          <Span xmlns="http://iso.org/pdf2/ssn"
+             id="ID.067"
+             actualtext="TeX"
+            >
+           <?MarkedContent page="1" ?>TEX
+          </Span>
+          <?MarkedContent page="1" ?>… In any case, here I can cite my work of [
+          <Reference xmlns="http://iso.org/pdf/ssn"
+             id="ID.068"
+            >
+            <?References objects="1" ?>
+           <?MarkedContent page="1" ?>1
+          </Reference>
+          <?MarkedContent page="1" ?>].
+         </text>
+        </text-unit>
+       </itembody>
+      </item>
+     </list>
+    </text-unit>
+   </Sect>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-partial/simplecv/simplecv-01.tex
+++ b/tagging-status/testfiles-partial/simplecv/simplecv-01.tex
@@ -1,0 +1,52 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on,
+  }
+\documentclass{simplecv}
+
+\begin{document}
+
+\leftheader{123 Hamlet Street\\
+Stratford-upon-Avon}
+
+\rightheader{TEL: 888-PUCK\\
+\texttt{\small bill@globe.org}}
+
+\title{William Shakespeare}
+
+\maketitle
+
+Some people put a summary here. Note: there are many \LaTeX{}
+variables you can set in the preamble to change the look of the CV.
+
+\section{Work Experience}
+
+\begin{topic}
+\item[1593--1609] Wrote and produced plays for the Queen, and then for the
+King. He really liked them a lot, but they reminded him of plays by
+this guy, the Earl of Oxford.
+
+You can have several paragraphs in the same topic entry
+\end{topic}
+
+\section{Education}
+
+\begin{topic}
+\item[1577--78] My Dad taught me stuff.
+\item[April to May 1581] Tried high school. Hated my English teacher.
+[note how a linebreak is inserted if your subtitle is too long]
+\end{topic}
+
+\section{Publications}
+
+\begin{thebibliography}{1}
+\bibitem{firstref} First Folio. Me. 1623.
+\bibitem{secondref} These references could have been entered via
+Bib\TeX{}\ldots{} In any case, here I can cite my work of
+\cite{firstref}.
+\end{thebibliography}
+
+\end{document}


### PR DESCRIPTION
Lists abntex2abrev, curves, duplicat, fapapersize, gobble, and multienv as compatible without tests.

Lists zhlineskip as compatible with tests.

Lists abntex2 as incompatible since it is an extension of memoir.

Adds several tests for memoir.

Lists zhspacing as no-support since it requires xetex.

Lists currvita as incompatible with a test.

Lists simplecv as partially compatible with a test.