### PR TITLE
package status updates

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -6351,11 +6351,12 @@
 
 - name: grabbox
   type: package
-  status: unchecked
+  status: currently-incompatible
   priority: 9
-  tests: false
-  tasks: needs tests
-  updated: 2024-07-18
+  tests: true
+  comments: "Boxes are not yet supported by the tagging code."
+  issues: [1462]
+  updated: 2026-06-30
 
 - name: graphbox
   type: package
@@ -6755,12 +6756,12 @@
 
 - name: hypgotoe
   type: package
-  status: unchecked
+  status: currently-incompatible
   priority: 9
-  tests: false
-  tasks: needs tests
+  tests: true
+  issues: [1463]
   package-repository: "https://github.com/LaTeX-Package-Repositories/oberdiek"
-  updated: 2024-07-18
+  updated: 2026-06-30
 
 - name: hyphenat
   type: package
@@ -6789,7 +6790,7 @@
   priority: 9
   issues: [350]
   tests: true
-  tasks: needs tests
+  tasks: needs more tests
   updated: 2024-07-29
 
 - name: InriaSans
@@ -6932,12 +6933,12 @@
 
 - name: isotope
   type: package
-  status: unchecked
+  status: partially-compatible
   included-in: [ol0.02]
   priority: 9
-  tests: false
-  tasks: needs tests
-  updated: 2026-01-23
+  tests: true
+  comments: "Tagging of isotopes in text mode is not ideal."
+  updated: 2026-06-30
 
 - name: ifsym
   type: package
@@ -8960,6 +8961,7 @@
   issues: [907]
   comments: "None of the formatting is represented at the tag level; spaces between
              keywords are lost."
+  package-repository: "https://github.com/tweh/menukeys"
   tests: true
   updated: 2025-06-10
 
@@ -11605,6 +11607,7 @@
   status: partially-compatible
   priority: 9
   tests: true
+  package-repository: "https://github.com/Skillmon/ltx_pxpic"
   comments: "pixpic's should be tagged as figures with Alt text."
   updated: 2024-08-07
 
@@ -15276,6 +15279,7 @@
   status: partially-compatible
   priority: 9
   comments: "Missing ToUnicode or ActualText for symbols."
+  package-repository: "https://github.com/Skillmon/ltx_xistercian"
   tests: true
   updated: 2024-07-26
 

--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -4895,6 +4895,14 @@
   tests: true
   updated: 2024-08-23
 
+- name: etl
+  type: package
+  status: compatible
+  priority: 9
+  tests: false
+  package-repository: "https://github.com/Skillmon/ltx_etl"
+  updated: 2026-06-30
+
 - name: etoc
   type: package
   status: currently-incompatible
@@ -5012,6 +5020,51 @@
   issues: [1128]
   tests: true
   updated: 2025-12-15
+
+- name: expkv
+  ctan-pkg: expkv-bundle
+  type: package
+  status: compatible
+  priority: 9
+  tests: false
+  package-repository: "https://gitlab.com/islandoftex/texmf/expkv-bundle"
+  updated: 2026-06-30
+
+- name: expkv-cs
+  ctan-pkg: expkv-bundle
+  type: package
+  status: compatible
+  priority: 9
+  tests: false
+  package-repository: "https://gitlab.com/islandoftex/texmf/expkv-bundle"
+  updated: 2026-06-30
+
+- name: expkv-def
+  ctan-pkg: expkv-bundle
+  type: package
+  status: compatible
+  priority: 9
+  tests: false
+  package-repository: "https://gitlab.com/islandoftex/texmf/expkv-bundle"
+  updated: 2026-06-30
+
+- name: expkv-opt
+  ctan-pkg: expkv-bundle
+  type: package
+  status: compatible
+  priority: 9
+  tests: false
+  package-repository: "https://gitlab.com/islandoftex/texmf/expkv-bundle"
+  updated: 2026-06-30
+
+- name: expkv-pop
+  ctan-pkg: expkv-bundle
+  type: package
+  status: compatible
+  priority: 9
+  tests: false
+  package-repository: "https://gitlab.com/islandoftex/texmf/expkv-bundle"
+  updated: 2026-06-30
 
 - name: expl3
   type: package
@@ -10818,6 +10871,14 @@
   priority: 3
   tests: false
   updated: 2024-08-02
+
+- name: pgfmath-xfp
+  type: package
+  status: compatible
+  priority: 9
+  tests: false
+  package-repository: "https://github.com/Skillmon/ltx_pgfmath-xfp"
+  updated: 2026-06-30
 
 - name: pgfmorepages
   type: package

--- a/tagging-status/testfiles-incompatible/grabbox/grabbox-01-BAD.pdftex.struct.xml
+++ b/tagging-status/testfiles-incompatible/grabbox/grabbox-01-BAD.pdftex.struct.xml
@@ -1,0 +1,128 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <Code xmlns="http://iso.org/pdf/ssn"
+      id="ID.005"
+     >
+    <?MarkedContent page="1" ?>\name
+   </Code>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.006"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.007"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+    </text>
+    <Table xmlns="http://iso.org/pdf2/ssn"
+       id="ID.008"
+      >
+     <TR xmlns="http://iso.org/pdf2/ssn"
+        id="ID.009"
+       >
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.010"
+        >
+       <?MarkedContent page="1" ?>Arg1:
+      </TD>
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.011"
+        >
+       <?MarkedContent page="1" ?>Hi,
+      </TD>
+     </TR>
+     <TR xmlns="http://iso.org/pdf2/ssn"
+        id="ID.012"
+       >
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.013"
+        >
+       <?MarkedContent page="1" ?>Arg2:
+      </TD>
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.014"
+        >
+       <?MarkedContent page="1" ?>my
+      </TD>
+     </TR>
+     <TR xmlns="http://iso.org/pdf2/ssn"
+        id="ID.015"
+       >
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.016"
+        >
+       <?MarkedContent page="1" ?>Box:
+      </TD>
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.017"
+        >
+       <?MarkedContent page="1" ?>\nameis
+      </TD>
+     </TR>
+     <TR xmlns="http://iso.org/pdf2/ssn"
+        id="ID.018"
+       >
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.019"
+        >
+       <?MarkedContent page="1" ?>Arg3:
+      </TD>
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.020"
+        >
+       <?MarkedContent page="1" ?>Steve!
+      </TD>
+     </TR>
+    </Table>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.021"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.022"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.023"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Center"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+    </text>
+    <Div xmlns="http://iso.org/pdf2/ssn"
+       id="ID.024"
+      >
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.025"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.026"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Center"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>There once was a very smart but sadly blind duck. When it wasstill a small duckling it was renowned for its good vision. Butsadly as the duck grew older it caught a sickness which causedits eyesight to worsen. It became so bad, that the duck couldn’tread the notes it once took containing much of inline math.Only displayed equations remained legible. That annoyed thesmart duck, as it wasn’t able to do its research any longer. Itcalled for its underduckling and said: “Go, find me the besteye ducktor there is. He shall heal me from my disease!”
+      </text>
+     </text-unit>
+    </Div>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.027"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-incompatible/grabbox/grabbox-01-BAD.struct.xml
+++ b/tagging-status/testfiles-incompatible/grabbox/grabbox-01-BAD.struct.xml
@@ -1,0 +1,122 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <Code xmlns="http://iso.org/pdf/ssn"
+      id="ID.006"
+     >
+    <?MarkedContent page="1" ?>\name
+   </Code>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.007"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.008"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+    </text>
+    <Table xmlns="http://iso.org/pdf2/ssn"
+       id="ID.009"
+      >
+     <TR xmlns="http://iso.org/pdf2/ssn"
+        id="ID.010"
+       >
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.011"
+        >
+       <?MarkedContent page="1" ?>Arg1:
+      </TD>
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.012"
+        >
+       <?MarkedContent page="1" ?>Hi,
+      </TD>
+     </TR>
+     <TR xmlns="http://iso.org/pdf2/ssn"
+        id="ID.013"
+       >
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.014"
+        >
+       <?MarkedContent page="1" ?>Arg2:
+      </TD>
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.015"
+        >
+       <?MarkedContent page="1" ?>my
+      </TD>
+     </TR>
+     <TR xmlns="http://iso.org/pdf2/ssn"
+        id="ID.016"
+       >
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.017"
+        >
+       <?MarkedContent page="1" ?>Box:
+      </TD>
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.018"
+        >
+      </TD>
+     </TR>
+     <TR xmlns="http://iso.org/pdf2/ssn"
+        id="ID.019"
+       >
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.020"
+        >
+       <?MarkedContent page="1" ?>Arg3:
+      </TD>
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.021"
+        >
+       <?MarkedContent page="1" ?>Steve!
+      </TD>
+     </TR>
+    </Table>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.022"
+       rolemaps-to="P"
+      >
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.023"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.024"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Center"
+       rolemaps-to="P"
+      >
+    </text>
+    <Div xmlns="http://iso.org/pdf2/ssn"
+       id="ID.025"
+      >
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.026"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.027"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Center"
+         rolemaps-to="P"
+        >
+      </text>
+     </text-unit>
+    </Div>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.028"
+       rolemaps-to="P"
+      >
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-incompatible/grabbox/grabbox-01-BAD.tex
+++ b/tagging-status/testfiles-incompatible/grabbox/grabbox-01-BAD.tex
@@ -1,0 +1,56 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on,
+  }
+\documentclass{article}
+\usepackage{grabbox}
+\usepackage{duckuments}
+
+\newsavebox\ourbox
+\newcommand\examplecmd[2]
+{%
+\begingroup
+\grabbox\ourbox[\itshape]\hbox[ \sffamily is]{\examplecmdOut{#1}{#2}}
+}
+\newcommand\examplecmdOut[3]
+{%
+\begin{tabular}[t]{@{}ll@{}}
+Arg1: & #1\\
+Arg2: & #2\\
+Box: & \unhbox\ourbox\\
+Arg3: & #3
+\end{tabular}%
+\endgroup
+}
+
+\newsavebox\RectangleBox
+\newcommand\Rectangle[1][4]
+{%
+\begingroup
+\grabbox\RectangleBox\hbox
+{%
+% Since we don’t want to read more arguments after the box,
+% we don’t need a second macro and can put the output routine
+% here.
+\begin{minipage}{\dimexpr\wd\RectangleBox/#1\relax}
+\parfillskip0pt
+\unhbox\RectangleBox
+\end{minipage}%
+\endgroup
+}%
+}
+
+\title{grabbox tagging test}
+
+\begin{document}
+
+\examplecmd{Hi,}{my}{\verb|\name|}{Steve!}
+
+\begin{center}
+\Rectangle[9]{\blindduck}
+\end{center}
+
+\end{document}

--- a/tagging-status/testfiles-incompatible/hypgotoe/hypgotoe-01-BAD.pdftex.struct.xml
+++ b/tagging-status/testfiles-incompatible/hypgotoe/hypgotoe-01-BAD.pdftex.struct.xml
@@ -1,0 +1,1 @@
+<run-error code="1" />

--- a/tagging-status/testfiles-incompatible/hypgotoe/hypgotoe-01-BAD.struct.xml
+++ b/tagging-status/testfiles-incompatible/hypgotoe/hypgotoe-01-BAD.struct.xml
@@ -1,0 +1,1 @@
+<run-error code="1" />

--- a/tagging-status/testfiles-incompatible/hypgotoe/hypgotoe-01-BAD.tex
+++ b/tagging-status/testfiles-incompatible/hypgotoe/hypgotoe-01-BAD.tex
@@ -1,0 +1,65 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on,
+  }
+\begin{filecontents}{hypgotoe-child.tex}
+\NeedsTeXFormat{LaTeX2e}
+\documentclass{article}
+\usepackage{hypgotoe}[2019/12/29]
+\begin{document}
+\section{This is the child document.}
+\href{gotoe:%
+  dest={page.1},parent%
+}{Go to first page of main document}\\
+\href{gotoe:%
+  dest={page.2},parent%
+}{Go to second page of main document}
+\newpage
+\section{This is the second page of the child document.}
+\href{gotoe:%
+  dest={page.1},parent%
+}{Go to first page of main document}\\
+\href{gotoe:%
+  dest={page.2},parent%
+}{Go to second page of main document}
+
+\hypertarget{foobar}{}
+Anchor foobar is here.
+\end{document}
+\end{filecontents}
+\documentclass{article}
+\usepackage{hypgotoe}[2019/12/29]
+\usepackage{embedfile}
+\IfFileExists{hypgotoe-child.pdf}{%
+  \embedfile{hypgotoe-child.pdf}%
+}{%
+  \typeout{}%
+  \typeout{--> Run hypgotoe-child.tex through pdflatex}%
+  \typeout{}%
+}
+\begin{document}
+\section{First page of main document}
+\href{gotoe:%
+  dest=page.1,embedded=hypgotoe-child.pdf%
+}{Go to first page of child document}\\
+\href{gotoe:%
+  dest=page.2,embedded=hypgotoe-child.pdf%
+}{Go to second page of child document}\\
+\href{gotoe:%
+  dest=foobar,embedded=hypgotoe-child.pdf%
+}{Go to foobar in child document}
+\newpage
+\section{Second page of main document}
+\href{gotoe:%
+  dest=section.1,embedded=hypgotoe-child.pdf%
+}{Go to first section of child document}\\
+\href{gotoe:%
+  dest=section.2,embedded=hypgotoe-child.pdf%
+}{Go to second section of child document}\\
+\href{gotoe:%
+  dest=foobar,embedded=hypgotoe-child.pdf%
+}{Go to foobar in child document}
+\end{document}

--- a/tagging-status/testfiles-partial-mathml/isotope/isotope-01-BAD.pdftex.struct.xml
+++ b/tagging-status/testfiles-partial-mathml/isotope/isotope-01-BAD.pdftex.struct.xml
@@ -1,0 +1,76 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.005"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.006"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Ra
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.007"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.008"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>228Ra
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.009"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.010"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>22888Ra
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.011"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.012"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.013"
+        title="math"
+        af="mathml-1.xml tag-AFfile1.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-1.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mrow> <msubsup> <mrow/> <mtext> <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="false" scriptlevel="1"> <mi>𝑍</mi> </mstyle> </math> </mtext> <mtext> <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="false" scriptlevel="1"> <mi>𝐴</mi> </mstyle> </math> </mtext> </msubsup> <mi mathvariant="normal">X</mi> </mrow> <mo lspace="0.278em" rspace="0.278em" stretchy="false">→</mo> <mrow> <msubsup> <mrow/> <mtext> <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="false" scriptlevel="1"> <mi>𝑍</mi> <mo lspace="0" rspace="0">−</mo> <mn>2</mn> </mstyle> </math> </mtext> <mtext> <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="false" scriptlevel="1"> <mi>𝐴</mi> <mo lspace="0" rspace="0">−</mo> <mn>4</mn> </mstyle> </math> </mtext> </msubsup> <mi mathvariant="normal">Y</mi> </mrow> <mo lspace="0" rspace="0">+</mo> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile1.tex" xmlns="">
+       $\isotope [A][Z]{X}\to \isotope [A-4][Z-2]{Y}+$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>AZX→A−4Z−2Y+
+     </Formula>
+     <?MarkedContent page="1" ?>
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-partial-mathml/isotope/isotope-01-BAD.struct.xml
+++ b/tagging-status/testfiles-partial-mathml/isotope/isotope-01-BAD.struct.xml
@@ -1,0 +1,74 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.006"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.007"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Ra
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.008"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.009"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>228Ra
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.010"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.011"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>22888Ra
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.012"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.013"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.014"
+        title="math"
+        af="mathml-1.xml tag-AFfile1.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-1.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mrow> <msubsup> <mrow/> <mtext> <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="false" scriptlevel="1"> <mi>𝑍</mi> </mstyle> </math> </mtext> <mtext> <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="false" scriptlevel="1"> <mi>𝐴</mi> </mstyle> </math> </mtext> </msubsup> <mi mathvariant="normal">X</mi> </mrow> <mo lspace="0.278em" rspace="0.278em" stretchy="false">→</mo> <mrow> <msubsup> <mrow/> <mtext> <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="false" scriptlevel="1"> <mi>𝑍</mi> <mo lspace="0" rspace="0">−</mo> <mn>2</mn> </mstyle> </math> </mtext> <mtext> <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="false" scriptlevel="1"> <mi>𝐴</mi> <mo lspace="0" rspace="0">−</mo> <mn>4</mn> </mstyle> </math> </mtext> </msubsup> <mi mathvariant="normal">Y</mi> </mrow> <mo lspace="0" rspace="0">+</mo> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile1.tex" xmlns="">
+       $\isotope [A][Z]{X}\to \isotope [A-4][Z-2]{Y}+$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>𝐴𝑍X→𝐴−4𝑍−2Y+
+     </Formula>
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-partial-mathml/isotope/isotope-01-BAD.tex
+++ b/tagging-status/testfiles-partial-mathml/isotope/isotope-01-BAD.tex
@@ -1,0 +1,24 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on,
+  }
+\documentclass{article}
+\ifdefined\Uchar
+  \usepackage{unicode-math}
+\fi
+\usepackage{isotope}
+
+\begin{document}
+
+\isotope{Ra}
+
+\isotope[228]{Ra}
+
+\isotope[228][88]{Ra}
+
+$\isotope[A][Z]{X}\to\isotope[A-4][Z-2]{Y}+$
+
+\end{document}


### PR DESCRIPTION
Lists grabbox and hypgotoe as incompatible with tests.

Lists isotope as partially compatible with a test.

Lists etl, the expkv bundle, and pgfmath-xfp as compatible without tests.