### PR TITLE
More status updates

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -12509,12 +12509,13 @@
 
 - name: setouterhbox
   type: package
-  status: unchecked
+  status: partially-compatible
   priority: 9
-  tests: false
-  tasks: needs tests
+  tests: true
+  issues: [1466]
+  comments: "Only works with lualatex when tagging is loaded."
   package-repository: "https://github.com/LaTeX-Package-Repositories/oberdiek"
-  updated: 2024-07-18
+  updated: 2026-06-30
 
 - name: setspace
   type: package
@@ -12535,13 +12536,12 @@
 
 - name: settobox
   type: package
-  status: unchecked
+  status: compatible
   included-in: [ol0.1]
   priority: 9
   tests: false
-  tasks: needs tests
   package-repository: "https://github.com/LaTeX-Package-Repositories/oberdiek"
-  updated: 2024-07-18
+  updated: 2026-06-30
 
 - name: sfmath
   type: package
@@ -13167,7 +13167,7 @@
   status: currently-incompatible
   included-in: [tlc3, arxiv5, ol10]
   priority: 2
-  comments: Issue when hyperref and both listoffigures are used.
+  comments: Issue when both hyperref and listoffigures are used.
   issues: [85]
   tests: false
   tasks: needs tests
@@ -14108,12 +14108,11 @@
 
 - name: titlepic
   type: package
-  status: unchecked
+  status: compatible
   included-in: [ol0.02]
   priority: 9
-  tests: false
-  tasks: needs tests
-  updated: 2026-01-23
+  tests: true
+  updated: 2026-06-30
 
 - name: titleps
   type: package
@@ -15729,11 +15728,10 @@
   ctan-pkg: zref
   type: package
   package-repository: "https://github.com/LaTeX-Package-Repositories/zref"
-  status: unchecked
+  status: compatible
   priority: 9
   tests: false
-  tasks: needs tests
-  updated: 2026-02-13
+  updated: 2026-06-30
 
 - name: zref-env
   ctan-pkg: zref
@@ -15747,12 +15745,11 @@
 - name: zref-hyperref
   ctan-pkg: zref
   type: package
-  status: unchecked
+  status: compatible
   package-repository: "https://github.com/LaTeX-Package-Repositories/zref"
   priority: 9
   tests: false
-  tasks: needs tests
-  updated: 2026-02-13
+  updated: 2026-06-30
 
 - name: zref-lastpage
   ctan-pkg: zref

--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -5359,6 +5359,13 @@
   tests: true
   updated: 2024-08-07
 
+- name: filedate
+  type: package
+  status: compatible
+  priority: 9
+  tests: false
+  updated: 2026-06-30
+
 - name: filehook
   type: package
   status: compatible
@@ -5914,6 +5921,7 @@
 
 - name: fp
   type: package
+  subpackages: [defpattern,fp-addons,fp-basic,fp-eqn,fp-eval,fp-exp,fp-pas,fp-random,fp-snap,fp-trigo,fp-upn]
   status: compatible
   included-in: [arxiv01, ol0.1]
   priority: 6
@@ -10034,11 +10042,10 @@
 
 - name: numerica-plus
   type: package
-  status: unchecked
+  status: compatible
   priority: 9
-  tests: false
-  tasks: needs tests
-  updated: 2024-07-18
+  tests: true
+  updated: 2026-06-30
 
 - name: numerica-tables
   type: package
@@ -10210,12 +10217,11 @@
 
 - name: optidef
   type: package
-  status: unchecked
+  status: compatible
   included-in: [ol0.1]
   priority: 9
-  tests: false
-  tasks: needs tests
-  updated: 2026-01-23
+  tests: true
+  updated: 2026-06-30
 
 - name: optional
   type: package
@@ -10551,21 +10557,20 @@
 
 - name: pb-diagram
   type: package
-  status: unchecked
+  status: currently-incompatible
   included-in: [ol0.02]
   priority: 9
-  tests: false
-  tasks: needs tests
-  updated: 2026-01-23
+  tests: true
+  issues: [1465]
+  updated: 2026-06-30
 
 - name: pbalance
   type: package
-  status: unchecked
+  status: compatible
   included-in: [ol0.02]
   priority: 9
-  tests: false
-  tasks: needs tests
-  updated: 2024-07-18
+  tests: true
+  updated: 2026-06-30
 
 - name: pbox
   type: package
@@ -10588,13 +10593,12 @@
 
 - name: pdfcol
   type: package
-  status: unchecked
+  status: compatible
   package-repository: "https://github.com/LaTeX-Package-Repositories/pdfcol"
   included-in: [arxiv01]
   priority: 6
   tests: false
-  tasks: needs tests
-  updated: 2024-07-18
+  updated: 2026-06-30
 
 - name: pdfcolfoot
   type: package
@@ -10701,12 +10705,11 @@
 
 - name: pdfsync
   type: package
-  status: unchecked
+  status: compatible
   included-in: [ol0.02]
   priority: 9
   tests: false
-  tasks: needs tests
-  updated: 2026-01-23
+  updated: 2026-06-30
 
 - name: pdftexcmds
   type: package
@@ -14920,12 +14923,11 @@
 
 - name: versions
   type: package
-  status: unchecked
+  status: compatible
   included-in: [ol0.02]
   priority: 9
-  tests: false
-  tasks: needs tests
-  updated: 2026-01-23
+  tests: true
+  updated: 2026-06-30
 
 - name: versonotes
   type: package
@@ -15881,6 +15883,13 @@
   tests: false
   tasks: needs tests
   updated: 2026-02-13
+
+- name: zwgetfdate
+  type: package
+  status: compatible
+  priority: 9
+  tests: false
+  updated: 2026-06-30
 
 - name: zxjafbfont
   type: package

--- a/tagging-status/testfiles-compatible-mathml/numerica-plus/numerica-plus-01.pdftex.struct.xml
+++ b/tagging-status/testfiles-compatible-mathml/numerica-plus/numerica-plus-01.pdftex.struct.xml
@@ -1,0 +1,91 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.005"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.006"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>0.356899, 5 iterations.
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.007"
+      rolemaps-to="Part"
+     >
+    <Formula xmlns="http://iso.org/pdf2/ssn"
+       id="ID.008"
+       title="equation*"
+       af="mathml-1.xml tag-AFfile1.tex"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:Placement="Block"
+      >
+      <AssociatedFile name="mathml-1.xml" xmlns="">
+      <math display="block" xmlns="http://www.w3.org/1998/Math/MathML"> <mspace width="4.981pt"/> <mtable> <mtr> <mtd columnalign="right"> <msup> <mi>𝑐</mi> <mrow> <mo lspace="0" rspace="0">−</mo> <mn>1</mn> </mrow> </msup> <msqrt> <mrow> <msubsup> <mi>𝑟</mi> <mn>1</mn> <mn>2</mn> </msubsup> <mo lspace="0.222em" rspace="0.222em">+</mo> <msubsup> <mi>𝑟</mi> <mn>3</mn> <mn>2</mn> </msubsup> <mo lspace="0.222em" rspace="0.222em">−</mo> <mn>2</mn> <msub> <mi>𝑟</mi> <mn>1</mn> </msub> <msub> <mi>𝑟</mi> <mn>3</mn> </msub> <mspace width="0.167em"/> <mi mathvariant="normal"> cos </mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <msub> <mi>𝜃</mi> <mn>3</mn> </msub> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝜔</mi> <mi>𝑡</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mrow> </msqrt> </mtd> <mtd columnalign="left"> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>0</mn> <mo lspace="0" rspace="0">.</mo> <mn> 382355 </mn> </mtd> </mtr> <mtr> <mtd columnalign="left"> <mo lspace="0" rspace="0.278em" stretchy="false">↪</mo> <mn>0</mn> <mo lspace="0" rspace="0">.</mo> <mn> 357756 </mn> </mtd> </mtr> <mtr> <mtd columnalign="left"> <mo lspace="0" rspace="0.278em" stretchy="false">↪</mo> <mn>0</mn> <mo lspace="0" rspace="0">.</mo> <mn> 356928 </mn> </mtd> </mtr> <mtr> <mtd columnalign="left"> <mo lspace="0" rspace="0.278em" stretchy="false">↪</mo> <mn>0</mn> <mo lspace="0" rspace="0">.</mo> <mn> 3569 </mn> </mtd> </mtr> <mtr> <mtd columnalign="left"> <mo lspace="0" rspace="0.278em" stretchy="false">↪</mo> <mn>0</mn> <mo lspace="0" rspace="0">.</mo> <mn> 356899 </mn> </mtd> </mtr> <mtr> <mtd columnalign="left"> <mo lspace="0" rspace="0.278em" stretchy="false">↪</mo> <mn>0</mn> <mo lspace="0" rspace="0">.</mo> <mn> 356899 </mn> </mtd> </mtr> <mtr> <mtd columnalign="left"> <mo lspace="0" rspace="0.278em" stretchy="false">↪</mo> <mn>0</mn> <mo lspace="0" rspace="0">.</mo> <mn> 356899 </mn> </mtd> </mtr> </mtable> <mspace width="4.981pt"/> </math>
+      </AssociatedFile>
+      <AssociatedFile name="tag-AFfile1.tex" xmlns="">
+      \begin {equation*}\begin {array}{r@{}l}c^{-1}\sqrt {r_1^2+r_3^2-2r_1 r_3 \cos (\theta _3+\omega t)}&amp;{}=0.382355\\&amp;\hookrightarrow 0.357756\\&amp;\hookrightarrow 0.356928\\&amp;\hookrightarrow 0.3569\\&amp;\hookrightarrow 0.356899\\&amp;\hookrightarrow 0.356899\\&amp;\hookrightarrow 0.356899\end {array}\end {equation*}
+      </AssociatedFile>
+     <?MarkedContent page="1" ?>c−1√︁r21+r23− 2r1r3cos(θ3+ωt) = 0.382355↪→ 0.357756↪→ 0.356928↪→ 0.3569↪→ 0.356899↪→ 0.356899↪→ 0.356899
+    </Formula>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.009"
+      rolemaps-to="Part"
+     >
+    <Formula xmlns="http://iso.org/pdf2/ssn"
+       id="ID.010"
+       title="multline*"
+       af="mathml-2.xml tag-AFfile2.tex"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:Placement="Block"
+      >
+      <AssociatedFile name="mathml-2.xml" xmlns="">
+      <math display="block" xmlns="http://www.w3.org/1998/Math/MathML"> <mtable class="multline" displaystyle="true" intent=":system-of-equations" width="100%"> <mtr columnalign="left"> <mtd> <mspace width="9.963pt"/> <msub> <mi>𝑓</mi> <mrow> <mi>𝑛</mi> <mo lspace="0" rspace="0">+</mo> <mn>1</mn> </mrow> </msub> <mo lspace="0.278em" rspace="0.278em">=</mo> <msup> <mi>𝑐</mi> <mrow> <mo lspace="0" rspace="0">−</mo> <mn>1</mn> </mrow> </msup> <msqrt> <mrow> <msubsup> <mi>𝑟</mi> <mn>1</mn> <mn>2</mn> </msubsup> <mo lspace="0.222em" rspace="0.222em">+</mo> <msubsup> <mi>𝑟</mi> <mn>3</mn> <mn>2</mn> </msubsup> <mo lspace="0.222em" rspace="0.222em">−</mo> <mn>2</mn> <msub> <mi>𝑟</mi> <mn>1</mn> </msub> <msub> <mi>𝑟</mi> <mn>3</mn> </msub> <mspace width="0.167em"/> <mi mathvariant="normal"> cos </mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <msub> <mi>𝜃</mi> <mn>3</mn> </msub> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝜔</mi> <msub> <mi>𝑓</mi> <mi>𝑛</mi> </msub> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mrow> </msqrt> <mi mathvariant="normal">,</mi> </mtd> </mtr> <mtr> <mtd> <mo lspace="0" rspace="0" stretchy="false">(</mo> <msub> <mi>𝑟</mi> <mn>1</mn> </msub> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn> 10 </mn> <mo lspace="0" rspace="0.167em">,</mo> <msub> <mi>𝑟</mi> <mn>3</mn> </msub> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn> 20 </mn> <mo lspace="0" rspace="0.167em">,</mo> <msub> <mi>𝜃</mi> <mn>3</mn> </msub> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>0</mn> <mo lspace="0" rspace="0">.</mo> <mn>2</mn> <mo lspace="0" rspace="0.167em">,</mo> <msub> <mi>𝑓</mi> <mn>0</mn> </msub> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>1</mn> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> </mtr> <mtr columnalign="right"> <mtd> <mspace width="1.661pt"/> <mo lspace="0.278em" rspace="0.278em" stretchy="false">→</mo> <mspace width="1.661pt"/> <mn>0</mn> <mo lspace="0" rspace="0">.</mo> <mn> 356928 </mn> <mo lspace="0" rspace="0.167em">,</mo> <mspace width="3.318pt"/> <mn>0</mn> <mo lspace="0" rspace="0">.</mo> <mn> 3569 </mn> <mo lspace="0" rspace="0.167em">,</mo> <mspace width="3.318pt"/> <mn>0</mn> <mo lspace="0" rspace="0">.</mo> <mn> 356899 </mn> <mo lspace="0" rspace="0.167em">,</mo> <mspace width="3.318pt"/> <mn>0</mn> <mo lspace="0" rspace="0">.</mo> <mn> 356899 </mn> <mo lspace="0" rspace="0.167em">,</mo> <mspace width="3.318pt"/> <mn>0</mn> <mo lspace="0" rspace="0">.</mo> <mn> 356899 </mn> <mspace width="9.963pt"/> </mtd> </mtr> </mtable> </math>
+      </AssociatedFile>
+      <AssociatedFile name="tag-AFfile2.tex" xmlns="">
+      \begin {multline*}f_{n+1}=c^{-1}\sqrt {r_1^2+r_3^2-2r_1 r_3 \cos (\theta _3+\omega f_{n})}{,}\\(r_1=10,r_3=20,\theta _3=0.2,f_{0}=1)\\\protect \protect \leavevmode@ifvmode \kern +.1667em\relax \to \protect \protect \leavevmode@ifvmode \kern +.1667em\relax 0.356928\c__nmc_vv_delim_tl \ 0.3569\c__nmc_vv_delim_tl \ 0.356899\c__nmc_vv_delim_tl \ 0.356899\c__nmc_vv_delim_tl \ 0.356899\end {multline*}
+      </AssociatedFile>
+     <?MarkedContent page="1" ?>fn+1=c−1√︂r21+r23− 2r1r3cos(θ3+ωfn),(r1= 10,r3= 20,θ3= 0.2,f0= 1)→ 0.356928, 0.3569, 0.356899, 0.356899, 0.356899
+    </Formula>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.011"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.012"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>0.356898, 1+20 steps.
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.013"
+      rolemaps-to="Part"
+     >
+    <Formula xmlns="http://iso.org/pdf2/ssn"
+       id="ID.014"
+       title="multline*"
+       af="tag-AFfile3.tex"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:Placement="Block"
+      >
+      <AssociatedFile name="tag-AFfile3.tex" xmlns="">
+      \begin {multline*}2\times \iter [var=t,+=1]{ c^{-1}\sqrt {a^2+r^2-2ar \cos (\theta -\omega t)} } + \iter [var=t,+=1]{ c^{-1}\sqrt {2r^2-2r^2 \cos (2\theta +\omega t)} } - 2\times \iter [var=t,+=1]{ c^{-1}\sqrt {a^2+r^2-2ar \cos (\theta +\omega t)} } - \iter [var=t,+=1]{ c^{-1}\sqrt {2r^2-2r^2 \cos (2\theta -\omega t)} }=0,\\(a=10,r=20,\theta =0.1,t=1)\protect \protect \leavevmode@ifvmode \kern +.1667em\relax \to \protect \protect \leavevmode@ifvmode \kern +.1667em\relax \theta =1.0358.\end {multline*}
+      </AssociatedFile>
+     <?MarkedContent page="1" ?>2× 0.5378 + 1.2213− 2× 0.6144− 1.068 = 0,(a = 10,r = 20,θ = 0.1,t = 1)→θ = 1.0358.
+    </Formula>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-compatible-mathml/numerica-plus/numerica-plus-01.struct.xml
+++ b/tagging-status/testfiles-compatible-mathml/numerica-plus/numerica-plus-01.struct.xml
@@ -1,0 +1,97 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.006"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.007"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>0.356899,  5 iterations.
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.008"
+      rolemaps-to="Part"
+     >
+    <Formula xmlns="http://iso.org/pdf2/ssn"
+       id="ID.009"
+       title="equation*"
+       af="mathml-1.xml tag-AFfile1.tex"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:Placement="Block"
+      >
+      <AssociatedFile name="mathml-1.xml" xmlns="">
+      <math display="block" xmlns="http://www.w3.org/1998/Math/MathML"> <mspace width="4.981pt"/> <mtable> <mtr> <mtd columnalign="right"> <msup> <mi>𝑐</mi> <mrow> <mo lspace="0" rspace="0">−</mo> <mn>1</mn> </mrow> </msup> <msqrt> <mrow> <msubsup> <mi>𝑟</mi> <mn>1</mn> <mn>2</mn> </msubsup> <mo lspace="0.222em" rspace="0.222em">+</mo> <msubsup> <mi>𝑟</mi> <mn>3</mn> <mn>2</mn> </msubsup> <mo lspace="0.222em" rspace="0.222em">−</mo> <mn>2</mn> <msub> <mi>𝑟</mi> <mn>1</mn> </msub> <msub> <mi>𝑟</mi> <mn>3</mn> </msub> <mspace width="0.167em"/> <mi mathvariant="normal"> cos </mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <msub> <mi>𝜃</mi> <mn>3</mn> </msub> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝜔</mi> <mi>𝑡</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mrow> </msqrt> </mtd> <mtd columnalign="left"> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>0</mn> <mo lspace="0" rspace="0">.</mo> <mn> 382355 </mn> </mtd> </mtr> <mtr> <mtd columnalign="left"> <mo lspace="0" rspace="0.278em" stretchy="false">↪</mo> <mn>0</mn> <mo lspace="0" rspace="0">.</mo> <mn> 357756 </mn> </mtd> </mtr> <mtr> <mtd columnalign="left"> <mo lspace="0" rspace="0.278em" stretchy="false">↪</mo> <mn>0</mn> <mo lspace="0" rspace="0">.</mo> <mn> 356928 </mn> </mtd> </mtr> <mtr> <mtd columnalign="left"> <mo lspace="0" rspace="0.278em" stretchy="false">↪</mo> <mn>0</mn> <mo lspace="0" rspace="0">.</mo> <mn> 3569 </mn> </mtd> </mtr> <mtr> <mtd columnalign="left"> <mo lspace="0" rspace="0.278em" stretchy="false">↪</mo> <mn>0</mn> <mo lspace="0" rspace="0">.</mo> <mn> 356899 </mn> </mtd> </mtr> <mtr> <mtd columnalign="left"> <mo lspace="0" rspace="0.278em" stretchy="false">↪</mo> <mn>0</mn> <mo lspace="0" rspace="0">.</mo> <mn> 356899 </mn> </mtd> </mtr> <mtr> <mtd columnalign="left"> <mo lspace="0" rspace="0.278em" stretchy="false">↪</mo> <mn>0</mn> <mo lspace="0" rspace="0">.</mo> <mn> 356899 </mn> </mtd> </mtr> </mtable> <mspace width="4.981pt"/> </math>
+      </AssociatedFile>
+      <AssociatedFile name="tag-AFfile1.tex" xmlns="">
+      \begin {equation*}\begin {array}{r@{}l}c^{-1}\sqrt {r_1^2+r_3^2-2r_1 r_3 \cos (\theta _3+\omega t)}&amp;{}=0.382355\\&amp;\hookrightarrow 0.357756\\&amp;\hookrightarrow 0.356928\\&amp;\hookrightarrow 0.3569\\&amp;\hookrightarrow 0.356899\\&amp;\hookrightarrow 0.356899\\&amp;\hookrightarrow 0.356899\end {array}\end {equation*}
+      </AssociatedFile>
+     <?MarkedContent page="1" ?>𝑐−1√𝑟21+𝑟23−2𝑟1𝑟3cos(𝜃3+𝜔𝑡)=0.382355↪0.357756↪0.356928↪0.3569↪0.356899↪0.356899↪0.356899
+    </Formula>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.010"
+      rolemaps-to="Part"
+     >
+    <Formula xmlns="http://iso.org/pdf2/ssn"
+       id="ID.011"
+       title="multline*"
+       af="mathml-2.xml tag-AFfile2.tex"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:Placement="Block"
+      >
+      <AssociatedFile name="mathml-2.xml" xmlns="">
+      <math display="block" xmlns="http://www.w3.org/1998/Math/MathML"> <mtable class="multline" displaystyle="true" intent=":system-of-equations" width="100%"> <mtr columnalign="left"> <mtd> <mspace width="9.963pt"/> <msub> <mi>𝑓</mi> <mrow> <mi>𝑛</mi> <mo lspace="0" rspace="0">+</mo> <mn>1</mn> </mrow> </msub> <mo lspace="0.278em" rspace="0.278em">=</mo> <msup> <mi>𝑐</mi> <mrow> <mo lspace="0" rspace="0">−</mo> <mn>1</mn> </mrow> </msup> <msqrt> <mrow> <msubsup> <mi>𝑟</mi> <mn>1</mn> <mn>2</mn> </msubsup> <mo lspace="0.222em" rspace="0.222em">+</mo> <msubsup> <mi>𝑟</mi> <mn>3</mn> <mn>2</mn> </msubsup> <mo lspace="0.222em" rspace="0.222em">−</mo> <mn>2</mn> <msub> <mi>𝑟</mi> <mn>1</mn> </msub> <msub> <mi>𝑟</mi> <mn>3</mn> </msub> <mspace width="0.167em"/> <mi mathvariant="normal"> cos </mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <msub> <mi>𝜃</mi> <mn>3</mn> </msub> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝜔</mi> <msub> <mi>𝑓</mi> <mi>𝑛</mi> </msub> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mrow> </msqrt> <mi mathvariant="normal">,</mi> </mtd> </mtr> <mtr> <mtd> <mo lspace="0" rspace="0" stretchy="false">(</mo> <msub> <mi>𝑟</mi> <mn>1</mn> </msub> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn> 10 </mn> <mo lspace="0" rspace="0.167em">,</mo> <msub> <mi>𝑟</mi> <mn>3</mn> </msub> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn> 20 </mn> <mo lspace="0" rspace="0.167em">,</mo> <msub> <mi>𝜃</mi> <mn>3</mn> </msub> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>0</mn> <mo lspace="0" rspace="0">.</mo> <mn>2</mn> <mo lspace="0" rspace="0.167em">,</mo> <msub> <mi>𝑓</mi> <mn>0</mn> </msub> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>1</mn> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> </mtr> <mtr columnalign="right"> <mtd> <mspace width="1.661pt"/> <mo lspace="0.278em" rspace="0.278em" stretchy="false">→</mo> <mspace width="1.661pt"/> <mn>0</mn> <mo lspace="0" rspace="0">.</mo> <mn> 356928 </mn> <mo lspace="0" rspace="0.167em">,</mo> <mspace width="3.318pt"/> <mn>0</mn> <mo lspace="0" rspace="0">.</mo> <mn> 3569 </mn> <mo lspace="0" rspace="0.167em">,</mo> <mspace width="3.318pt"/> <mn>0</mn> <mo lspace="0" rspace="0">.</mo> <mn> 356899 </mn> <mo lspace="0" rspace="0.167em">,</mo> <mspace width="3.318pt"/> <mn>0</mn> <mo lspace="0" rspace="0">.</mo> <mn> 356899 </mn> <mo lspace="0" rspace="0.167em">,</mo> <mspace width="3.318pt"/> <mn>0</mn> <mo lspace="0" rspace="0">.</mo> <mn> 356899 </mn> <mspace width="9.963pt"/> </mtd> </mtr> </mtable> </math>
+      </AssociatedFile>
+      <AssociatedFile name="tag-AFfile2.tex" xmlns="">
+      \begin {multline*}f_{n+1}=c^{-1}\sqrt {r_1^2+r_3^2-2r_1 r_3 \cos (\theta _3+\omega f_{n})}{,}\\(r_1=10,r_3=20,\theta _3=0.2,f_{0}=1)\\\protect \protect \leavevmode@ifvmode \kern +.1667em\relax \to \protect \protect \leavevmode@ifvmode \kern +.1667em\relax 0.356928\c__nmc_vv_delim_tl \ 0.3569\c__nmc_vv_delim_tl \ 0.356899\c__nmc_vv_delim_tl \ 0.356899\c__nmc_vv_delim_tl \ 0.356899\end {multline*}
+      </AssociatedFile>
+     <?MarkedContent page="1" ?>𝑓𝑛+1=𝑐−1√𝑟21+𝑟23−2𝑟1𝑟3cos(𝜃3+𝜔𝑓𝑛),
+     <?MarkedContent page="1" ?>(𝑟1=10,𝑟3=20,𝜃3=0.2,𝑓0=1)
+     <?MarkedContent page="1" ?>→0.356928,0.3569,0.356899,0.356899,0.356899
+    </Formula>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.012"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.013"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>0.356898,  1+20 steps.
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.014"
+      rolemaps-to="Part"
+     >
+    <Formula xmlns="http://iso.org/pdf2/ssn"
+       id="ID.015"
+       title="multline*"
+       af="mathml-3.xml tag-AFfile3.tex"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:Placement="Block"
+      >
+      <AssociatedFile name="mathml-3.xml" xmlns="">
+      <math display="block" xmlns="http://www.w3.org/1998/Math/MathML"> <mtable class="multline" displaystyle="true" intent=":system-of-equations" width="100%"> <mtr columnalign="left"> <mtd> <mspace width="9.963pt"/> <mn>2</mn> <mo lspace="0.222em" rspace="0.222em">×</mo> <mn>0</mn> <mo lspace="0" rspace="0">.</mo> <mn> 5378 </mn> <mo lspace="0.222em" rspace="0.222em">+</mo> <mn>1</mn> <mo lspace="0" rspace="0">.</mo> <mn> 2213 </mn> <mo lspace="0.222em" rspace="0.222em">−</mo> <mn>2</mn> <mo lspace="0.222em" rspace="0.222em">×</mo> <mn>0</mn> <mo lspace="0" rspace="0">.</mo> <mn> 6144 </mn> <mo lspace="0.222em" rspace="0.222em">−</mo> <mn>1</mn> <mo lspace="0" rspace="0">.</mo> <mn> 068 </mn> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>0</mn> <mo lspace="0" rspace="0">,</mo> </mtd> </mtr> <mtr columnalign="right"> <mtd> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑎</mi> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn> 10 </mn> <mo lspace="0" rspace="0.167em">,</mo> <mi>𝑟</mi> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn> 20 </mn> <mo lspace="0" rspace="0.167em">,</mo> <mi>𝜃</mi> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>0</mn> <mo lspace="0" rspace="0">.</mo> <mn>1</mn> <mo lspace="0" rspace="0.167em">,</mo> <mi>𝑡</mi> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>1</mn> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mspace width="1.661pt"/> <mo lspace="0.278em" rspace="0.278em" stretchy="false">→</mo> <mspace width="1.661pt"/> <mi>𝜃</mi> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>1</mn> <mo lspace="0" rspace="0">.</mo> <mn> 0358 </mn> <mo lspace="0" rspace="0">.</mo> <mspace width="9.963pt"/> </mtd> </mtr> </mtable> </math>
+      </AssociatedFile>
+      <AssociatedFile name="tag-AFfile3.tex" xmlns="">
+      \begin {multline*}2\times \iter [var=t,+=1]{ c^{-1}\sqrt {a^2+r^2-2ar \cos (\theta -\omega t)} } + \iter [var=t,+=1]{ c^{-1}\sqrt {2r^2-2r^2 \cos (2\theta +\omega t)} } - 2\times \iter [var=t,+=1]{ c^{-1}\sqrt {a^2+r^2-2ar \cos (\theta +\omega t)} } - \iter [var=t,+=1]{ c^{-1}\sqrt {2r^2-2r^2 \cos (2\theta -\omega t)} }=0,\\(a=10,r=20,\theta =0.1,t=1)\protect \protect \leavevmode@ifvmode \kern +.1667em\relax \to \protect \protect \leavevmode@ifvmode \kern +.1667em\relax \mittheta =1.0358.\end {multline*}
+      </AssociatedFile>
+     <?MarkedContent page="1" ?>2×0.5378+1.2213−2×0.6144−1.068=0,
+     <?MarkedContent page="1" ?>(𝑎=10,𝑟=20,𝜃=0.1,𝑡=1)→𝜃=1.0358.
+    </Formula>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-compatible-mathml/numerica-plus/numerica-plus-01.tex
+++ b/tagging-status/testfiles-compatible-mathml/numerica-plus/numerica-plus-01.tex
@@ -1,0 +1,55 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on,
+  }
+\documentclass{article}
+\ifdefined\Uchar
+  \usepackage{unicode-math}
+\fi
+\usepackage{numerica}
+\usepackage{numerica-plus}
+
+\title{numerica-plus tagging test}
+
+\constants{ c=30,\omega=0.2 }
+
+\begin{document}
+
+\iter*{ c^{-1}\sqrt{r_1^2+r_3^2-2r_1 r_3
+\cos(\theta_3+\omega t)}
+}[ r_1=10,r_3=20,\theta_3=0.2,t=1 ],
+\quad\info{iter}.
+
+\iter[do=7,see=7,vv=]
+{\[ c^{-1}\sqrt{r_1^2+r_3^2-2r_1 r_3
+\cos(\theta_3+\omega t)} \]}
+[ r_1=10,r_3=20,\theta_3=0.2,t=1 ]
+
+\recur[env=multline*,vv={,}\\(vv)\\,
+do=8,see1=0,see2=5]
+{ f_{n+1}=c^{-1}\sqrt{r_1^2+r_3^2-2r_1 r_3
+\cos(\theta_3+\omega f_{n})} }
+[ r_1=10,r_3=20,\theta_3=0.2,f_{0}=1 ]
+
+\solve*{ c^{-1}\sqrt{r_1^2+r_3^2-2r_1 r_3
+\cos(\theta_3+\omega t)} - t }
+[ r_1=10,r_3=20,\theta_3=0.2,t=0 ],
+\quad \nmcInfo{solve}.
+
+\solve[env=multline*,p=.,var=\theta,+=1]
+{% circuit 1231
+2\times\iter[var=t,+=1]{ c^{-1}\sqrt{a^2+r^2-2ar
+\cos(\theta-\omega t)} }
++ \iter[var=t,+=1]{ c^{-1}\sqrt{2r^2-2r^2
+\cos(2\theta+\omega t)} }
+% circuit 1321
+- 2\times\iter[var=t,+=1]{ c^{-1}\sqrt{a^2+r^2-2ar
+\cos(\theta+\omega t)} }
+- \iter[var=t,+=1]{ c^{-1}\sqrt{2r^2-2r^2
+\cos(2\theta-\omega t)} }
+}[ a=10,r=20,\theta=0.1,t=1 ][4]
+
+\end{document}

--- a/tagging-status/testfiles-compatible-mathml/optidef/optidef-01.pdftex.struct.xml
+++ b/tagging-status/testfiles-compatible-mathml/optidef/optidef-01.pdftex.struct.xml
@@ -1,0 +1,377 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.005"
+      rolemaps-to="Part"
+     >
+    <Formula xmlns="http://iso.org/pdf2/ssn"
+       id="ID.006"
+       title="equation"
+       af="mathml-1.xml tag-AFfile1.tex"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:Placement="Block"
+      >
+      <AssociatedFile name="mathml-1.xml" xmlns="">
+      <math display="block" xmlns="http://www.w3.org/1998/Math/MathML"> <mtable displaystyle="true" intent=":system-of-equations"> <mtr> <mtd intent=":equation-label"> <mtext> (1) </mtext> </mtd> <mtd intent=":pause-medium"> <mrow/> <mtable class="alignedat" columnalign="right left right left right left" columnspacing="0 0 0 0" displaystyle="true"> <mtr> <mtd/> <mtd> <mtext> <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <munder> <mi mathvariant="normal"> minimize </mi> <mstyle displaystyle="true" scriptlevel="0"> <mi>𝑤</mi> </mstyle> </munder> </mstyle> </math> </mtext> <mspace width="9.963pt"/> <mi>𝑓</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝑅</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0.222em" rspace="0.222em">+</mo> <mn>6</mn> <mi>𝑥</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd/> <mtd/> <mtd/> <mtd/> </mtr> <mtr> <mtd/> <mtd> <mtext> <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <mrow> <mi mathvariant="normal"> subject </mi> <mspace width="3.318pt"/> <mi mathvariant="normal"> to </mi> </mrow> </mstyle> </math> </mtext> <mspace width="9.963pt"/> </mtd> <mtd> <mi>𝑔</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>0</mn> <mo lspace="0" rspace="0">,</mo> </mtd> <mtd/> <mtd/> </mtr> <mtr> <mtd/> <mtd> <mspace width="9.963pt"/> </mtd> <mtd> <mi>𝑛</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>6</mn> <mo lspace="0" rspace="0">,</mo> </mtd> <mtd/> <mtd/> </mtr> <mtr> <mtd/> <mtd> <mspace width="9.963pt"/> </mtd> <mtd> <mi>𝐿</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝑟</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑥</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mi>𝐾</mi> <mi>𝑤</mi> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝑝</mi> <mo lspace="0" rspace="0">,</mo> </mtd> <mtd/> <mtd/> </mtr> <mtr> <mtd/> <mtd> <mspace width="9.963pt"/> </mtd> <mtd> <mi mathvariant="normal">ℎ</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑥</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>0</mn> <mo lspace="0" rspace="0">.</mo> </mtd> </mtr> </mtable> </mtd> </mtr> </mtable> </math>
+      </AssociatedFile>
+      <AssociatedFile name="tag-AFfile1.tex" xmlns="">
+      \begin {equation}\label {eq:Example1} \begin {alignedat}{5} \bodyobj {w}{f(w)+ R(w+6x)}{minimize}{} \BODY \end {alignedat}\end {equation}
+      </AssociatedFile>
+     <?MarkedContent page="1" ?>minimizewf(w) +R(w + 6x)subject tog(w) = 0,n(w) = 6,L(w) +r(x) =Kw +p,h(x) = 0.
+     <Lbl xmlns="http://iso.org/pdf2/ssn"
+        id="ID.007"
+       >
+      <?MarkedContent page="1" ?>(1)
+     </Lbl>
+     <?MarkedContent page="1" ?>
+    </Formula>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.008"
+      rolemaps-to="Part"
+     >
+    <Formula xmlns="http://iso.org/pdf2/ssn"
+       id="ID.009"
+       title="alignat*"
+       af="mathml-2.xml tag-AFfile2.tex"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:Placement="Block"
+      >
+      <AssociatedFile name="mathml-2.xml" xmlns="">
+      <math display="block" xmlns="http://www.w3.org/1998/Math/MathML"> <mtable class="alignat" columnspacing="0 0 0 0 0 0 0 0 0 0" displaystyle="true" intent=":system-of-equations"> <mtr> <mtd intent=":no-equation-label"></mtd> <mtd intent=":pause-medium"/> <mtd> <mtext> <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <munder> <mi mathvariant="normal"> minimize </mi> <mstyle displaystyle="true" scriptlevel="0"> <mi>𝑤</mi> </mstyle> </munder> </mstyle> </math> </mtext> <mspace width="9.963pt"/> <mi>𝑓</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝑅</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0.222em" rspace="0.222em">+</mo> <mn>6</mn> <mi>𝑥</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> </mtr> <mtr> <mtd intent=":no-equation-label"></mtd> <mtd intent=":pause-medium"/> <mtd> <mtext> <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <mrow> <mi mathvariant="normal"> subject </mi> <mspace width="3.318pt"/> <mi mathvariant="normal"> to </mi> </mrow> </mstyle> </math> </mtext> <mspace width="9.963pt"/> </mtd> <mtd intent=":pause-medium"> <mi>𝑔</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>0</mn> <mo lspace="0" rspace="0">,</mo> </mtd> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> </mtr> <mtr> <mtd intent=":no-equation-label"></mtd> <mtd intent=":pause-medium"/> <mtd> <mspace width="9.963pt"/> </mtd> <mtd intent=":pause-medium"> <mi>𝑛</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>6</mn> <mo lspace="0" rspace="0">,</mo> <mo lspace="0.167em" rspace="0">,</mo> </mtd> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> </mtr> <mtr> <mtd intent=":no-equation-label"></mtd> <mtd intent=":pause-medium"/> <mtd> <mspace width="9.963pt"/> </mtd> <mtd intent=":pause-medium"> <mi>𝐿</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝑟</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑥</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mi>𝐾</mi> <mi>𝑤</mi> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝑝</mi> <mo lspace="0" rspace="0">,</mo> </mtd> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> </mtr> <mtr> <mtd intent=":no-equation-label"></mtd> <mtd intent=":pause-medium"/> <mtd> <mspace width="9.963pt"/> </mtd> <mtd intent=":pause-medium"> <mi mathvariant="normal">ℎ</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑥</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>0</mn> <mo lspace="0" rspace="0">.</mo> </mtd> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> </mtr> </mtable> </math>
+      </AssociatedFile>
+      <AssociatedFile name="tag-AFfile2.tex" xmlns="">
+      \begin {alignat*}{5} \bodyobj {w}{f(w)+ R(w+6x)}{minimize}{} \BODY \end {alignat*}
+      </AssociatedFile>
+     <?MarkedContent page="1" ?>minimizewf(w) +R(w + 6x)subject tog(w) = 0,n(w) = 6,,L(w) +r(x) =Kw +p,h(x) = 0.
+    </Formula>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.010"
+      rolemaps-to="Part"
+     >
+    <Formula xmlns="http://iso.org/pdf2/ssn"
+       id="ID.011"
+       title="alignat"
+       af="mathml-3.xml tag-AFfile3.tex"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:Placement="Block"
+      >
+      <AssociatedFile name="mathml-3.xml" xmlns="">
+      <math display="block" xmlns="http://www.w3.org/1998/Math/MathML"> <mtable class="alignat" columnspacing="0 0 0 0 0 0 0 0 0 0" displaystyle="true" intent=":system-of-equations"> <mtr> <mtd intent=":equation-label"> <mtext> (2a) </mtext> </mtd> <mtd intent=":pause-medium"/> <mtd> <mtext> <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <munder> <mi mathvariant="normal"> minimize </mi> <mstyle displaystyle="true" scriptlevel="0"> <mi>𝑤</mi> </mstyle> </munder> </mstyle> </math> </mtext> <mspace width="9.963pt"/> <mi>𝑓</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝑅</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0.222em" rspace="0.222em">+</mo> <mn>6</mn> <mi>𝑥</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> </mtr> <mtr> <mtd intent=":equation-label"> <mtext> (2b) </mtext> </mtd> <mtd intent=":pause-medium"/> <mtd> <mtext> <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <mrow> <mi mathvariant="normal"> subject </mi> <mspace width="3.318pt"/> <mi mathvariant="normal"> to </mi> </mrow> </mstyle> </math> </mtext> <mspace width="9.963pt"/> </mtd> <mtd intent=":pause-medium"> <mi>𝑔</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>0</mn> <mo lspace="0" rspace="0">,</mo> </mtd> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> </mtr> <mtr> <mtd intent=":equation-label"> <mtext> (2c) </mtext> </mtd> <mtd intent=":pause-medium"/> <mtd> <mspace width="9.963pt"/> </mtd> <mtd intent=":pause-medium"> <mi>𝑛</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>6</mn> <mo lspace="0" rspace="0">,</mo> </mtd> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> </mtr> <mtr> <mtd intent=":equation-label"> <mtext> (2d) </mtext> </mtd> <mtd intent=":pause-medium"/> <mtd> <mspace width="9.963pt"/> </mtd> <mtd intent=":pause-medium"> <mi>𝐿</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝑟</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑥</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mi>𝐾</mi> <mi>𝑤</mi> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝑝</mi> <mo lspace="0" rspace="0">,</mo> </mtd> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> </mtr> <mtr> <mtd intent=":equation-label"> <mtext> (2e) </mtext> </mtd> <mtd intent=":pause-medium"/> <mtd> <mspace width="9.963pt"/> </mtd> <mtd intent=":pause-medium"> <mi mathvariant="normal">ℎ</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑥</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>0</mn> <mo lspace="0" rspace="0">.</mo> </mtd> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> </mtr> </mtable> </math>
+      </AssociatedFile>
+      <AssociatedFile name="tag-AFfile3.tex" xmlns="">
+      \begin {alignat}{5} \bodyobj {w}{f(w)+ R(w+6x) \label {eq:ObjectiveExample1}}{minimize}{} \BODY \end {alignat}
+      </AssociatedFile>
+     <?MarkedContent page="1" ?>minimizewf(w) +R(w + 6x)
+     <Lbl xmlns="http://iso.org/pdf2/ssn"
+        id="ID.012"
+       >
+      <?MarkedContent page="1" ?>(2a)
+     </Lbl>
+     <?MarkedContent page="1" ?>subject tog(w) = 0,
+     <Lbl xmlns="http://iso.org/pdf2/ssn"
+        id="ID.013"
+       >
+      <?MarkedContent page="1" ?>(2b)
+     </Lbl>
+     <?MarkedContent page="1" ?>n(w) = 6,
+     <Lbl xmlns="http://iso.org/pdf2/ssn"
+        id="ID.014"
+       >
+      <?MarkedContent page="1" ?>(2c)
+     </Lbl>
+     <?MarkedContent page="1" ?>L(w) +r(x) =Kw +p,
+     <Lbl xmlns="http://iso.org/pdf2/ssn"
+        id="ID.015"
+       >
+      <?MarkedContent page="1" ?>(2d)
+     </Lbl>
+     <?MarkedContent page="1" ?>h(x) = 0.
+     <Lbl xmlns="http://iso.org/pdf2/ssn"
+        id="ID.016"
+       >
+      <?MarkedContent page="1" ?>(2e)
+     </Lbl>
+     <?MarkedContent page="1" ?>
+    </Formula>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.017"
+      rolemaps-to="Part"
+     >
+    <Formula xmlns="http://iso.org/pdf2/ssn"
+       id="ID.018"
+       title="equation"
+       af="mathml-4.xml tag-AFfile4.tex"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:Placement="Block"
+      >
+      <AssociatedFile name="mathml-4.xml" xmlns="">
+      <math display="block" xmlns="http://www.w3.org/1998/Math/MathML"> <mtable displaystyle="true" intent=":system-of-equations"> <mtr> <mtd intent=":equation-label"> <mtext> (3) </mtext> </mtd> <mtd intent=":pause-medium"> <mrow/> <mtable class="alignedat" columnalign="right left right left right left" columnspacing="0 0 0 0" displaystyle="true"> <mtr> <mtd> <mi>𝐽</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <msup> <mi>𝑤</mi> <mi mathvariant="normal">∗</mi> </msup> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.278em" rspace="0">=</mo> <mspace width="3.318pt"/> </mtd> <mtd> <mtext> <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <munder> <mi mathvariant="normal"> minimize </mi> <mstyle displaystyle="true" scriptlevel="0"> <mi>𝑤</mi> </mstyle> </munder> </mstyle> </math> </mtext> <mspace width="9.963pt"/> <mi>𝑓</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝑅</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0.222em" rspace="0.222em">+</mo> <mn>6</mn> <mi>𝑥</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd/> <mtd/> <mtd/> <mtd/> </mtr> <mtr> <mtd/> <mtd> <mtext> <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <mrow> <mi mathvariant="normal"> subject </mi> <mspace width="3.318pt"/> <mi mathvariant="normal"> to </mi> </mrow> </mstyle> </math> </mtext> <mspace width="9.963pt"/> </mtd> <mtd> <mi>𝑔</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>0</mn> <mo lspace="0" rspace="0">,</mo> </mtd> <mtd/> <mtd/> </mtr> <mtr> <mtd/> <mtd> <mspace width="9.963pt"/> </mtd> <mtd> <mi>𝑛</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>6</mn> <mo lspace="0" rspace="0">,</mo> </mtd> <mtd/> <mtd/> </mtr> <mtr> <mtd/> <mtd> <mspace width="9.963pt"/> </mtd> <mtd> <mi>𝐿</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝑟</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑥</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mi>𝐾</mi> <mi>𝑤</mi> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝑝</mi> <mo lspace="0" rspace="0">,</mo> </mtd> <mtd/> <mtd/> </mtr> <mtr> <mtd/> <mtd> <mspace width="9.963pt"/> </mtd> <mtd> <mi mathvariant="normal">ℎ</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑥</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>0</mn> <mo lspace="0" rspace="0">.</mo> </mtd> </mtr> </mtable> </mtd> </mtr> </mtable> </math>
+      </AssociatedFile>
+      <AssociatedFile name="tag-AFfile4.tex" xmlns="">
+      \begin {equation}\label {eq:Example12} \begin {alignedat}{5} \bodyobj {w}{f(w)+ R(w+6x)}{minimize}{J(w^*)=} \BODY \end {alignedat}\end {equation}
+      </AssociatedFile>
+     <?MarkedContent page="1" ?>J(w∗) = minimizewf(w) +R(w + 6x)subject tog(w) = 0,n(w) = 6,L(w) +r(x) =Kw +p,h(x) = 0.
+     <Lbl xmlns="http://iso.org/pdf2/ssn"
+        id="ID.019"
+       >
+      <?MarkedContent page="1" ?>(3)
+     </Lbl>
+     <?MarkedContent page="1" ?>
+    </Formula>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.020"
+      rolemaps-to="Part"
+     >
+    <Formula xmlns="http://iso.org/pdf2/ssn"
+       id="ID.021"
+       title="equation"
+       af="mathml-5.xml tag-AFfile5.tex"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:Placement="Block"
+      >
+      <AssociatedFile name="mathml-5.xml" xmlns="">
+      <math display="block" xmlns="http://www.w3.org/1998/Math/MathML"> <mtable displaystyle="true" intent=":system-of-equations"> <mtr> <mtd intent=":equation-label"> <mtext> (4) </mtext> </mtd> <mtd intent=":pause-medium"> <mrow/> <mtable class="alignedat" columnalign="right left right left right left" columnspacing="0 0 0 0" displaystyle="true"> <mtr> <mtd/> <mtd> <munder> <mi mathvariant="normal"> min </mi> <mstyle displaystyle="true" scriptlevel="0"> <mi>𝑤</mi> </mstyle> </munder> <mspace width="9.963pt"/> <mi>𝑓</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝑅</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0.222em" rspace="0.222em">+</mo> <mn>6</mn> <mi>𝑥</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd/> <mtd/> <mtd/> <mtd/> </mtr> <mtr> <mtd/> <mtd> <mtext> <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <mtext> <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <mrow> <mspace width="0.996pt"/> <mi mathvariant="normal">s</mi> <mo lspace="0" rspace="0">.</mo> <mi mathvariant="normal">t</mi> <mo lspace="0" rspace="0">.</mo> </mrow> </mstyle> </math> </mtext> </mstyle> </math> </mtext> <mspace width="9.963pt"/> </mtd> <mtd> <mi>𝑔</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>0</mn> <mo lspace="0" rspace="0">,</mo> </mtd> <mtd/> <mtd/> </mtr> <mtr> <mtd/> <mtd> <mspace width="9.963pt"/> </mtd> <mtd> <mi>𝑛</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>6</mn> <mo lspace="0" rspace="0">,</mo> </mtd> <mtd/> <mtd/> </mtr> <mtr> <mtd/> <mtd> <mspace width="9.963pt"/> </mtd> <mtd> <mi>𝐿</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝑟</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑥</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mi>𝐾</mi> <mi>𝑤</mi> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝑝</mi> <mo lspace="0" rspace="0">,</mo> </mtd> <mtd/> <mtd/> </mtr> <mtr> <mtd/> <mtd> <mspace width="9.963pt"/> </mtd> <mtd> <mi mathvariant="normal">ℎ</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑥</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>0</mn> <mo lspace="0" rspace="0">.</mo> </mtd> </mtr> </mtable> </mtd> </mtr> </mtable> </math>
+      </AssociatedFile>
+      <AssociatedFile name="tag-AFfile5.tex" xmlns="">
+      \begin {equation}\label {eq:Example13} \begin {alignedat}{5} \bodyobj {w}{f(w)+ R(w+6x)}{min}{} \BODY \end {alignedat}\end {equation}
+      </AssociatedFile>
+     <?MarkedContent page="1" ?>minwf(w) +R(w + 6x)s.t.g(w) = 0,n(w) = 6,L(w) +r(x) =Kw +p,h(x) = 0.
+     <Lbl xmlns="http://iso.org/pdf2/ssn"
+        id="ID.022"
+       >
+      <?MarkedContent page="1" ?>(4)
+     </Lbl>
+     <?MarkedContent page="1" ?>
+    </Formula>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.023"
+      rolemaps-to="Part"
+     >
+    <Formula xmlns="http://iso.org/pdf2/ssn"
+       id="ID.024"
+       title="equation"
+       af="mathml-6.xml tag-AFfile6.tex"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:Placement="Block"
+      >
+      <AssociatedFile name="mathml-6.xml" xmlns="">
+      <math display="block" xmlns="http://www.w3.org/1998/Math/MathML"> <mtable displaystyle="true" intent=":system-of-equations"> <mtr> <mtd intent=":equation-label"> <mtext> (5) </mtext> </mtd> <mtd intent=":pause-medium"> <mrow/> <mtable class="alignedat" columnalign="right left right left right left" columnspacing="0 0 0 0" displaystyle="true"> <mtr> <mtd/> <mtd> <mtext> <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <munder> <mi mathvariant="normal"> minimize </mi> <mstyle displaystyle="true" scriptlevel="0"> <mi>𝑤</mi> </mstyle> </munder> </mstyle> </math> </mtext> <mspace width="9.963pt"/> <mi>𝑓</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝑅</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0.222em" rspace="0.222em">+</mo> <mn>6</mn> <mi>𝑥</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd/> <mtd/> <mtd/> <mtd/> </mtr> <mtr> <mtd/> <mtd> <mtext> <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <mrow> <mi mathvariant="normal"> subject </mi> <mspace width="3.318pt"/> <mi mathvariant="normal"> to </mi> </mrow> </mstyle> </math> </mtext> </mtd> <mtd/> <mtd/> <mtd/> <mtd/> </mtr> <mtr> <mtd/> <mtd/> <mtd> <mi>𝑔</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>0</mn> <mo lspace="0" rspace="0">,</mo> </mtd> </mtr> <mtr> <mtd/> <mtd/> <mtd> <mi>𝑛</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>6</mn> <mo lspace="0" rspace="0">,</mo> </mtd> </mtr> <mtr> <mtd/> <mtd/> <mtd> <mi>𝐿</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝑟</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑥</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mi>𝐾</mi> <mi>𝑤</mi> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝑝</mi> <mo lspace="0" rspace="0">,</mo> </mtd> </mtr> <mtr> <mtd/> <mtd/> <mtd> <mi mathvariant="normal">ℎ</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑥</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>0</mn> <mo lspace="0" rspace="0">.</mo> </mtd> </mtr> </mtable> </mtd> </mtr> </mtable> </math>
+      </AssociatedFile>
+      <AssociatedFile name="tag-AFfile6.tex" xmlns="">
+      \begin {equation}\label {eq:Example14} \begin {alignedat}{5} \bodyobj {w}{f(w)+ R(w+6x)}{minimize}{} \BODY \end {alignedat}\end {equation}
+      </AssociatedFile>
+     <?MarkedContent page="1" ?>minimizewf(w) +R(w + 6x)subject tog(w) = 0,n(w) = 6,L(w) +r(x) =Kw +p,h(x) = 0.
+     <Lbl xmlns="http://iso.org/pdf2/ssn"
+        id="ID.025"
+       >
+      <?MarkedContent page="1" ?>(5)
+     </Lbl>
+     <?MarkedContent page="1" ?>
+    </Formula>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.026"
+      rolemaps-to="Part"
+     >
+    <Formula xmlns="http://iso.org/pdf2/ssn"
+       id="ID.027"
+       title="equation"
+       af="mathml-7.xml tag-AFfile7.tex"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:Placement="Block"
+      >
+      <AssociatedFile name="mathml-7.xml" xmlns="">
+      <math display="block" xmlns="http://www.w3.org/1998/Math/MathML"> <mtable displaystyle="true" intent=":system-of-equations"> <mtr> <mtd intent=":equation-label"> <mtext> (6) </mtext> </mtd> <mtd intent=":pause-medium"> <mrow/> <mtable class="alignedat" columnalign="right left right left right left" columnspacing="0 0 0 0" displaystyle="true"> <mtr> <mtd/> <mtd> <mtext> <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <munder> <mi mathvariant="normal"> minimize </mi> <mstyle displaystyle="true" scriptlevel="0"> <mi>𝑤</mi> </mstyle> </munder> </mstyle> </math> </mtext> <mspace width="9.963pt"/> <mi>𝑓</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝑅</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0.222em" rspace="0.222em">+</mo> <mn>6</mn> <mi>𝑥</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd/> <mtd/> <mtd/> <mtd/> </mtr> <mtr> <mtd/> <mtd> <mtext> <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <mrow> <mi mathvariant="normal"> subject </mi> <mspace width="3.318pt"/> <mi mathvariant="normal"> to </mi> </mrow> </mstyle> </math> </mtext> <mspace width="9.963pt"/> </mtd> <mtd/> <mtd> <mi>𝑔</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>0</mn> <mo lspace="0" rspace="0">,</mo> </mtd> </mtr> <mtr> <mtd/> <mtd> <mspace width="9.963pt"/> </mtd> <mtd/> <mtd> <mi>𝑛</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>6</mn> <mo lspace="0" rspace="0">,</mo> </mtd> </mtr> <mtr> <mtd/> <mtd> <mspace width="9.963pt"/> </mtd> <mtd/> <mtd> <mi>𝐿</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝑟</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑥</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.278em" rspace="0.278em">=</mo> <mi>𝐾</mi> <mi>𝑤</mi> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝑝</mi> <mo lspace="0" rspace="0">,</mo> </mtd> </mtr> <mtr> <mtd/> <mtd> <mspace width="9.963pt"/> </mtd> <mtd/> <mtd> <mi mathvariant="normal">ℎ</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑥</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>0</mn> <mo lspace="0" rspace="0">.</mo> </mtd> </mtr> </mtable> </mtd> </mtr> </mtable> </math>
+      </AssociatedFile>
+      <AssociatedFile name="tag-AFfile7.tex" xmlns="">
+      \begin {equation}\label {eq:Example15} \begin {alignedat}{5} \bodyobj {w}{f(w)+ R(w+6x)}{minimize}{} \BODY \end {alignedat}\end {equation}
+      </AssociatedFile>
+     <?MarkedContent page="2" ?>minimizewf(w) +R(w + 6x)subject tog(w) = 0,n(w) = 6,L(w) +r(x) =Kw +p,h(x) = 0.
+     <Lbl xmlns="http://iso.org/pdf2/ssn"
+        id="ID.028"
+       >
+      <?MarkedContent page="2" ?>(6)
+     </Lbl>
+     <?MarkedContent page="2" ?>
+    </Formula>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.029"
+      rolemaps-to="Part"
+     >
+    <Formula xmlns="http://iso.org/pdf2/ssn"
+       id="ID.030"
+       title="equation"
+       af="mathml-8.xml tag-AFfile8.tex"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:Placement="Block"
+      >
+      <AssociatedFile name="mathml-8.xml" xmlns="">
+      <math display="block" xmlns="http://www.w3.org/1998/Math/MathML"> <mtable displaystyle="true" intent=":system-of-equations"> <mtr> <mtd intent=":equation-label"> <mtext> (7) </mtext> </mtd> <mtd intent=":pause-medium"> <mrow/> <mtable class="alignedat" columnalign="right left right left right left" columnspacing="0 0 0 0" displaystyle="true"> <mtr> <mtd/> <mtd> <mtext> <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <munder> <mi mathvariant="normal"> minimize </mi> <mstyle displaystyle="true" scriptlevel="0"> <mi>𝑤</mi> </mstyle> </munder> </mstyle> </math> </mtext> <mspace width="9.963pt"/> <mi>𝑓</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝑅</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0.222em" rspace="0.222em">+</mo> <mn>6</mn> <mi>𝑥</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd/> <mtd/> <mtd/> <mtd/> </mtr> <mtr> <mtd/> <mtd> <mtext> <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <mrow> <mi mathvariant="normal"> subject </mi> <mspace width="3.318pt"/> <mi mathvariant="normal"> to </mi> </mrow> </mstyle> </math> </mtext> </mtd> <mtd/> <mtd/> <mtd/> <mtd/> </mtr> <mtr> <mtd/> <mtd/> <mtd/> <mtd> <mi>𝑔</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>0</mn> <mo lspace="0" rspace="0">,</mo> </mtd> </mtr> <mtr> <mtd/> <mtd/> <mtd/> <mtd> <mi>𝑛</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>6</mn> <mo lspace="0" rspace="0">,</mo> </mtd> </mtr> <mtr> <mtd/> <mtd/> <mtd/> <mtd> <mi>𝐿</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝑟</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑥</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.278em" rspace="0.278em">=</mo> <mi>𝐾</mi> <mi>𝑤</mi> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝑝</mi> <mo lspace="0" rspace="0">,</mo> </mtd> </mtr> <mtr> <mtd/> <mtd/> <mtd/> <mtd> <mi mathvariant="normal">ℎ</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑥</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>0</mn> <mo lspace="0" rspace="0">.</mo> </mtd> </mtr> </mtable> </mtd> </mtr> </mtable> </math>
+      </AssociatedFile>
+      <AssociatedFile name="tag-AFfile8.tex" xmlns="">
+      \begin {equation}\label {eq:Example16} \begin {alignedat}{5} \bodyobj {w}{f(w)+ R(w+6x)}{minimize}{} \BODY \end {alignedat}\end {equation}
+      </AssociatedFile>
+     <?MarkedContent page="2" ?>minimizewf(w) +R(w + 6x)subject tog(w) = 0,n(w) = 6,L(w) +r(x) =Kw +p,h(x) = 0.
+     <Lbl xmlns="http://iso.org/pdf2/ssn"
+        id="ID.031"
+       >
+      <?MarkedContent page="2" ?>(7)
+     </Lbl>
+     <?MarkedContent page="2" ?>
+    </Formula>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.032"
+      rolemaps-to="Part"
+     >
+    <Formula xmlns="http://iso.org/pdf2/ssn"
+       id="ID.033"
+       title="alignat*"
+       af="mathml-9.xml tag-AFfile9.tex"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:Placement="Block"
+      >
+      <AssociatedFile name="mathml-9.xml" xmlns="">
+      <math display="block" xmlns="http://www.w3.org/1998/Math/MathML"> <mtable class="alignat" columnspacing="0 0 0 0 0 0 0 0 0 0" displaystyle="true" intent=":system-of-equations"> <mtr> <mtd intent=":no-equation-label"></mtd> <mtd intent=":pause-medium"/> <mtd> <mtext> <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <munder> <mi mathvariant="normal"> minimize </mi> <mstyle displaystyle="true" scriptlevel="0"> <mi>𝑤</mi> <mo lspace="0" rspace="0.167em">,</mo> <mi>𝑢</mi> </mstyle> </munder> </mstyle> </math> </mtext> <mspace width="9.963pt"/> <mi>𝑓</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝑅</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0.222em" rspace="0.222em">+</mo> <mn>6</mn> <mi>𝑥</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝐻</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mn> 100 </mn> <mi>𝑤</mi> <mo lspace="0.222em" rspace="0.222em">−</mo> <mi>𝑥</mi> <mo lspace="0.222em" rspace="0.222em">∗</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0">/</mo> <mn> 500 </mn> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> </mtr> <mtr> <mtd intent=":no-equation-label"></mtd> <mtd intent=":pause-medium"> <mtext> <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"/> </math> </mtext> <mspace width="9.963pt"/> <mo lspace="0.222em" rspace="0.222em">−</mo> <mi>𝑔</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <msup> <mi>𝑤</mi> <mn>3</mn> </msup> <mo lspace="0.222em" rspace="0.222em">−</mo> <msup> <mi>𝑥</mi> <mn>2</mn> </msup> <mo lspace="0.222em" rspace="0.222em">∗</mo> <mn> 200 </mn> <mo lspace="0.222em" rspace="0.222em">+</mo> <mn> 10000 </mn> <mo lspace="0.222em" rspace="0.222em">∗</mo> <msup> <mi>𝑤</mi> <mn>5</mn> </msup> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd/> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> </mtr> <mtr> <mtd intent=":no-equation-label"></mtd> <mtd intent=":pause-medium"/> <mtd> <mtext> <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <mrow> <mi mathvariant="normal"> subject </mi> <mspace width="3.318pt"/> <mi mathvariant="normal"> to </mi> </mrow> </mstyle> </math> </mtext> <mspace width="9.963pt"/> </mtd> <mtd intent=":pause-medium"> <mi>𝑔</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <msub> <mi>𝑤</mi> <mi>𝑘</mi> </msub> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi mathvariant="normal">ℎ</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <msub> <mi>𝑤</mi> <mi>𝑘</mi> </msub> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>0</mn> <mo lspace="0" rspace="0">,</mo> <mo lspace="0.167em" rspace="0">,</mo> </mtd> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> </mtr> <mtr> <mtd intent=":no-equation-label"></mtd> <mtd intent=":pause-medium"/> <mtd> <mspace width="9.963pt"/> </mtd> <mtd intent=":pause-medium"> <mi>𝑙</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <msub> <mi>𝑤</mi> <mi>𝑘</mi> </msub> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>5</mn> <mi>𝑢</mi> <mo lspace="0" rspace="0">,</mo> <mspace width="9.963pt"/> </mtd> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> </mtr> </mtable> </math>
+      </AssociatedFile>
+      <AssociatedFile name="tag-AFfile9.tex" xmlns="">
+      \begin {alignat*}{5} \bodyobj {w,u}{f(w)+ R(w+6x)+ H(100w-x*w/500)}{minimize}{} \BODY \end {alignat*}
+      </AssociatedFile>
+     <?MarkedContent page="2" ?>minimizew,uf(w) +R(w + 6x) +H(100w−x∗w/500)−g(w3−x2∗ 200 + 10000∗w5)subject tog(wk) +h(wk) = 0,,l(wk) = 5u,
+    </Formula>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.034"
+      rolemaps-to="Part"
+     >
+    <Formula xmlns="http://iso.org/pdf2/ssn"
+       id="ID.035"
+       title="alignat*"
+       af="mathml-2.xml tag-AFfile10.tex"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:Placement="Block"
+      >
+      <AssociatedFile name="mathml-2.xml" xmlns="">
+      <math display="block" xmlns="http://www.w3.org/1998/Math/MathML"> <mtable class="alignat" columnspacing="0 0 0 0 0 0 0 0 0 0" displaystyle="true" intent=":system-of-equations"> <mtr> <mtd intent=":no-equation-label"></mtd> <mtd intent=":pause-medium"/> <mtd> <mtext> <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <munder> <mi mathvariant="normal"> minimize </mi> <mstyle displaystyle="true" scriptlevel="0"> <mi>𝑤</mi> </mstyle> </munder> </mstyle> </math> </mtext> <mspace width="9.963pt"/> <mi>𝑓</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝑅</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0.222em" rspace="0.222em">+</mo> <mn>6</mn> <mi>𝑥</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> </mtr> <mtr> <mtd intent=":no-equation-label"></mtd> <mtd intent=":pause-medium"/> <mtd> <mtext> <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <mrow> <mi mathvariant="normal"> subject </mi> <mspace width="3.318pt"/> <mi mathvariant="normal"> to </mi> </mrow> </mstyle> </math> </mtext> <mspace width="9.963pt"/> </mtd> <mtd intent=":pause-medium"> <mi>𝑔</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>0</mn> <mo lspace="0" rspace="0">,</mo> </mtd> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> </mtr> <mtr> <mtd intent=":no-equation-label"></mtd> <mtd intent=":pause-medium"/> <mtd> <mspace width="9.963pt"/> </mtd> <mtd intent=":pause-medium"> <mi>𝑛</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>6</mn> <mo lspace="0" rspace="0">,</mo> <mo lspace="0.167em" rspace="0">,</mo> </mtd> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> </mtr> <mtr> <mtd intent=":no-equation-label"></mtd> <mtd intent=":pause-medium"/> <mtd> <mspace width="9.963pt"/> </mtd> <mtd intent=":pause-medium"> <mi>𝐿</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝑟</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑥</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mi>𝐾</mi> <mi>𝑤</mi> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝑝</mi> <mo lspace="0" rspace="0">,</mo> </mtd> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> </mtr> <mtr> <mtd intent=":no-equation-label"></mtd> <mtd intent=":pause-medium"/> <mtd> <mspace width="9.963pt"/> </mtd> <mtd intent=":pause-medium"> <mi mathvariant="normal">ℎ</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑥</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>0</mn> <mo lspace="0" rspace="0">.</mo> </mtd> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> </mtr> </mtable> </math>
+      </AssociatedFile>
+      <AssociatedFile name="tag-AFfile10.tex" xmlns="">
+      \begin {alignat*}{5} \bodyobj {w}{f(w)+ R(w+6x)}{minimize}{} \BODY \end {alignat*}
+      </AssociatedFile>
+     <?MarkedContent page="2" ?>minimizewf(w) +R(w + 6x)subject tog(w) = 0, (Dynamic constraint),n(w) = 6, (Boundary constraint),L(w) +r(x) =Kw +p, (Random constraint),h(x) = 0, (Path constraint).
+    </Formula>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.036"
+      rolemaps-to="Part"
+     >
+    <Formula xmlns="http://iso.org/pdf2/ssn"
+       id="ID.037"
+       title="equation"
+       af="mathml-11.xml tag-AFfile11.tex"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:Placement="Block"
+      >
+      <AssociatedFile name="mathml-11.xml" xmlns="">
+      <math display="block" xmlns="http://www.w3.org/1998/Math/MathML"> <mtable displaystyle="true" intent=":system-of-equations"> <mtr> <mtd intent=":equation-label"> <mtext> (8) </mtext> </mtd> <mtd intent=":pause-medium"> <mrow/> <mtable class="alignedat" columnalign="right left right left right left" columnspacing="0 0 0 0" displaystyle="true"> <mtr> <mtd> <msup> <mi>𝑤</mi> <mi mathvariant="normal">∗</mi> </msup> <mo lspace="0.278em" rspace="0">=</mo> <mspace width="3.318pt"/> </mtd> <mtd> <mtext> <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <munder> <mrow> <mi mathvariant="normal"> arg </mi> <mspace width="3.318pt"/> <mi mathvariant="normal"> min </mi> </mrow> <mstyle displaystyle="true" scriptlevel="0"> <mi>𝑤</mi> </mstyle> </munder> </mstyle> </math> </mtext> <mspace width="9.963pt"/> <mi>𝑓</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝑅</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0.222em" rspace="0.222em">+</mo> <mn>6</mn> <mi>𝑥</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd/> <mtd/> <mtd/> <mtd/> </mtr> <mtr> <mtd/> <mtd> <mtext> <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <mrow> <mi mathvariant="normal"> subject </mi> <mspace width="3.318pt"/> <mi mathvariant="normal"> to </mi> </mrow> </mstyle> </math> </mtext> <mspace width="9.963pt"/> </mtd> <mtd> <mi>𝑔</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>0</mn> <mo lspace="0" rspace="0">,</mo> </mtd> <mtd/> <mtd/> </mtr> <mtr> <mtd/> <mtd> <mspace width="9.963pt"/> </mtd> <mtd> <mi>𝑛</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>6</mn> <mo lspace="0" rspace="0">,</mo> </mtd> <mtd/> <mtd/> </mtr> <mtr> <mtd/> <mtd> <mspace width="9.963pt"/> </mtd> <mtd> <mi>𝐿</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝑟</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑥</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mi>𝐾</mi> <mi>𝑤</mi> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝑝</mi> <mo lspace="0" rspace="0">,</mo> </mtd> <mtd/> <mtd/> </mtr> <mtr> <mtd/> <mtd> <mspace width="9.963pt"/> </mtd> <mtd> <mi mathvariant="normal">ℎ</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑥</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>0</mn> <mo lspace="0" rspace="0">.</mo> </mtd> </mtr> </mtable> </mtd> </mtr> </mtable> </math>
+      </AssociatedFile>
+      <AssociatedFile name="tag-AFfile11.tex" xmlns="">
+      \begin {equation}\label {eq:Example17} \begin {alignedat}{5} \bodyobj {w}{f(w)+ R(w+6x)}{arg~min}{w^*=} \BODY \end {alignedat}\end {equation}
+      </AssociatedFile>
+     <?MarkedContent page="2" ?>w∗= arg minwf(w) +R(w + 6x)subject tog(w) = 0,n(w) = 6,L(w) +r(x) =Kw +p,h(x) = 0.
+     <Lbl xmlns="http://iso.org/pdf2/ssn"
+        id="ID.038"
+       >
+      <?MarkedContent page="2" ?>(8)
+     </Lbl>
+     <?MarkedContent page="2" ?>
+    </Formula>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.039"
+      rolemaps-to="Part"
+     >
+    <Formula xmlns="http://iso.org/pdf2/ssn"
+       id="ID.040"
+       title="alignat*"
+       af="mathml-2.xml tag-AFfile12.tex"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:Placement="Block"
+      >
+      <AssociatedFile name="mathml-2.xml" xmlns="">
+      <math display="block" xmlns="http://www.w3.org/1998/Math/MathML"> <mtable class="alignat" columnspacing="0 0 0 0 0 0 0 0 0 0" displaystyle="true" intent=":system-of-equations"> <mtr> <mtd intent=":no-equation-label"></mtd> <mtd intent=":pause-medium"/> <mtd> <mtext> <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <munder> <mi mathvariant="normal"> minimize </mi> <mstyle displaystyle="true" scriptlevel="0"> <mi>𝑤</mi> </mstyle> </munder> </mstyle> </math> </mtext> <mspace width="9.963pt"/> <mi>𝑓</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝑅</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0.222em" rspace="0.222em">+</mo> <mn>6</mn> <mi>𝑥</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> </mtr> <mtr> <mtd intent=":no-equation-label"></mtd> <mtd intent=":pause-medium"/> <mtd> <mtext> <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <mrow> <mi mathvariant="normal"> subject </mi> <mspace width="3.318pt"/> <mi mathvariant="normal"> to </mi> </mrow> </mstyle> </math> </mtext> <mspace width="9.963pt"/> </mtd> <mtd intent=":pause-medium"> <mi>𝑔</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>0</mn> <mo lspace="0" rspace="0">,</mo> </mtd> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> </mtr> <mtr> <mtd intent=":no-equation-label"></mtd> <mtd intent=":pause-medium"/> <mtd> <mspace width="9.963pt"/> </mtd> <mtd intent=":pause-medium"> <mi>𝑛</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>6</mn> <mo lspace="0" rspace="0">,</mo> <mo lspace="0.167em" rspace="0">,</mo> </mtd> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> </mtr> <mtr> <mtd intent=":no-equation-label"></mtd> <mtd intent=":pause-medium"/> <mtd> <mspace width="9.963pt"/> </mtd> <mtd intent=":pause-medium"> <mi>𝐿</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝑟</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑥</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mi>𝐾</mi> <mi>𝑤</mi> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝑝</mi> <mo lspace="0" rspace="0">,</mo> </mtd> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> </mtr> <mtr> <mtd intent=":no-equation-label"></mtd> <mtd intent=":pause-medium"/> <mtd> <mspace width="9.963pt"/> </mtd> <mtd intent=":pause-medium"> <mi mathvariant="normal">ℎ</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑥</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>0</mn> <mo lspace="0" rspace="0">.</mo> </mtd> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> </mtr> </mtable> </math>
+      </AssociatedFile>
+      <AssociatedFile name="tag-AFfile12.tex" xmlns="">
+      \begin {alignat*}{5} \bodyobj {w}{f(w)+ R(w+6x)}{minimize}{} \BODY \end {alignat*}
+      </AssociatedFile>
+     <?MarkedContent page="2" ?>minimizewf(w) +R(w + 6x)subject tog(w) = 0,p(w) = 0,q(w) = 0,
+     <?MarkedContent page="3" ?>r(w) = 0,
+     <Lbl xmlns="http://iso.org/pdf2/ssn"
+        id="ID.041"
+       >
+      <?MarkedContent page="3" ?>(9)
+     </Lbl>
+     <?MarkedContent page="3" ?>n(w) = 6,L(w) +r(x) =Kw +p,h(x) = 0.
+    </Formula>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.042"
+      rolemaps-to="Part"
+     >
+    <Formula xmlns="http://iso.org/pdf2/ssn"
+       id="ID.043"
+       title="alignat"
+       af="mathml-13.xml tag-AFfile13.tex"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:Placement="Block"
+      >
+      <AssociatedFile name="mathml-13.xml" xmlns="">
+      <math display="block" xmlns="http://www.w3.org/1998/Math/MathML"> <mtable class="alignat" columnspacing="0 0 0 0 0 0 0 0 0 0" displaystyle="true" intent=":system-of-equations"> <mtr> <mtd intent=":equation-label"> <mtext> (10a) </mtext> </mtd> <mtd intent=":pause-medium"> <msup> <mi>𝑤</mi> <mi mathvariant="normal">∗</mi> </msup> <mo lspace="0.278em" rspace="0">=</mo> <mspace width="3.318pt"/> </mtd> <mtd> <munder> <mi mathvariant="normal"> min </mi> <mstyle displaystyle="true" scriptlevel="0"> <mi>𝑤</mi> </mstyle> </munder> <mspace width="9.963pt"/> <mi>𝑓</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝑅</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0.222em" rspace="0.222em">+</mo> <mn>6</mn> <mi>𝑥</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> </mtr> <mtr> <mtd intent=":equation-label"> <mtext> (10b) </mtext> </mtd> <mtd intent=":pause-medium"/> <mtd> <mtext> <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <mtext> <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <mrow> <mspace width="0.996pt"/> <mi mathvariant="normal">s</mi> <mo lspace="0" rspace="0">.</mo> <mi mathvariant="normal">t</mi> <mo lspace="0" rspace="0">.</mo> </mrow> </mstyle> </math> </mtext> </mstyle> </math> </mtext> <mspace width="9.963pt"/> </mtd> <mtd intent=":pause-medium"/> <mtd> <mi>𝑔</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>0</mn> <mo lspace="0" rspace="0">,</mo> </mtd> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> </mtr> <mtr> <mtd intent=":equation-label"> <mtext> (10c) </mtext> </mtd> <mtd intent=":pause-medium"/> <mtd> <mspace width="9.963pt"/> </mtd> <mtd intent=":pause-medium"/> <mtd> <mi>𝑛</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>6</mn> <mo lspace="0" rspace="0">,</mo> </mtd> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> </mtr> <mtr> <mtd intent=":equation-label"> <mtext> (10d) </mtext> </mtd> <mtd intent=":pause-medium"/> <mtd> <mspace width="9.963pt"/> </mtd> <mtd intent=":pause-medium"/> <mtd> <mi>𝐿</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝑟</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑥</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.278em" rspace="0.278em">=</mo> <mi>𝐾</mi> <mi>𝑤</mi> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝑝</mi> <mo lspace="0" rspace="0">,</mo> </mtd> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> </mtr> <mtr> <mtd intent=":equation-label"> <mtext> (10e) </mtext> </mtd> <mtd intent=":pause-medium"/> <mtd> <mspace width="9.963pt"/> </mtd> <mtd intent=":pause-medium"/> <mtd> <mi mathvariant="normal">ℎ</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑥</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>0</mn> <mo lspace="0" rspace="0">.</mo> </mtd> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> </mtr> </mtable> </math>
+      </AssociatedFile>
+      <AssociatedFile name="tag-AFfile13.tex" xmlns="">
+      \begin {alignat}{5} \bodyobj {w}{f(w)+ R(w+6x)\label {eq:ObjectiveExample3}}{min}{w^*=} \BODY \end {alignat}
+      </AssociatedFile>
+     <?MarkedContent page="3" ?>w∗= minwf(w) +R(w + 6x)
+     <Lbl xmlns="http://iso.org/pdf2/ssn"
+        id="ID.044"
+       >
+      <?MarkedContent page="3" ?>(10a)
+     </Lbl>
+     <?MarkedContent page="3" ?>s.t.g(w) = 0,
+     <Lbl xmlns="http://iso.org/pdf2/ssn"
+        id="ID.045"
+       >
+      <?MarkedContent page="3" ?>(10b)
+     </Lbl>
+     <?MarkedContent page="3" ?>n(w) = 6,
+     <Lbl xmlns="http://iso.org/pdf2/ssn"
+        id="ID.046"
+       >
+      <?MarkedContent page="3" ?>(10c)
+     </Lbl>
+     <?MarkedContent page="3" ?>L(w) +r(x) =Kw +p,
+     <Lbl xmlns="http://iso.org/pdf2/ssn"
+        id="ID.047"
+       >
+      <?MarkedContent page="3" ?>(10d)
+     </Lbl>
+     <?MarkedContent page="3" ?>h(x) = 0.
+     <Lbl xmlns="http://iso.org/pdf2/ssn"
+        id="ID.048"
+       >
+      <?MarkedContent page="3" ?>(10e)
+     </Lbl>
+     <?MarkedContent page="3" ?>
+    </Formula>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-compatible-mathml/optidef/optidef-01.struct.xml
+++ b/tagging-status/testfiles-compatible-mathml/optidef/optidef-01.struct.xml
@@ -1,0 +1,551 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.006"
+      rolemaps-to="Part"
+     >
+    <Formula xmlns="http://iso.org/pdf2/ssn"
+       id="ID.007"
+       title="equation"
+       af="mathml-1.xml tag-AFfile1.tex"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:Placement="Block"
+      >
+      <AssociatedFile name="mathml-1.xml" xmlns="">
+      <math display="block" xmlns="http://www.w3.org/1998/Math/MathML"> <mtable displaystyle="true" intent=":system-of-equations"> <mtr> <mtd intent=":equation-label"> <mtext> (1) </mtext> </mtd> <mtd intent=":pause-medium"> <mrow/> <mtable class="alignedat" columnalign="right left right left right left" columnspacing="0 0 0 0" displaystyle="true"> <mtr> <mtd/> <mtd> <mtext> <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <munder> <mi mathvariant="normal"> minimize </mi> <mstyle displaystyle="true" scriptlevel="0"> <mi>𝑤</mi> </mstyle> </munder> </mstyle> </math> </mtext> <mspace width="9.963pt"/> <mi>𝑓</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝑅</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0.222em" rspace="0.222em">+</mo> <mn>6</mn> <mi>𝑥</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd/> <mtd/> <mtd/> <mtd/> </mtr> <mtr> <mtd/> <mtd> <mtext> <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <mrow> <mi mathvariant="normal"> subject </mi> <mspace width="3.318pt"/> <mi mathvariant="normal"> to </mi> </mrow> </mstyle> </math> </mtext> <mspace width="9.963pt"/> </mtd> <mtd> <mi>𝑔</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>0</mn> <mo lspace="0" rspace="0">,</mo> </mtd> <mtd/> <mtd/> </mtr> <mtr> <mtd/> <mtd> <mspace width="9.963pt"/> </mtd> <mtd> <mi>𝑛</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>6</mn> <mo lspace="0" rspace="0">,</mo> </mtd> <mtd/> <mtd/> </mtr> <mtr> <mtd/> <mtd> <mspace width="9.963pt"/> </mtd> <mtd> <mi>𝐿</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝑟</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑥</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mi>𝐾</mi> <mi>𝑤</mi> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝑝</mi> <mo lspace="0" rspace="0">,</mo> </mtd> <mtd/> <mtd/> </mtr> <mtr> <mtd/> <mtd> <mspace width="9.963pt"/> </mtd> <mtd> <mi mathvariant="normal">ℎ</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑥</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>0</mn> <mo lspace="0" rspace="0">.</mo> </mtd> </mtr> </mtable> </mtd> </mtr> </mtable> </math>
+      </AssociatedFile>
+      <AssociatedFile name="tag-AFfile1.tex" xmlns="">
+      \begin {equation}\label {eq:Example1} \begin {alignedat}{5} \bodyobj {w}{f(w)+ R(w+6x)}{minimize}{} \BODY \end {alignedat}\end {equation}
+      </AssociatedFile>
+     <?MarkedContent page="1" ?>minimize𝑤𝑓(𝑤)+𝑅(𝑤+6𝑥)
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>subjectto
+     <?MarkedContent page="1" ?>𝑔(𝑤)=0,
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>𝑛(𝑤)=6,
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>𝐿(𝑤)+𝑟(𝑥)=𝐾𝑤+𝑝,
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>ℎ(𝑥)=0.
+     <?MarkedContent page="1" ?>(1)
+     <?MarkedContent page="1" ?>
+    </Formula>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.008"
+      rolemaps-to="Part"
+     >
+    <Formula xmlns="http://iso.org/pdf2/ssn"
+       id="ID.009"
+       title="alignat*"
+       af="mathml-2.xml tag-AFfile2.tex"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:Placement="Block"
+      >
+      <AssociatedFile name="mathml-2.xml" xmlns="">
+      <math display="block" xmlns="http://www.w3.org/1998/Math/MathML"> <mtable class="alignat" columnspacing="0 0 0 0 0 0 0 0 0 0" displaystyle="true" intent=":system-of-equations"> <mtr> <mtd intent=":no-equation-label"></mtd> <mtd intent=":pause-medium"/> <mtd> <mtext> <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <munder> <mi mathvariant="normal"> minimize </mi> <mstyle displaystyle="true" scriptlevel="0"> <mi>𝑤</mi> </mstyle> </munder> </mstyle> </math> </mtext> <mspace width="9.963pt"/> <mi>𝑓</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝑅</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0.222em" rspace="0.222em">+</mo> <mn>6</mn> <mi>𝑥</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> </mtr> <mtr> <mtd intent=":no-equation-label"></mtd> <mtd intent=":pause-medium"/> <mtd> <mtext> <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <mrow> <mi mathvariant="normal"> subject </mi> <mspace width="3.318pt"/> <mi mathvariant="normal"> to </mi> </mrow> </mstyle> </math> </mtext> <mspace width="9.963pt"/> </mtd> <mtd intent=":pause-medium"> <mi>𝑔</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>0</mn> <mo lspace="0" rspace="0">,</mo> </mtd> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> </mtr> <mtr> <mtd intent=":no-equation-label"></mtd> <mtd intent=":pause-medium"/> <mtd> <mspace width="9.963pt"/> </mtd> <mtd intent=":pause-medium"> <mi>𝑛</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>6</mn> <mo lspace="0" rspace="0">,</mo> <mo lspace="0.167em" rspace="0">,</mo> </mtd> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> </mtr> <mtr> <mtd intent=":no-equation-label"></mtd> <mtd intent=":pause-medium"/> <mtd> <mspace width="9.963pt"/> </mtd> <mtd intent=":pause-medium"> <mi>𝐿</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝑟</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑥</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mi>𝐾</mi> <mi>𝑤</mi> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝑝</mi> <mo lspace="0" rspace="0">,</mo> </mtd> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> </mtr> <mtr> <mtd intent=":no-equation-label"></mtd> <mtd intent=":pause-medium"/> <mtd> <mspace width="9.963pt"/> </mtd> <mtd intent=":pause-medium"> <mi mathvariant="normal">ℎ</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑥</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>0</mn> <mo lspace="0" rspace="0">.</mo> </mtd> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> </mtr> </mtable> </math>
+      </AssociatedFile>
+      <AssociatedFile name="tag-AFfile2.tex" xmlns="">
+      \begin {alignat*}{5} \bodyobj {w}{f(w)+ R(w+6x)}{minimize}{} \BODY \end {alignat*}
+      </AssociatedFile>
+     <?MarkedContent page="1" ?>minimize𝑤𝑓(𝑤)+𝑅(𝑤+6𝑥)
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>subjectto
+     <?MarkedContent page="1" ?>𝑔(𝑤)=0,
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>𝑛(𝑤)=6,,
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>𝐿(𝑤)+𝑟(𝑥)=𝐾𝑤+𝑝,
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>ℎ(𝑥)=0.
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+    </Formula>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.010"
+      rolemaps-to="Part"
+     >
+    <Formula xmlns="http://iso.org/pdf2/ssn"
+       id="ID.011"
+       title="alignat"
+       af="mathml-3.xml tag-AFfile3.tex"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:Placement="Block"
+      >
+      <AssociatedFile name="mathml-3.xml" xmlns="">
+      <math display="block" xmlns="http://www.w3.org/1998/Math/MathML"> <mtable class="alignat" columnspacing="0 0 0 0 0 0 0 0 0 0" displaystyle="true" intent=":system-of-equations"> <mtr> <mtd intent=":equation-label"> <mtext> (2a) </mtext> </mtd> <mtd intent=":pause-medium"/> <mtd> <mtext> <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <munder> <mi mathvariant="normal"> minimize </mi> <mstyle displaystyle="true" scriptlevel="0"> <mi>𝑤</mi> </mstyle> </munder> </mstyle> </math> </mtext> <mspace width="9.963pt"/> <mi>𝑓</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝑅</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0.222em" rspace="0.222em">+</mo> <mn>6</mn> <mi>𝑥</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> </mtr> <mtr> <mtd intent=":equation-label"> <mtext> (2b) </mtext> </mtd> <mtd intent=":pause-medium"/> <mtd> <mtext> <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <mrow> <mi mathvariant="normal"> subject </mi> <mspace width="3.318pt"/> <mi mathvariant="normal"> to </mi> </mrow> </mstyle> </math> </mtext> <mspace width="9.963pt"/> </mtd> <mtd intent=":pause-medium"> <mi>𝑔</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>0</mn> <mo lspace="0" rspace="0">,</mo> </mtd> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> </mtr> <mtr> <mtd intent=":equation-label"> <mtext> (2c) </mtext> </mtd> <mtd intent=":pause-medium"/> <mtd> <mspace width="9.963pt"/> </mtd> <mtd intent=":pause-medium"> <mi>𝑛</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>6</mn> <mo lspace="0" rspace="0">,</mo> </mtd> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> </mtr> <mtr> <mtd intent=":equation-label"> <mtext> (2d) </mtext> </mtd> <mtd intent=":pause-medium"/> <mtd> <mspace width="9.963pt"/> </mtd> <mtd intent=":pause-medium"> <mi>𝐿</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝑟</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑥</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mi>𝐾</mi> <mi>𝑤</mi> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝑝</mi> <mo lspace="0" rspace="0">,</mo> </mtd> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> </mtr> <mtr> <mtd intent=":equation-label"> <mtext> (2e) </mtext> </mtd> <mtd intent=":pause-medium"/> <mtd> <mspace width="9.963pt"/> </mtd> <mtd intent=":pause-medium"> <mi mathvariant="normal">ℎ</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑥</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>0</mn> <mo lspace="0" rspace="0">.</mo> </mtd> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> </mtr> </mtable> </math>
+      </AssociatedFile>
+      <AssociatedFile name="tag-AFfile3.tex" xmlns="">
+      \begin {alignat}{5} \bodyobj {w}{f(w)+ R(w+6x) \label {eq:ObjectiveExample1}}{minimize}{} \BODY \end {alignat}
+      </AssociatedFile>
+     <?MarkedContent page="1" ?>minimize𝑤𝑓(𝑤)+𝑅(𝑤+6𝑥)
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>(2a)
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>subjectto
+     <?MarkedContent page="1" ?>𝑔(𝑤)=0,
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>(2b)
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>𝑛(𝑤)=6,
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>(2c)
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>𝐿(𝑤)+𝑟(𝑥)=𝐾𝑤+𝑝,
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>(2d)
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>ℎ(𝑥)=0.
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>(2e)
+     <?MarkedContent page="1" ?>
+    </Formula>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.012"
+      rolemaps-to="Part"
+     >
+    <Formula xmlns="http://iso.org/pdf2/ssn"
+       id="ID.013"
+       title="equation"
+       af="mathml-4.xml tag-AFfile4.tex"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:Placement="Block"
+      >
+      <AssociatedFile name="mathml-4.xml" xmlns="">
+      <math display="block" xmlns="http://www.w3.org/1998/Math/MathML"> <mtable displaystyle="true" intent=":system-of-equations"> <mtr> <mtd intent=":equation-label"> <mtext> (3) </mtext> </mtd> <mtd intent=":pause-medium"> <mrow/> <mtable class="alignedat" columnalign="right left right left right left" columnspacing="0 0 0 0" displaystyle="true"> <mtr> <mtd> <mi>𝐽</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <msup> <mi>𝑤</mi> <mi mathvariant="normal">∗</mi> </msup> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.278em" rspace="0">=</mo> <mspace width="3.318pt"/> </mtd> <mtd> <mtext> <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <munder> <mi mathvariant="normal"> minimize </mi> <mstyle displaystyle="true" scriptlevel="0"> <mi>𝑤</mi> </mstyle> </munder> </mstyle> </math> </mtext> <mspace width="9.963pt"/> <mi>𝑓</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝑅</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0.222em" rspace="0.222em">+</mo> <mn>6</mn> <mi>𝑥</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd/> <mtd/> <mtd/> <mtd/> </mtr> <mtr> <mtd/> <mtd> <mtext> <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <mrow> <mi mathvariant="normal"> subject </mi> <mspace width="3.318pt"/> <mi mathvariant="normal"> to </mi> </mrow> </mstyle> </math> </mtext> <mspace width="9.963pt"/> </mtd> <mtd> <mi>𝑔</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>0</mn> <mo lspace="0" rspace="0">,</mo> </mtd> <mtd/> <mtd/> </mtr> <mtr> <mtd/> <mtd> <mspace width="9.963pt"/> </mtd> <mtd> <mi>𝑛</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>6</mn> <mo lspace="0" rspace="0">,</mo> </mtd> <mtd/> <mtd/> </mtr> <mtr> <mtd/> <mtd> <mspace width="9.963pt"/> </mtd> <mtd> <mi>𝐿</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝑟</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑥</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mi>𝐾</mi> <mi>𝑤</mi> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝑝</mi> <mo lspace="0" rspace="0">,</mo> </mtd> <mtd/> <mtd/> </mtr> <mtr> <mtd/> <mtd> <mspace width="9.963pt"/> </mtd> <mtd> <mi mathvariant="normal">ℎ</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑥</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>0</mn> <mo lspace="0" rspace="0">.</mo> </mtd> </mtr> </mtable> </mtd> </mtr> </mtable> </math>
+      </AssociatedFile>
+      <AssociatedFile name="tag-AFfile4.tex" xmlns="">
+      \begin {equation}\label {eq:Example12} \begin {alignedat}{5} \bodyobj {w}{f(w)+ R(w+6x)}{minimize}{J(w^*)=} \BODY \end {alignedat}\end {equation}
+      </AssociatedFile>
+     <?MarkedContent page="1" ?>𝐽(𝑤∗)=minimize𝑤𝑓(𝑤)+𝑅(𝑤+6𝑥)
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>subjectto
+     <?MarkedContent page="1" ?>𝑔(𝑤)=0,
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>𝑛(𝑤)=6,
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>𝐿(𝑤)+𝑟(𝑥)=𝐾𝑤+𝑝,
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>ℎ(𝑥)=0.
+     <?MarkedContent page="1" ?>(3)
+     <?MarkedContent page="1" ?>
+    </Formula>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.014"
+      rolemaps-to="Part"
+     >
+    <Formula xmlns="http://iso.org/pdf2/ssn"
+       id="ID.015"
+       title="equation"
+       af="mathml-5.xml tag-AFfile5.tex"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:Placement="Block"
+      >
+      <AssociatedFile name="mathml-5.xml" xmlns="">
+      <math display="block" xmlns="http://www.w3.org/1998/Math/MathML"> <mtable displaystyle="true" intent=":system-of-equations"> <mtr> <mtd intent=":equation-label"> <mtext> (4) </mtext> </mtd> <mtd intent=":pause-medium"> <mrow/> <mtable class="alignedat" columnalign="right left right left right left" columnspacing="0 0 0 0" displaystyle="true"> <mtr> <mtd/> <mtd> <munder> <mi mathvariant="normal"> min </mi> <mstyle displaystyle="true" scriptlevel="0"> <mi>𝑤</mi> </mstyle> </munder> <mspace width="9.963pt"/> <mi>𝑓</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝑅</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0.222em" rspace="0.222em">+</mo> <mn>6</mn> <mi>𝑥</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd/> <mtd/> <mtd/> <mtd/> </mtr> <mtr> <mtd/> <mtd> <mtext> <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <mtext> <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <mrow> <mspace width="0.996pt"/> <mi mathvariant="normal">s</mi> <mo lspace="0" rspace="0">.</mo> <mi mathvariant="normal">t</mi> <mo lspace="0" rspace="0">.</mo> </mrow> </mstyle> </math> </mtext> </mstyle> </math> </mtext> <mspace width="9.963pt"/> </mtd> <mtd> <mi>𝑔</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>0</mn> <mo lspace="0" rspace="0">,</mo> </mtd> <mtd/> <mtd/> </mtr> <mtr> <mtd/> <mtd> <mspace width="9.963pt"/> </mtd> <mtd> <mi>𝑛</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>6</mn> <mo lspace="0" rspace="0">,</mo> </mtd> <mtd/> <mtd/> </mtr> <mtr> <mtd/> <mtd> <mspace width="9.963pt"/> </mtd> <mtd> <mi>𝐿</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝑟</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑥</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mi>𝐾</mi> <mi>𝑤</mi> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝑝</mi> <mo lspace="0" rspace="0">,</mo> </mtd> <mtd/> <mtd/> </mtr> <mtr> <mtd/> <mtd> <mspace width="9.963pt"/> </mtd> <mtd> <mi mathvariant="normal">ℎ</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑥</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>0</mn> <mo lspace="0" rspace="0">.</mo> </mtd> </mtr> </mtable> </mtd> </mtr> </mtable> </math>
+      </AssociatedFile>
+      <AssociatedFile name="tag-AFfile5.tex" xmlns="">
+      \begin {equation}\label {eq:Example13} \begin {alignedat}{5} \bodyobj {w}{f(w)+ R(w+6x)}{min}{} \BODY \end {alignedat}\end {equation}
+      </AssociatedFile>
+     <?MarkedContent page="1" ?>min𝑤𝑓(𝑤)+𝑅(𝑤+6𝑥)
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>s.t.
+     <?MarkedContent page="1" ?>𝑔(𝑤)=0,
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>𝑛(𝑤)=6,
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>𝐿(𝑤)+𝑟(𝑥)=𝐾𝑤+𝑝,
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>ℎ(𝑥)=0.
+     <?MarkedContent page="1" ?>(4)
+     <?MarkedContent page="1" ?>
+    </Formula>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.016"
+      rolemaps-to="Part"
+     >
+    <Formula xmlns="http://iso.org/pdf2/ssn"
+       id="ID.017"
+       title="equation"
+       af="mathml-6.xml tag-AFfile6.tex"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:Placement="Block"
+      >
+      <AssociatedFile name="mathml-6.xml" xmlns="">
+      <math display="block" xmlns="http://www.w3.org/1998/Math/MathML"> <mtable displaystyle="true" intent=":system-of-equations"> <mtr> <mtd intent=":equation-label"> <mtext> (5) </mtext> </mtd> <mtd intent=":pause-medium"> <mrow/> <mtable class="alignedat" columnalign="right left right left right left" columnspacing="0 0 0 0" displaystyle="true"> <mtr> <mtd/> <mtd> <mtext> <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <munder> <mi mathvariant="normal"> minimize </mi> <mstyle displaystyle="true" scriptlevel="0"> <mi>𝑤</mi> </mstyle> </munder> </mstyle> </math> </mtext> <mspace width="9.963pt"/> <mi>𝑓</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝑅</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0.222em" rspace="0.222em">+</mo> <mn>6</mn> <mi>𝑥</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd/> <mtd/> <mtd/> <mtd/> </mtr> <mtr> <mtd/> <mtd> <mtext> <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <mrow> <mi mathvariant="normal"> subject </mi> <mspace width="3.318pt"/> <mi mathvariant="normal"> to </mi> </mrow> </mstyle> </math> </mtext> </mtd> <mtd/> <mtd/> <mtd/> <mtd/> </mtr> <mtr> <mtd/> <mtd/> <mtd> <mi>𝑔</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>0</mn> <mo lspace="0" rspace="0">,</mo> </mtd> </mtr> <mtr> <mtd/> <mtd/> <mtd> <mi>𝑛</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>6</mn> <mo lspace="0" rspace="0">,</mo> </mtd> </mtr> <mtr> <mtd/> <mtd/> <mtd> <mi>𝐿</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝑟</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑥</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mi>𝐾</mi> <mi>𝑤</mi> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝑝</mi> <mo lspace="0" rspace="0">,</mo> </mtd> </mtr> <mtr> <mtd/> <mtd/> <mtd> <mi mathvariant="normal">ℎ</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑥</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>0</mn> <mo lspace="0" rspace="0">.</mo> </mtd> </mtr> </mtable> </mtd> </mtr> </mtable> </math>
+      </AssociatedFile>
+      <AssociatedFile name="tag-AFfile6.tex" xmlns="">
+      \begin {equation}\label {eq:Example14} \begin {alignedat}{5} \bodyobj {w}{f(w)+ R(w+6x)}{minimize}{} \BODY \end {alignedat}\end {equation}
+      </AssociatedFile>
+     <?MarkedContent page="1" ?>minimize𝑤𝑓(𝑤)+𝑅(𝑤+6𝑥)
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>subjectto
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>𝑔(𝑤)=0,
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>𝑛(𝑤)=6,
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>𝐿(𝑤)+𝑟(𝑥)=𝐾𝑤+𝑝,
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>ℎ(𝑥)=0.
+     <?MarkedContent page="1" ?>(5)
+     <?MarkedContent page="1" ?>
+    </Formula>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.018"
+      rolemaps-to="Part"
+     >
+    <Formula xmlns="http://iso.org/pdf2/ssn"
+       id="ID.019"
+       title="equation"
+       af="mathml-7.xml tag-AFfile7.tex"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:Placement="Block"
+      >
+      <AssociatedFile name="mathml-7.xml" xmlns="">
+      <math display="block" xmlns="http://www.w3.org/1998/Math/MathML"> <mtable displaystyle="true" intent=":system-of-equations"> <mtr> <mtd intent=":equation-label"> <mtext> (6) </mtext> </mtd> <mtd intent=":pause-medium"> <mrow/> <mtable class="alignedat" columnalign="right left right left right left" columnspacing="0 0 0 0" displaystyle="true"> <mtr> <mtd/> <mtd> <mtext> <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <munder> <mi mathvariant="normal"> minimize </mi> <mstyle displaystyle="true" scriptlevel="0"> <mi>𝑤</mi> </mstyle> </munder> </mstyle> </math> </mtext> <mspace width="9.963pt"/> <mi>𝑓</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝑅</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0.222em" rspace="0.222em">+</mo> <mn>6</mn> <mi>𝑥</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd/> <mtd/> <mtd/> <mtd/> </mtr> <mtr> <mtd/> <mtd> <mtext> <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <mrow> <mi mathvariant="normal"> subject </mi> <mspace width="3.318pt"/> <mi mathvariant="normal"> to </mi> </mrow> </mstyle> </math> </mtext> <mspace width="9.963pt"/> </mtd> <mtd/> <mtd> <mi>𝑔</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>0</mn> <mo lspace="0" rspace="0">,</mo> </mtd> </mtr> <mtr> <mtd/> <mtd> <mspace width="9.963pt"/> </mtd> <mtd/> <mtd> <mi>𝑛</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>6</mn> <mo lspace="0" rspace="0">,</mo> </mtd> </mtr> <mtr> <mtd/> <mtd> <mspace width="9.963pt"/> </mtd> <mtd/> <mtd> <mi>𝐿</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝑟</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑥</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.278em" rspace="0.278em">=</mo> <mi>𝐾</mi> <mi>𝑤</mi> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝑝</mi> <mo lspace="0" rspace="0">,</mo> </mtd> </mtr> <mtr> <mtd/> <mtd> <mspace width="9.963pt"/> </mtd> <mtd/> <mtd> <mi mathvariant="normal">ℎ</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑥</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>0</mn> <mo lspace="0" rspace="0">.</mo> </mtd> </mtr> </mtable> </mtd> </mtr> </mtable> </math>
+      </AssociatedFile>
+      <AssociatedFile name="tag-AFfile7.tex" xmlns="">
+      \begin {equation}\label {eq:Example15} \begin {alignedat}{5} \bodyobj {w}{f(w)+ R(w+6x)}{minimize}{} \BODY \end {alignedat}\end {equation}
+      </AssociatedFile>
+     <?MarkedContent page="2" ?>minimize𝑤𝑓(𝑤)+𝑅(𝑤+6𝑥)
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>subjectto
+     <?MarkedContent page="2" ?>𝑔(𝑤)=0,
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>𝑛(𝑤)=6,
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>𝐿(𝑤)+𝑟(𝑥)=𝐾𝑤+𝑝,
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>ℎ(𝑥)=0.
+     <?MarkedContent page="2" ?>(6)
+     <?MarkedContent page="2" ?>
+    </Formula>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.020"
+      rolemaps-to="Part"
+     >
+    <Formula xmlns="http://iso.org/pdf2/ssn"
+       id="ID.021"
+       title="equation"
+       af="mathml-8.xml tag-AFfile8.tex"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:Placement="Block"
+      >
+      <AssociatedFile name="mathml-8.xml" xmlns="">
+      <math display="block" xmlns="http://www.w3.org/1998/Math/MathML"> <mtable displaystyle="true" intent=":system-of-equations"> <mtr> <mtd intent=":equation-label"> <mtext> (7) </mtext> </mtd> <mtd intent=":pause-medium"> <mrow/> <mtable class="alignedat" columnalign="right left right left right left" columnspacing="0 0 0 0" displaystyle="true"> <mtr> <mtd/> <mtd> <mtext> <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <munder> <mi mathvariant="normal"> minimize </mi> <mstyle displaystyle="true" scriptlevel="0"> <mi>𝑤</mi> </mstyle> </munder> </mstyle> </math> </mtext> <mspace width="9.963pt"/> <mi>𝑓</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝑅</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0.222em" rspace="0.222em">+</mo> <mn>6</mn> <mi>𝑥</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd/> <mtd/> <mtd/> <mtd/> </mtr> <mtr> <mtd/> <mtd> <mtext> <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <mrow> <mi mathvariant="normal"> subject </mi> <mspace width="3.318pt"/> <mi mathvariant="normal"> to </mi> </mrow> </mstyle> </math> </mtext> </mtd> <mtd/> <mtd/> <mtd/> <mtd/> </mtr> <mtr> <mtd/> <mtd/> <mtd/> <mtd> <mi>𝑔</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>0</mn> <mo lspace="0" rspace="0">,</mo> </mtd> </mtr> <mtr> <mtd/> <mtd/> <mtd/> <mtd> <mi>𝑛</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>6</mn> <mo lspace="0" rspace="0">,</mo> </mtd> </mtr> <mtr> <mtd/> <mtd/> <mtd/> <mtd> <mi>𝐿</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝑟</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑥</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.278em" rspace="0.278em">=</mo> <mi>𝐾</mi> <mi>𝑤</mi> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝑝</mi> <mo lspace="0" rspace="0">,</mo> </mtd> </mtr> <mtr> <mtd/> <mtd/> <mtd/> <mtd> <mi mathvariant="normal">ℎ</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑥</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>0</mn> <mo lspace="0" rspace="0">.</mo> </mtd> </mtr> </mtable> </mtd> </mtr> </mtable> </math>
+      </AssociatedFile>
+      <AssociatedFile name="tag-AFfile8.tex" xmlns="">
+      \begin {equation}\label {eq:Example16} \begin {alignedat}{5} \bodyobj {w}{f(w)+ R(w+6x)}{minimize}{} \BODY \end {alignedat}\end {equation}
+      </AssociatedFile>
+     <?MarkedContent page="2" ?>minimize𝑤𝑓(𝑤)+𝑅(𝑤+6𝑥)
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>subjectto
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>𝑔(𝑤)=0,
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>𝑛(𝑤)=6,
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>𝐿(𝑤)+𝑟(𝑥)=𝐾𝑤+𝑝,
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>ℎ(𝑥)=0.
+     <?MarkedContent page="2" ?>(7)
+     <?MarkedContent page="2" ?>
+    </Formula>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.022"
+      rolemaps-to="Part"
+     >
+    <Formula xmlns="http://iso.org/pdf2/ssn"
+       id="ID.023"
+       title="alignat*"
+       af="mathml-9.xml tag-AFfile9.tex"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:Placement="Block"
+      >
+      <AssociatedFile name="mathml-9.xml" xmlns="">
+      <math display="block" xmlns="http://www.w3.org/1998/Math/MathML"> <mtable class="alignat" columnspacing="0 0 0 0 0 0 0 0 0 0" displaystyle="true" intent=":system-of-equations"> <mtr> <mtd intent=":no-equation-label"></mtd> <mtd intent=":pause-medium"/> <mtd> <mtext> <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <munder> <mi mathvariant="normal"> minimize </mi> <mstyle displaystyle="true" scriptlevel="0"> <mi>𝑤</mi> <mo lspace="0" rspace="0.167em">,</mo> <mi>𝑢</mi> </mstyle> </munder> </mstyle> </math> </mtext> <mspace width="9.963pt"/> <mi>𝑓</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝑅</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0.222em" rspace="0.222em">+</mo> <mn>6</mn> <mi>𝑥</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝐻</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mn> 100 </mn> <mi>𝑤</mi> <mo lspace="0.222em" rspace="0.222em">−</mo> <mi>𝑥</mi> <mo lspace="0.222em" rspace="0.222em">∗</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0">/</mo> <mn> 500 </mn> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> </mtr> <mtr> <mtd intent=":no-equation-label"></mtd> <mtd intent=":pause-medium"> <mtext> <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"/> </math> </mtext> <mspace width="9.963pt"/> <mo lspace="0.222em" rspace="0.222em">−</mo> <mi>𝑔</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <msup> <mi>𝑤</mi> <mn>3</mn> </msup> <mo lspace="0.222em" rspace="0.222em">−</mo> <msup> <mi>𝑥</mi> <mn>2</mn> </msup> <mo lspace="0.222em" rspace="0.222em">∗</mo> <mn> 200 </mn> <mo lspace="0.222em" rspace="0.222em">+</mo> <mn> 10000 </mn> <mo lspace="0.222em" rspace="0.222em">∗</mo> <msup> <mi>𝑤</mi> <mn>5</mn> </msup> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd/> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> </mtr> <mtr> <mtd intent=":no-equation-label"></mtd> <mtd intent=":pause-medium"/> <mtd> <mtext> <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <mrow> <mi mathvariant="normal"> subject </mi> <mspace width="3.318pt"/> <mi mathvariant="normal"> to </mi> </mrow> </mstyle> </math> </mtext> <mspace width="9.963pt"/> </mtd> <mtd intent=":pause-medium"> <mi>𝑔</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <msub> <mi>𝑤</mi> <mi>𝑘</mi> </msub> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi mathvariant="normal">ℎ</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <msub> <mi>𝑤</mi> <mi>𝑘</mi> </msub> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>0</mn> <mo lspace="0" rspace="0">,</mo> <mo lspace="0.167em" rspace="0">,</mo> </mtd> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> </mtr> <mtr> <mtd intent=":no-equation-label"></mtd> <mtd intent=":pause-medium"/> <mtd> <mspace width="9.963pt"/> </mtd> <mtd intent=":pause-medium"> <mi>𝑙</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <msub> <mi>𝑤</mi> <mi>𝑘</mi> </msub> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>5</mn> <mi>𝑢</mi> <mo lspace="0" rspace="0">,</mo> <mspace width="9.963pt"/> </mtd> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> </mtr> </mtable> </math>
+      </AssociatedFile>
+      <AssociatedFile name="tag-AFfile9.tex" xmlns="">
+      \begin {alignat*}{5} \bodyobj {w,u}{f(w)+ R(w+6x)+ H(100w-x*w/500)}{minimize}{} \BODY \end {alignat*}
+      </AssociatedFile>
+     <?MarkedContent page="2" ?>minimize𝑤,𝑢𝑓(𝑤)+𝑅(𝑤+6𝑥)+𝐻(100𝑤−𝑥∗𝑤/500)
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>−𝑔(𝑤3−𝑥2∗200+10000∗𝑤5)
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>subjectto
+     <?MarkedContent page="2" ?>𝑔(𝑤𝑘)+ℎ(𝑤𝑘)=0,,
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>𝑙(𝑤𝑘)=5𝑢,
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>
+    </Formula>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.024"
+      rolemaps-to="Part"
+     >
+    <Formula xmlns="http://iso.org/pdf2/ssn"
+       id="ID.025"
+       title="alignat*"
+       af="mathml-2.xml tag-AFfile10.tex"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:Placement="Block"
+      >
+      <AssociatedFile name="mathml-2.xml" xmlns="">
+      <math display="block" xmlns="http://www.w3.org/1998/Math/MathML"> <mtable class="alignat" columnspacing="0 0 0 0 0 0 0 0 0 0" displaystyle="true" intent=":system-of-equations"> <mtr> <mtd intent=":no-equation-label"></mtd> <mtd intent=":pause-medium"/> <mtd> <mtext> <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <munder> <mi mathvariant="normal"> minimize </mi> <mstyle displaystyle="true" scriptlevel="0"> <mi>𝑤</mi> </mstyle> </munder> </mstyle> </math> </mtext> <mspace width="9.963pt"/> <mi>𝑓</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝑅</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0.222em" rspace="0.222em">+</mo> <mn>6</mn> <mi>𝑥</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> </mtr> <mtr> <mtd intent=":no-equation-label"></mtd> <mtd intent=":pause-medium"/> <mtd> <mtext> <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <mrow> <mi mathvariant="normal"> subject </mi> <mspace width="3.318pt"/> <mi mathvariant="normal"> to </mi> </mrow> </mstyle> </math> </mtext> <mspace width="9.963pt"/> </mtd> <mtd intent=":pause-medium"> <mi>𝑔</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>0</mn> <mo lspace="0" rspace="0">,</mo> </mtd> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> </mtr> <mtr> <mtd intent=":no-equation-label"></mtd> <mtd intent=":pause-medium"/> <mtd> <mspace width="9.963pt"/> </mtd> <mtd intent=":pause-medium"> <mi>𝑛</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>6</mn> <mo lspace="0" rspace="0">,</mo> <mo lspace="0.167em" rspace="0">,</mo> </mtd> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> </mtr> <mtr> <mtd intent=":no-equation-label"></mtd> <mtd intent=":pause-medium"/> <mtd> <mspace width="9.963pt"/> </mtd> <mtd intent=":pause-medium"> <mi>𝐿</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝑟</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑥</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mi>𝐾</mi> <mi>𝑤</mi> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝑝</mi> <mo lspace="0" rspace="0">,</mo> </mtd> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> </mtr> <mtr> <mtd intent=":no-equation-label"></mtd> <mtd intent=":pause-medium"/> <mtd> <mspace width="9.963pt"/> </mtd> <mtd intent=":pause-medium"> <mi mathvariant="normal">ℎ</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑥</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>0</mn> <mo lspace="0" rspace="0">.</mo> </mtd> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> </mtr> </mtable> </math>
+      </AssociatedFile>
+      <AssociatedFile name="tag-AFfile10.tex" xmlns="">
+      \begin {alignat*}{5} \bodyobj {w}{f(w)+ R(w+6x)}{minimize}{} \BODY \end {alignat*}
+      </AssociatedFile>
+     <?MarkedContent page="2" ?>minimize𝑤𝑓(𝑤)+𝑅(𝑤+6𝑥)
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>subjectto
+     <?MarkedContent page="2" ?>𝑔(𝑤)=0,
+     <?MarkedContent page="2" ?>(Dynamic constraint),
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>𝑛(𝑤)=6,
+     <?MarkedContent page="2" ?>(Boundary constraint),
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>𝐿(𝑤)+𝑟(𝑥)=𝐾𝑤+𝑝,
+     <?MarkedContent page="2" ?>(Random constraint),
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>ℎ(𝑥)=0,
+     <?MarkedContent page="2" ?>(Path constraint).
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>
+    </Formula>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.026"
+      rolemaps-to="Part"
+     >
+    <Formula xmlns="http://iso.org/pdf2/ssn"
+       id="ID.027"
+       title="equation"
+       af="mathml-11.xml tag-AFfile11.tex"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:Placement="Block"
+      >
+      <AssociatedFile name="mathml-11.xml" xmlns="">
+      <math display="block" xmlns="http://www.w3.org/1998/Math/MathML"> <mtable displaystyle="true" intent=":system-of-equations"> <mtr> <mtd intent=":equation-label"> <mtext> (8) </mtext> </mtd> <mtd intent=":pause-medium"> <mrow/> <mtable class="alignedat" columnalign="right left right left right left" columnspacing="0 0 0 0" displaystyle="true"> <mtr> <mtd> <msup> <mi>𝑤</mi> <mi mathvariant="normal">∗</mi> </msup> <mo lspace="0.278em" rspace="0">=</mo> <mspace width="3.318pt"/> </mtd> <mtd> <mtext> <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <munder> <mrow> <mi mathvariant="normal"> arg </mi> <mspace width="3.318pt"/> <mi mathvariant="normal"> min </mi> </mrow> <mstyle displaystyle="true" scriptlevel="0"> <mi>𝑤</mi> </mstyle> </munder> </mstyle> </math> </mtext> <mspace width="9.963pt"/> <mi>𝑓</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝑅</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0.222em" rspace="0.222em">+</mo> <mn>6</mn> <mi>𝑥</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd/> <mtd/> <mtd/> <mtd/> </mtr> <mtr> <mtd/> <mtd> <mtext> <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <mrow> <mi mathvariant="normal"> subject </mi> <mspace width="3.318pt"/> <mi mathvariant="normal"> to </mi> </mrow> </mstyle> </math> </mtext> <mspace width="9.963pt"/> </mtd> <mtd> <mi>𝑔</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>0</mn> <mo lspace="0" rspace="0">,</mo> </mtd> <mtd/> <mtd/> </mtr> <mtr> <mtd/> <mtd> <mspace width="9.963pt"/> </mtd> <mtd> <mi>𝑛</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>6</mn> <mo lspace="0" rspace="0">,</mo> </mtd> <mtd/> <mtd/> </mtr> <mtr> <mtd/> <mtd> <mspace width="9.963pt"/> </mtd> <mtd> <mi>𝐿</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝑟</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑥</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mi>𝐾</mi> <mi>𝑤</mi> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝑝</mi> <mo lspace="0" rspace="0">,</mo> </mtd> <mtd/> <mtd/> </mtr> <mtr> <mtd/> <mtd> <mspace width="9.963pt"/> </mtd> <mtd> <mi mathvariant="normal">ℎ</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑥</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>0</mn> <mo lspace="0" rspace="0">.</mo> </mtd> </mtr> </mtable> </mtd> </mtr> </mtable> </math>
+      </AssociatedFile>
+      <AssociatedFile name="tag-AFfile11.tex" xmlns="">
+      \begin {equation}\label {eq:Example17} \begin {alignedat}{5} \bodyobj {w}{f(w)+ R(w+6x)}{arg~min}{w^*=} \BODY \end {alignedat}\end {equation}
+      </AssociatedFile>
+     <?MarkedContent page="2" ?>𝑤∗=argmin𝑤𝑓(𝑤)+𝑅(𝑤+6𝑥)
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>subjectto
+     <?MarkedContent page="2" ?>𝑔(𝑤)=0,
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>𝑛(𝑤)=6,
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>𝐿(𝑤)+𝑟(𝑥)=𝐾𝑤+𝑝,
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>ℎ(𝑥)=0.
+     <?MarkedContent page="2" ?>(8)
+     <?MarkedContent page="2" ?>
+    </Formula>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.028"
+      rolemaps-to="Part"
+     >
+    <Formula xmlns="http://iso.org/pdf2/ssn"
+       id="ID.029"
+       title="alignat*"
+       af="mathml-2.xml tag-AFfile12.tex"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:Placement="Block"
+      >
+      <AssociatedFile name="mathml-2.xml" xmlns="">
+      <math display="block" xmlns="http://www.w3.org/1998/Math/MathML"> <mtable class="alignat" columnspacing="0 0 0 0 0 0 0 0 0 0" displaystyle="true" intent=":system-of-equations"> <mtr> <mtd intent=":no-equation-label"></mtd> <mtd intent=":pause-medium"/> <mtd> <mtext> <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <munder> <mi mathvariant="normal"> minimize </mi> <mstyle displaystyle="true" scriptlevel="0"> <mi>𝑤</mi> </mstyle> </munder> </mstyle> </math> </mtext> <mspace width="9.963pt"/> <mi>𝑓</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝑅</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0.222em" rspace="0.222em">+</mo> <mn>6</mn> <mi>𝑥</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> </mtr> <mtr> <mtd intent=":no-equation-label"></mtd> <mtd intent=":pause-medium"/> <mtd> <mtext> <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <mrow> <mi mathvariant="normal"> subject </mi> <mspace width="3.318pt"/> <mi mathvariant="normal"> to </mi> </mrow> </mstyle> </math> </mtext> <mspace width="9.963pt"/> </mtd> <mtd intent=":pause-medium"> <mi>𝑔</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>0</mn> <mo lspace="0" rspace="0">,</mo> </mtd> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> </mtr> <mtr> <mtd intent=":no-equation-label"></mtd> <mtd intent=":pause-medium"/> <mtd> <mspace width="9.963pt"/> </mtd> <mtd intent=":pause-medium"> <mi>𝑛</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>6</mn> <mo lspace="0" rspace="0">,</mo> <mo lspace="0.167em" rspace="0">,</mo> </mtd> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> </mtr> <mtr> <mtd intent=":no-equation-label"></mtd> <mtd intent=":pause-medium"/> <mtd> <mspace width="9.963pt"/> </mtd> <mtd intent=":pause-medium"> <mi>𝐿</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝑟</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑥</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mi>𝐾</mi> <mi>𝑤</mi> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝑝</mi> <mo lspace="0" rspace="0">,</mo> </mtd> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> </mtr> <mtr> <mtd intent=":no-equation-label"></mtd> <mtd intent=":pause-medium"/> <mtd> <mspace width="9.963pt"/> </mtd> <mtd intent=":pause-medium"> <mi mathvariant="normal">ℎ</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑥</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>0</mn> <mo lspace="0" rspace="0">.</mo> </mtd> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> </mtr> </mtable> </math>
+      </AssociatedFile>
+      <AssociatedFile name="tag-AFfile12.tex" xmlns="">
+      \begin {alignat*}{5} \bodyobj {w}{f(w)+ R(w+6x)}{minimize}{} \BODY \end {alignat*}
+      </AssociatedFile>
+     <?MarkedContent page="2" ?>minimize𝑤𝑓(𝑤)+𝑅(𝑤+6𝑥)
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>subjectto
+     <?MarkedContent page="2" ?>𝑔(𝑤)=0,
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>𝑝(𝑤)=0,
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>𝑞(𝑤)=0,
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="3" ?>
+     <?MarkedContent page="3" ?>𝑟(𝑤)=0,
+     <?MarkedContent page="3" ?>
+     <?MarkedContent page="3" ?>
+     <?MarkedContent page="3" ?>
+     <?MarkedContent page="3" ?>(9)
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="3" ?>
+     <?MarkedContent page="3" ?>
+     <?MarkedContent page="3" ?>𝑛(𝑤)=6,
+     <?MarkedContent page="3" ?>
+     <?MarkedContent page="3" ?>
+     <?MarkedContent page="3" ?>
+     <?MarkedContent page="3" ?>
+     <?MarkedContent page="3" ?>𝐿(𝑤)+𝑟(𝑥)=𝐾𝑤+𝑝,
+     <?MarkedContent page="3" ?>
+     <?MarkedContent page="3" ?>
+     <?MarkedContent page="3" ?>
+     <?MarkedContent page="3" ?>
+     <?MarkedContent page="3" ?>ℎ(𝑥)=0.
+     <?MarkedContent page="3" ?>
+     <?MarkedContent page="3" ?>
+     <?MarkedContent page="3" ?>
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>
+     <?MarkedContent page="2" ?>
+    </Formula>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.030"
+      rolemaps-to="Part"
+     >
+    <Formula xmlns="http://iso.org/pdf2/ssn"
+       id="ID.031"
+       title="alignat"
+       af="mathml-13.xml tag-AFfile13.tex"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:Placement="Block"
+      >
+      <AssociatedFile name="mathml-13.xml" xmlns="">
+      <math display="block" xmlns="http://www.w3.org/1998/Math/MathML"> <mtable class="alignat" columnspacing="0 0 0 0 0 0 0 0 0 0" displaystyle="true" intent=":system-of-equations"> <mtr> <mtd intent=":equation-label"> <mtext> (10a) </mtext> </mtd> <mtd intent=":pause-medium"> <msup> <mi>𝑤</mi> <mi mathvariant="normal">∗</mi> </msup> <mo lspace="0.278em" rspace="0">=</mo> <mspace width="3.318pt"/> </mtd> <mtd> <munder> <mi mathvariant="normal"> min </mi> <mstyle displaystyle="true" scriptlevel="0"> <mi>𝑤</mi> </mstyle> </munder> <mspace width="9.963pt"/> <mi>𝑓</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝑅</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0.222em" rspace="0.222em">+</mo> <mn>6</mn> <mi>𝑥</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </mtd> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> </mtr> <mtr> <mtd intent=":equation-label"> <mtext> (10b) </mtext> </mtd> <mtd intent=":pause-medium"/> <mtd> <mtext> <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <mtext> <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <mrow> <mspace width="0.996pt"/> <mi mathvariant="normal">s</mi> <mo lspace="0" rspace="0">.</mo> <mi mathvariant="normal">t</mi> <mo lspace="0" rspace="0">.</mo> </mrow> </mstyle> </math> </mtext> </mstyle> </math> </mtext> <mspace width="9.963pt"/> </mtd> <mtd intent=":pause-medium"/> <mtd> <mi>𝑔</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>0</mn> <mo lspace="0" rspace="0">,</mo> </mtd> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> </mtr> <mtr> <mtd intent=":equation-label"> <mtext> (10c) </mtext> </mtd> <mtd intent=":pause-medium"/> <mtd> <mspace width="9.963pt"/> </mtd> <mtd intent=":pause-medium"/> <mtd> <mi>𝑛</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>6</mn> <mo lspace="0" rspace="0">,</mo> </mtd> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> </mtr> <mtr> <mtd intent=":equation-label"> <mtext> (10d) </mtext> </mtd> <mtd intent=":pause-medium"/> <mtd> <mspace width="9.963pt"/> </mtd> <mtd intent=":pause-medium"/> <mtd> <mi>𝐿</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑤</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝑟</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑥</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.278em" rspace="0.278em">=</mo> <mi>𝐾</mi> <mi>𝑤</mi> <mo lspace="0.222em" rspace="0.222em">+</mo> <mi>𝑝</mi> <mo lspace="0" rspace="0">,</mo> </mtd> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> </mtr> <mtr> <mtd intent=":equation-label"> <mtext> (10e) </mtext> </mtd> <mtd intent=":pause-medium"/> <mtd> <mspace width="9.963pt"/> </mtd> <mtd intent=":pause-medium"/> <mtd> <mi mathvariant="normal">ℎ</mi> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mi>𝑥</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mo lspace="0.278em" rspace="0.278em">=</mo> <mn>0</mn> <mo lspace="0" rspace="0">.</mo> </mtd> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> <mtd intent=":pause-medium"/> <mtd/> </mtr> </mtable> </math>
+      </AssociatedFile>
+      <AssociatedFile name="tag-AFfile13.tex" xmlns="">
+      \begin {alignat}{5} \bodyobj {w}{f(w)+ R(w+6x)\label {eq:ObjectiveExample3}}{min}{w^*=} \BODY \end {alignat}
+      </AssociatedFile>
+     <?MarkedContent page="3" ?>𝑤∗=min𝑤𝑓(𝑤)+𝑅(𝑤+6𝑥)
+     <?MarkedContent page="3" ?>
+     <?MarkedContent page="3" ?>
+     <?MarkedContent page="3" ?>
+     <?MarkedContent page="3" ?>
+     <?MarkedContent page="3" ?>(10a)
+     <?MarkedContent page="3" ?>
+     <?MarkedContent page="3" ?>s.t.
+     <?MarkedContent page="3" ?>𝑔(𝑤)=0,
+     <?MarkedContent page="3" ?>
+     <?MarkedContent page="3" ?>
+     <?MarkedContent page="3" ?>
+     <?MarkedContent page="3" ?>(10b)
+     <?MarkedContent page="3" ?>
+     <?MarkedContent page="3" ?>
+     <?MarkedContent page="3" ?>𝑛(𝑤)=6,
+     <?MarkedContent page="3" ?>
+     <?MarkedContent page="3" ?>
+     <?MarkedContent page="3" ?>
+     <?MarkedContent page="3" ?>(10c)
+     <?MarkedContent page="3" ?>
+     <?MarkedContent page="3" ?>
+     <?MarkedContent page="3" ?>𝐿(𝑤)+𝑟(𝑥)=𝐾𝑤+𝑝,
+     <?MarkedContent page="3" ?>
+     <?MarkedContent page="3" ?>
+     <?MarkedContent page="3" ?>
+     <?MarkedContent page="3" ?>(10d)
+     <?MarkedContent page="3" ?>
+     <?MarkedContent page="3" ?>
+     <?MarkedContent page="3" ?>ℎ(𝑥)=0.
+     <?MarkedContent page="3" ?>
+     <?MarkedContent page="3" ?>
+     <?MarkedContent page="3" ?>
+     <?MarkedContent page="3" ?>(10e)
+     <?MarkedContent page="3" ?>
+    </Formula>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-compatible-mathml/optidef/optidef-01.tex
+++ b/tagging-status/testfiles-compatible-mathml/optidef/optidef-01.tex
@@ -1,0 +1,142 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on,
+  }
+\documentclass{article}
+\ifdefined\Uchar
+  \usepackage{unicode-math}
+\fi
+\usepackage{optidef}
+
+\title{optidef tagging test}
+
+\begin{document}
+
+\begin{mini}
+{w}{f(w)+ R(w+6x)}
+{\label{eq:Example1}}{}
+\addConstraint{g(w)}{=0}
+\addConstraint{n(w)}{= 6}
+\addConstraint{L(w)+r(x)}{=Kw+p}
+\addConstraint{h(x)}{=0.}
+\end{mini}
+
+\begin{mini*}
+{w}{f(w)+ R(w+6x)}
+{}{}
+\addConstraint{g(w)}{=0}
+\addConstraint{n(w)}{= 6,}
+\addConstraint{L(w)+r(x)}{=Kw+p}
+\addConstraint{h(x)}{=0.}
+\end{mini*}
+
+\begin{mini!}
+{w}{f(w)+ R(w+6x) \label{eq:ObjectiveExample1}}
+{\label{eq:Example11}}{}
+\addConstraint{g(w)}{=0 \label{eq:C1Example31}}
+\addConstraint{n(w)}{= 6 \label{eq:C2Example1}}
+\addConstraint{L(w)+r(x)}{=Kw+p \label{eq:C3Example1}}
+\addConstraint{h(x)}{=0. \label{eq:C4Example1}}
+\end{mini!}
+
+\begin{mini}
+{w}{f(w)+ R(w+6x)}
+{\label{eq:Example12}}
+{J(w^*)=}
+\addConstraint{g(w)}{=0}
+\addConstraint{n(w)}{= 6}
+\addConstraint{L(w)+r(x)}{=Kw+p}
+\addConstraint{h(x)}{=0.}
+\end{mini}
+
+\begin{mini}|s|
+{w}{f(w)+ R(w+6x)}
+{\label{eq:Example13}}
+{}
+\addConstraint{g(w)}{=0}
+\addConstraint{n(w)}{= 6}
+\addConstraint{L(w)+r(x)}{=Kw+p}
+\addConstraint{h(x)}{=0.}
+\end{mini}
+
+\begin{mini}[1]
+{w}{f(w)+ R(w+6x)}
+{\label{eq:Example14}}
+{}
+\addConstraint{g(w)}{=0}
+\addConstraint{n(w)}{= 6}
+\addConstraint{L(w)+r(x)}{=Kw+p}
+\addConstraint{h(x)}{=0.}
+\end{mini}
+
+\begin{mini}[2]
+{w}{f(w)+ R(w+6x)}
+{\label{eq:Example15}}
+{}
+\addConstraint{g(w)}{=0}
+\addConstraint{n(w)}{= 6}
+\addConstraint{L(w)+r(x)}{=Kw+p}
+\addConstraint{h(x)}{=0.}
+\end{mini}
+
+\begin{mini}[3]
+{w}{f(w)+ R(w+6x)}
+{\label{eq:Example16}}
+{}
+\addConstraint{g(w)}{=0}
+\addConstraint{n(w)}{= 6}
+\addConstraint{L(w)+r(x)}{=Kw+p}
+\addConstraint{h(x)}{=0.}
+\end{mini}
+
+\begin{mini*}
+{w,u}{f(w)+ R(w+6x)+ H(100w-x*w/500)}{}{}
+\breakObjective{-g(w^3-x^2*200+10000*w^5)}
+\addConstraint{g(w_k)+h(w_k)}{=0,}
+\addConstraint{l(w_k)}{=5u,\quad}
+\end{mini*}
+
+\begin{mini*}
+{w}{f(w)+ R(w+6x)}
+{}{}
+\addConstraint{g(w)}{=0,}{ \quad \text{(Dynamic constraint)}}
+\addConstraint{n(w)}{= 6,}{ \quad \text{(Boundary constraint)}}
+\addConstraint{L(w)+r(x)}{=Kw+p,}{ \quad \text{(Random constraint)}}
+\addConstraint{h(x)}{=0,}{ \quad \text{(Path constraint).}}
+\end{mini*}
+
+\begin{argmini}
+{w}{f(w)+ R(w+6x)}
+{\label{eq:Example17}}{w^*=}
+\addConstraint{g(w)}{=0}
+\addConstraint{n(w)}{= 6}
+\addConstraint{L(w)+r(x)}{=Kw+p}
+\addConstraint{h(x)}{=0.}
+\end{argmini}
+
+\begin{mini}<b>
+{w}{f(w)+ R(w+6x)}
+{\label{eq:Example18}}{}
+\addConstraint{g(w)}{=0}
+\addConstraint{p(w)}{=0}
+\addConstraint{q(w)}{=0}
+\addConstraint{r(w)}{=0\labelOP{testLabel}}
+\addConstraint{n(w)}{= 6}
+\addConstraint{L(w)+r(x)}{=Kw+p}
+\addConstraint{h(x)}{=0.}
+\end{mini}
+
+\begin{mini!}|s|[2]<b>
+{w}{f(w)+ R(w+6x)\label{eq:ObjectiveExample3}}
+{\label{eq:Example3}}
+{w^*=}
+\addConstraint{g(w)}{=0 \label{eq:C1Example3}}
+\addConstraint{n(w)}{= 6 \label{eq:C2Example3}}
+\addConstraint{L(w)+r(x)}{=Kw+p \label{eq:C3Example3}}
+\addConstraint{h(x)}{=0.\label{eq:C4Example3}}
+\end{mini!}
+
+\end{document}

--- a/tagging-status/testfiles-compatible/pbalance/pbalance-01.pdftex.struct.xml
+++ b/tagging-status/testfiles-compatible/pbalance/pbalance-01.pdftex.struct.xml
@@ -1,0 +1,356 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.005"
+      rolemaps-to="Part"
+     >
+    <Title xmlns="http://iso.org/pdf2/ssn"
+       id="ID.006"
+      >
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.007"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextAlign="Center"
+        rolemaps-to="P"
+       >
+      <?MarkedContent page="1" ?>pbalance tagging test
+     </text>
+    </Title>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.008"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Center"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Some author
+    </text>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.009"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Center"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>May 20, 2016
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.010"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.011"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Lorem ipsum dolor sit amet, consectetueradipiscing elit. Ut purus elit, vestibulum ut,placerat ac, adipiscing vitae, felis. Curabi-tur dictum gravida mauris. Nam arcu libero,nonummy eget, consectetuer id, vulputate a,magna. Donec vehicula augue eu neque. Pel-lentesque habitant morbi tristique senectus etnetus et malesuada fames ac turpis egestas.Mauris ut leo. Cras viverra metus rhoncussem. Nulla et lectus vestibulum urna fringillaultrices. Phasellus eu tellus sit amet tortorgravida placerat. Integer sapien est, iaculis in,pretium quis, viverra ac, nunc. Praesent egetsem vel leo ultrices bibendum. Aenean fauci-bus. Morbi dolor nulla, malesuada eu, pulvi-nar at, mollis ac, nulla. Curabitur auctor sem-per nulla. Donec varius orci eget risus. Duisnibh mi, congue eu, accumsan eleifend, sagit-tis quis, diam. Duis eget orci sit amet orcidignissim rutrum.
+    </text>
+   </text-unit>
+   <Sect xmlns="http://iso.org/pdf2/ssn"
+      id="ID.012"
+     >
+    <section xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.013"
+       title="Using pbalance"
+       rolemaps-to="H1"
+      >
+     <section-number xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.014"
+        rolemaps-to="Span"
+       >
+      <?MarkedContent page="1" ?>1
+     </section-number>
+     <?MarkedContent page="1" ?>Usingpbalance
+    </section>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.015"
+       rolemaps-to="Part"
+      >
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.016"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextAlign="Justify"
+        rolemaps-to="P"
+       >
+      <?MarkedContent page="1" ?>Nam dui ligula, fringilla a, euismod sodales,sollicitudin vel, wisi. Morbi auctor lorem nonjusto. Nam lacus libero, pretium at, lobortisvitae, ultricies et, tellus. Donec aliquet, tor-tor sed accumsan bibendum, erat ligula ali-quet magna, vitae ornare odio metus a mi.Morbi ac orci et nisl hendrerit mollis. Suspen-disse ut massa. Cras nec ante. Pellentesquea nulla. Cum sociis natoque penatibus et ma-gnis dis parturient montes, nascetur ridiculusmus. Aliquam tincidunt urna. Nulla ullam-corper vestibulum turpis. Pellentesque cursusluctus mauris.
+     </text>
+    </text-unit>
+    <theorem-like xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.017"
+       rolemaps-to="Sect"
+      >
+     <Caption xmlns="http://iso.org/pdf2/ssn"
+        id="ID.018"
+       >
+      <?MarkedContent page="1" ?>Theorem
+      <Lbl xmlns="http://iso.org/pdf2/ssn"
+         id="ID.019"
+        >
+       <?MarkedContent page="1" ?>1.1
+      </Lbl>
+      <?MarkedContent page="1" ?>.
+     </Caption>
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.020"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.021"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Justify"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>Nulla malesuada porttitordiam. Donec felis erat, congue non, volutpat
+       <?MarkedContent page="1" ?>at, tincidunt tristique, libero. Vivamus viverrafermentum felis. Donec nonummy pellentesqueante. Phasellus adipiscing semper elit. Proinfermentum massa ac quam. Sed diam turpis,molestie vitae, placerat a, molestie nec, leo.Maecenas lacinia. Nam ipsum ligula, eleifendat, accumsan nec, suscipit a, ipsum. Morbiblandit ligula feugiat magna. Nunc eleifendconsequat lorem. Sed lacinia nulla vitae enim.Pellentesque tincidunt purus vel magna. Inte-ger non enim. Praesent euismod nunc eu pu-rus. Donec bibendum quam in tellus. Nullamcursus pulvinar lectus. Donec et mi. Nam vul-putate metus eu enim. Vestibulum pellentesquefelis eu massa.
+      </text>
+     </text-unit>
+    </theorem-like>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.022"
+       rolemaps-to="Part"
+      >
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.023"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextAlign="Justify"
+        rolemaps-to="P"
+       >
+      <?MarkedContent page="1" ?>Quisque ullamcorper placerat ipsum. Crasnibh. Morbi vel justo vitae lacus tincidunt ul-trices. Lorem ipsum dolor sit amet, consec-tetuer adipiscing elit. In hac habitasse pla-tea dictumst. Integer tempus convallis augue.Etiam facilisis. Nunc elementum fermentumwisi. Aenean placerat. Ut imperdiet, enim sedgravida sollicitudin, felis odio placerat quam,ac pulvinar elit purus eget enim. Nunc vitaetortor. Proin tempus nibh sit amet nisl. Viva-mus quis tortor vitae risus porta vehicula.
+     </text>
+    </text-unit>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.024"
+       rolemaps-to="Part"
+      >
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.025"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextAlign="Justify"
+        rolemaps-to="P"
+       >
+      <?MarkedContent page="1" ?>Consider the following drawing
+      <footnotemark xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.026"
+         rolemaps-to="Lbl"
+         referenced-as="2"
+        >
+        <?References objects="1" ?>
+       <?MarkedContent page="1" ?>
+       <Span xmlns="http://iso.org/pdf2/ssn"
+          id="ID.027"
+          xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+          Layout:TextPosition="Sup"
+         >
+        <?MarkedContent page="1" ?>1
+       </Span>
+       <?MarkedContent page="1" ?>
+      </footnotemark>
+      <?MarkedContent page="1" ?>
+      <footnote xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.028"
+         rolemaps-to="FENote"
+         referenced-as="1"
+        >
+        <?References objects="2" ?>
+       <footnotelabel xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.031"
+          rolemaps-to="Lbl"
+         >
+        <?MarkedContent page="1" ?>
+        <Span xmlns="http://iso.org/pdf2/ssn"
+           id="ID.032"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextPosition="Sup"
+          >
+         <?MarkedContent page="1" ?>1
+        </Span>
+        <?MarkedContent page="1" ?>
+       </footnotelabel>
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.029"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.030"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="1" ?>
+         <?MarkedContent page="1" ?>
+         <?MarkedContent page="1" ?>Etiam pede massa, dapibus vitae, rhoncus in, pla-cerat posuere, odio. Vestibulum luctus commodo lacus.Morbi lacus dui, tempor sed, euismod eget, condimen-tum at, tortor. Phasellus aliquet odio ac lacus temporfaucibus. Praesent sed sem. Praesent iaculis. Crasrhoncus tellus sed justo ullamcorper sagittis. Donecquis orci. Sed ut tortor quis tellus euismod tincidunt.Suspendisse congue nisl eu elit. Aliquam tortor diam,tempus id, tristique eget, sodales vel, nulla. Praesenttellus mi, condimentum sed, viverra at, consectetuerquis, lectus. In auctor vehicula orci. Sed pede sapien,euismod in, suscipit in, pharetra placerat, metus. Vi-vamus commodo dui non odio. Donec et felis.
+         <?MarkedContent page="1" ?>
+        </text>
+       </text-unit>
+      </footnote>
+      <?MarkedContent page="1" ?>.
+      <?MarkedContent page="1" ?>
+     </text>
+    </text-unit>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.040"
+       rolemaps-to="Part"
+      >
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.041"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextAlign="Justify"
+        rolemaps-to="P"
+       >
+      <?MarkedContent page="2" ?>Fusce mauris. Vestibulum luctus nibh at lec-tus. Sed bibendum, nulla a faucibus semper,leo velit ultricies tellus, ac venenatis arcu wisivel nisl. Vestibulum diam. Aliquam pellentes-que, augue quis sagittis posuere, turpis lacuscongue quam, in hendrerit risus eros eget felis.Maecenas eget erat in sapien mattis porttitor.Vestibulum porttitor. Nulla facilisi. Sed a tur-pis eu lacus commodo facilisis. Morbi fringilla,wisi in dignissim interdum, justo lectus sagittisdui, et vehicula libero dui cursus dui. Mauris
+      <?MarkedContent page="2" ?>tempor ligula sed lacus. Duis cursus enim utaugue. Cras ac magna. Cras nulla. Nulla ege-stas. Curabitur a leo. Quisque egestas wisieget nunc. Nam feugiat lacus vel est. Curabi-tur consectetuer.
+     </text>
+    </text-unit>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.042"
+       rolemaps-to="Part"
+      >
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.043"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextAlign="Justify"
+        rolemaps-to="P"
+       >
+      <?MarkedContent page="2" ?>As a consequence, we have
+      <footnotemark xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.044"
+         rolemaps-to="Lbl"
+         referenced-as="4"
+        >
+        <?References objects="3" ?>
+       <?MarkedContent page="2" ?>
+       <Span xmlns="http://iso.org/pdf2/ssn"
+          id="ID.045"
+          xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+          Layout:TextPosition="Sup"
+         >
+        <?MarkedContent page="2" ?>2
+       </Span>
+       <?MarkedContent page="2" ?>
+      </footnotemark>
+      <?MarkedContent page="2" ?>
+      <footnote xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.046"
+         rolemaps-to="FENote"
+         referenced-as="3"
+        >
+        <?References objects="4" ?>
+       <footnotelabel xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.049"
+          rolemaps-to="Lbl"
+         >
+        <?MarkedContent page="2" ?>
+        <Span xmlns="http://iso.org/pdf2/ssn"
+           id="ID.050"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextPosition="Sup"
+          >
+         <?MarkedContent page="2" ?>2
+        </Span>
+        <?MarkedContent page="2" ?>
+       </footnotelabel>
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.047"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.048"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="2" ?>
+         <?MarkedContent page="2" ?>
+         <?MarkedContent page="2" ?>Well, well! It appears in an unexpected place.
+         <?MarkedContent page="2" ?>
+        </text>
+       </text-unit>
+      </footnote>
+      <?MarkedContent page="2" ?>
+     </text>
+    </text-unit>
+    <theorem-like xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.051"
+       rolemaps-to="Sect"
+      >
+     <Caption xmlns="http://iso.org/pdf2/ssn"
+        id="ID.052"
+       >
+      <?MarkedContent page="2" ?>Lemma
+      <Lbl xmlns="http://iso.org/pdf2/ssn"
+         id="ID.053"
+        >
+       <?MarkedContent page="2" ?>1.2
+      </Lbl>
+      <?MarkedContent page="2" ?>.
+     </Caption>
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.054"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.055"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Justify"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="2" ?>Suspendisse vel felis. Ut loremlorem, interdum eu, tincidunt sit amet, lao-reet vitae, arcu. Aenean faucibus pede eu ante.Praesent enim elit, rutrum at, molestie non,nonummy vel, nisl. Ut lectus eros, malesuadasit amet, fermentum eu, sodales cursus, ma-gna. Donec eu purus. Quisque vehicula, urnased ultricies auctor, pede lorem egestas dui, etconvallis elit erat sed nulla. Donec luctus. Cu-rabitur et nunc. Aliquam dolor odio, commodopretium, ultricies non, pharetra in, velit. In-teger arcu est, nonummy in, fermentum fauci-bus, egestas vel, odio.
+      </text>
+     </text-unit>
+    </theorem-like>
+   </Sect>
+   <figures xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.003"
+      rolemaps-to="Sect"
+     >
+    <float xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.033"
+       rolemaps-to="Aside"
+      >
+     <Caption xmlns="http://iso.org/pdf2/ssn"
+        id="ID.037"
+       >
+      <Lbl xmlns="http://iso.org/pdf2/ssn"
+         id="ID.038"
+        >
+       <?MarkedContent page="2" ?>Figure 1:
+      </Lbl>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.039"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Center"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="2" ?>Example image
+      </text>
+     </Caption>
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.034"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.035"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Center"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="2" ?>
+       <Figure xmlns="http://iso.org/pdf2/ssn"
+          id="ID.036"
+          alt="example image"
+          xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+          Layout:BBox="{ 96.51314, 606.51578, 270.86314, 737.28205 }"
+         >
+        <?MarkedContent page="2" ?>
+       </Figure>
+       <?MarkedContent page="2" ?>
+      </text>
+     </text-unit>
+    </float>
+   </figures>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-compatible/pbalance/pbalance-01.struct.xml
+++ b/tagging-status/testfiles-compatible/pbalance/pbalance-01.struct.xml
@@ -1,0 +1,369 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.006"
+      rolemaps-to="Part"
+     >
+    <Title xmlns="http://iso.org/pdf2/ssn"
+       id="ID.007"
+      >
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.008"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextAlign="Center"
+        rolemaps-to="P"
+       >
+      <?MarkedContent page="1" ?>pbalance tagging test
+     </text>
+    </Title>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.009"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Center"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?> Some author
+    </text>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.010"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Center"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>May 20, 2016
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.011"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.012"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Ut purus elit, vestibulum ut, placerat ac, adipiscing vitae, felis. Curabitur dictum gravida mauris. Nam arcu libero, nonummy eget, consectetuer id, vulputate a, magna. Donec vehicula augue eu neque. Pel
+     <?MarkedContent page="1" ?>lentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Mauris ut leo. Cras viverra metus rhoncus sem. Nulla et lectus vestibulum urna fringilla ultrices. Phasellus eu tellus sit amet tortor gravida placerat. Integer sapien est, iaculis in, pretium quis, viverra ac, nunc. Praesent eget sem vel leo ultrices bibendum. Aenean fau
+     <?MarkedContent page="1" ?>cibus. Morbi dolor nulla, malesuada eu, pul
+     <?MarkedContent page="1" ?>vinar at, mollis ac, nulla. Curabitur auctor semper nulla. Donec varius orci eget risus. Duis nibh mi, congue eu, accumsan eleifend, sagittis quis, diam. Duis eget orci sit amet orci dignissim rutrum.
+    </text>
+   </text-unit>
+   <Sect xmlns="http://iso.org/pdf2/ssn"
+      id="ID.013"
+     >
+    <section xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.014"
+       title="Using pbalance"
+       rolemaps-to="H1"
+      >
+     <section-number xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.015"
+        rolemaps-to="Span"
+       >
+      <?MarkedContent page="1" ?>1 
+     </section-number>
+     <?MarkedContent page="1" ?>Using pbalance
+    </section>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.016"
+       rolemaps-to="Part"
+      >
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.017"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextAlign="Justify"
+        rolemaps-to="P"
+       >
+      <?MarkedContent page="1" ?>Nam dui ligula, fringilla a, euismod sodales, sollicitudin vel, wisi. Morbi auctor lorem non justo. Nam lacus libero, pretium at, lobortis vitae, ultricies et, tellus. Donec aliquet, tor
+      <?MarkedContent page="1" ?>tor sed accumsan bibendum, erat ligula ali
+      <?MarkedContent page="1" ?>quet magna, vitae ornare odio metus a mi. Morbi ac orci et nisl hendrerit mollis. Sus
+      <?MarkedContent page="1" ?>pendisse ut massa. Cras nec ante. Pellen
+      <?MarkedContent page="1" ?>tesque a nulla. Cum sociis natoque penati
+      <?MarkedContent page="1" ?>bus et magnis dis parturient montes, nascetur ridiculus mus. Aliquam tincidunt urna. Nulla ullamcorper vestibulum turpis. Pellentesque cursus luctus mauris.
+     </text>
+    </text-unit>
+    <theorem-like xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.018"
+       rolemaps-to="Sect"
+      >
+     <Caption xmlns="http://iso.org/pdf2/ssn"
+        id="ID.019"
+       >
+      <?MarkedContent page="1" ?>Theorem
+      <Lbl xmlns="http://iso.org/pdf2/ssn"
+         id="ID.020"
+        >
+       <?MarkedContent page="1" ?> 1.1
+      </Lbl>
+      <?MarkedContent page="1" ?>.
+     </Caption>
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.021"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.022"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Justify"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>Nulla malesuada porttitor diam. Donec felis erat, congue non, volut
+       <?MarkedContent page="1" ?>
+       <?MarkedContent page="1" ?>pat at, tincidunt tristique, libero. Vivamus viverra fermentum felis. Donec nonummy pel
+       <?MarkedContent page="1" ?>lentesque ante. Phasellus adipiscing semper elit. Proin fermentum massa ac quam. Sed diam turpis, molestie vitae, placerat a, mo
+       <?MarkedContent page="1" ?>lestie nec, leo. Maecenas lacinia. Nam ipsum ligula, eleifend at, accumsan nec, suscipit a, ipsum. Morbi blandit ligula feugiat magna. Nunc eleifend consequat lorem. Sed lacinia nulla vitae enim. Pellentesque tincidunt purus vel magna. Integer non enim. Praesent euis
+       <?MarkedContent page="1" ?>mod nunc eu purus. Donec bibendum quam in tellus. Nullam cursus pulvinar lectus. Donec et mi. Nam vulputate metus eu enim. Vestibu
+       <?MarkedContent page="1" ?>lum pellentesque felis eu massa.
+      </text>
+     </text-unit>
+    </theorem-like>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.023"
+       rolemaps-to="Part"
+      >
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.024"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextAlign="Justify"
+        rolemaps-to="P"
+       >
+      <?MarkedContent page="1" ?>Quisque ullamcorper placerat ipsum. Cras nibh. Morbi vel justo vitae lacus tincidunt ultrices. Lorem ipsum dolor sit amet, con
+      <?MarkedContent page="1" ?>sectetuer adipiscing elit. In hac habitasse platea dictumst. Integer tempus convallis au
+      <?MarkedContent page="1" ?>gue. Etiam facilisis. Nunc elementum fer
+      <?MarkedContent page="1" ?>mentum wisi. Aenean placerat. Ut imperdiet, enim sed gravida sollicitudin, felis odio plac
+      <?MarkedContent page="1" ?>erat quam, ac pulvinar elit purus eget enim. Nunc vitae tortor. Proin tempus nibh sit amet nisl. Vivamus quis tortor vitae risus porta ve
+      <?MarkedContent page="1" ?>hicula.
+     </text>
+    </text-unit>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.025"
+       rolemaps-to="Part"
+      >
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.026"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextAlign="Justify"
+        rolemaps-to="P"
+       >
+      <?MarkedContent page="1" ?>Consider the following drawing
+      <footnotemark xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.027"
+         rolemaps-to="Lbl"
+         referenced-as="2"
+        >
+        <?References objects="1" ?>
+       <Span xmlns="http://iso.org/pdf2/ssn"
+          id="ID.028"
+          xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+          Layout:TextPosition="Sup"
+         >
+        <?MarkedContent page="1" ?>1
+       </Span>
+      </footnotemark>
+      <footnote xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.029"
+         rolemaps-to="FENote"
+         referenced-as="1"
+        >
+        <?References objects="2" ?>
+       <footnotelabel xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.032"
+          rolemaps-to="Lbl"
+         >
+        <Span xmlns="http://iso.org/pdf2/ssn"
+           id="ID.033"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextPosition="Sup"
+          >
+         <?MarkedContent page="1" ?>1
+        </Span>
+       </footnotelabel>
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.030"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.031"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="1" ?>Etiam pede massa, dapibus vitae, rhoncus in, placerat posuere, odio. Vestibulum luctus commodo lacus. Morbi lacus dui, tempor sed, euismod eget, condimentum at, tortor. Phasellus aliquet odio ac la
+         <?MarkedContent page="1" ?>cus tempor faucibus. Praesent sed sem. Praesent iac
+         <?MarkedContent page="1" ?>ulis. Cras rhoncus tellus sed justo ullamcorper sagittis. Donec quis orci. Sed ut tortor quis tellus euismod tin
+         <?MarkedContent page="1" ?>cidunt. Suspendisse congue nisl eu elit. Aliquam tor
+         <?MarkedContent page="1" ?>tor diam, tempus id, tristique eget, sodales vel, nulla. Praesent tellus mi, condimentum sed, viverra at, con
+         <?MarkedContent page="1" ?>sectetuer quis, lectus. In auctor vehicula orci. Sed pede sapien, euismod in, suscipit in, pharetra placerat, 
+         <?MarkedContent page="2" ?>metus. Vivamus commodo dui non odio. Donec et felis.
+        </text>
+       </text-unit>
+      </footnote>
+      <?MarkedContent page="1" ?>. 
+     </text>
+    </text-unit>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.041"
+       rolemaps-to="Part"
+      >
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.042"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextAlign="Justify"
+        rolemaps-to="P"
+       >
+      <?MarkedContent page="2" ?>Fusce mauris. Vestibulum luctus nibh at lectus. Sed bibendum, nulla a faucibus sem
+      <?MarkedContent page="2" ?>per, leo velit ultricies tellus, ac venenatis arcu wisi vel nisl. Vestibulum diam. Aliquam pel
+      <?MarkedContent page="2" ?>lentesque, augue quis sagittis posuere, turpis lacus congue quam, in hendrerit risus eros eget felis. Maecenas eget erat in sapien mattis port
+      <?MarkedContent page="2" ?>titor. Vestibulum porttitor. Nulla facilisi. Sed a turpis eu lacus commodo facilisis. Morbi fringilla, wisi in dignissim interdum, justo lec
+      <?MarkedContent page="2" ?>
+      <?MarkedContent page="2" ?>tus sagittis dui, et vehicula libero dui cursus dui. Mauris tempor ligula sed lacus. Duis cur
+      <?MarkedContent page="2" ?>sus enim ut augue. Cras ac magna. Cras nulla. Nulla egestas. Curabitur a leo. Quisque eges
+      <?MarkedContent page="2" ?>tas wisi eget nunc. Nam feugiat lacus vel est. Curabitur consectetuer.
+     </text>
+    </text-unit>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.043"
+       rolemaps-to="Part"
+      >
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.044"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextAlign="Justify"
+        rolemaps-to="P"
+       >
+      <?MarkedContent page="2" ?>As a consequence, we have
+      <footnotemark xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.045"
+         rolemaps-to="Lbl"
+         referenced-as="4"
+        >
+        <?References objects="3" ?>
+       <Span xmlns="http://iso.org/pdf2/ssn"
+          id="ID.046"
+          xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+          Layout:TextPosition="Sup"
+         >
+        <?MarkedContent page="2" ?>2
+       </Span>
+      </footnotemark>
+      <footnote xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.047"
+         rolemaps-to="FENote"
+         referenced-as="3"
+        >
+        <?References objects="4" ?>
+       <footnotelabel xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.050"
+          rolemaps-to="Lbl"
+         >
+        <Span xmlns="http://iso.org/pdf2/ssn"
+           id="ID.051"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextPosition="Sup"
+          >
+         <?MarkedContent page="2" ?>2
+        </Span>
+       </footnotelabel>
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.048"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.049"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="2" ?>Well, well! It appears in an unexpected place.
+        </text>
+       </text-unit>
+      </footnote>
+     </text>
+    </text-unit>
+    <theorem-like xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.052"
+       rolemaps-to="Sect"
+      >
+     <Caption xmlns="http://iso.org/pdf2/ssn"
+        id="ID.053"
+       >
+      <?MarkedContent page="2" ?>Lemma
+      <Lbl xmlns="http://iso.org/pdf2/ssn"
+         id="ID.054"
+        >
+       <?MarkedContent page="2" ?> 1.2
+      </Lbl>
+      <?MarkedContent page="2" ?>.
+     </Caption>
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.055"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.056"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Justify"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="2" ?>Suspendisse vel felis. Ut lorem lorem, interdum eu, tincidunt sit amet, laoreet vitae, arcu. Aenean faucibus pede eu ante. Praesent enim elit, rutrum at, molestie non, nonummy vel, nisl. Ut lectus eros, male
+       <?MarkedContent page="2" ?>suada sit amet, fermentum eu, sodales cursus, magna. Donec eu purus. Quisque vehicula, urna sed ultricies auctor, pede lorem egestas dui, et convallis elit erat sed nulla. Donec luc
+       <?MarkedContent page="2" ?>tus. Curabitur et nunc. Aliquam dolor odio, commodo pretium, ultricies non, pharetra in, velit. Integer arcu est, nonummy in, fermen
+       <?MarkedContent page="2" ?>tum faucibus, egestas vel, odio.
+      </text>
+     </text-unit>
+    </theorem-like>
+   </Sect>
+   <figures xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.004"
+      rolemaps-to="Sect"
+     >
+    <float xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.034"
+       rolemaps-to="Aside"
+      >
+     <Caption xmlns="http://iso.org/pdf2/ssn"
+        id="ID.038"
+       >
+      <Lbl xmlns="http://iso.org/pdf2/ssn"
+         id="ID.039"
+        >
+       <?MarkedContent page="2" ?>Figure 1: 
+      </Lbl>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.040"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Center"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="2" ?>Example image
+      </text>
+     </Caption>
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.035"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.036"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Center"
+         rolemaps-to="P"
+        >
+       <Figure xmlns="http://iso.org/pdf2/ssn"
+          id="ID.037"
+          alt="example image"
+          xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+          Layout:BBox="{ 96.51314, 606.51578, 270.86314, 737.28205 }"
+         >
+        <?MarkedContent page="2" ?>
+       </Figure>
+      </text>
+     </text-unit>
+    </float>
+   </figures>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-compatible/pbalance/pbalance-01.tex
+++ b/tagging-status/testfiles-compatible/pbalance/pbalance-01.tex
@@ -1,0 +1,50 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on
+  }
+\documentclass[11pt,a4paper,twocolumn]{article}
+\usepackage[top=105pt, bottom=75pt, left=75pt, right=75pt]{geometry}
+\usepackage{graphicx}
+\usepackage{pbalance}
+\usepackage{lipsum}
+
+\newtheorem{thm}{Theorem}[section]
+\newtheorem{lem}[thm]{Lemma}
+
+\title{pbalance tagging test}
+\author{Some author}
+
+\begin{document}
+\maketitle
+
+\lipsum[1]
+
+\section{Using \texttt{pbalance}}
+
+\lipsum[2]
+\begin{thm}
+  \lipsum[3]
+\end{thm}
+
+\lipsum[4]
+
+Consider the following drawing\footnote{\lipsum[21]}.
+\begin{figure}[ht!]
+  \centering
+  \includegraphics[alt=example image,width=0.8\columnwidth]{example-image}
+  \caption{Example image}
+\end{figure}
+
+\lipsum[5]
+
+As a consequence, we have\footnote{Well, well!  It appears in an
+  unexpected place.}
+
+\begin{lem}
+  \lipsum[6]
+\end{lem}
+
+\end{document}

--- a/tagging-status/testfiles-compatible/titlepic/titlepic-01.pdftex.struct.xml
+++ b/tagging-status/testfiles-compatible/titlepic/titlepic-01.pdftex.struct.xml
@@ -1,0 +1,91 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.005"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.006"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Center"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Example
+    </text>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.007"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Center"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+    </text>
+    <Table xmlns="http://iso.org/pdf2/ssn"
+       id="ID.008"
+      >
+     <TR xmlns="http://iso.org/pdf2/ssn"
+        id="ID.009"
+       >
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.010"
+        >
+       <?MarkedContent page="1" ?>John Doe
+      </TD>
+     </TR>
+    </Table>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.011"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+    </text>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.012"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Center"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>May 20, 2016
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.013"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.014"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Center"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+     <Figure xmlns="http://iso.org/pdf2/ssn"
+        id="ID.015"
+        alt="some alt text"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:BBox="{ 133.76837, 207.5426, 477.47946, 465.33249 }"
+       >
+      <?MarkedContent page="1" ?>
+     </Figure>
+     <?MarkedContent page="1" ?>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.016"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.017"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="2" ?>Some text
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-compatible/titlepic/titlepic-01.struct.xml
+++ b/tagging-status/testfiles-compatible/titlepic/titlepic-01.struct.xml
@@ -1,0 +1,87 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.006"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.007"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Center"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Example
+    </text>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.008"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Center"
+       rolemaps-to="P"
+      >
+    </text>
+    <Table xmlns="http://iso.org/pdf2/ssn"
+       id="ID.009"
+      >
+     <TR xmlns="http://iso.org/pdf2/ssn"
+        id="ID.010"
+       >
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.011"
+        >
+       <?MarkedContent page="1" ?>John Doe
+      </TD>
+     </TR>
+    </Table>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.012"
+       rolemaps-to="P"
+      >
+    </text>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.013"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Center"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>May 20, 2016
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.014"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.015"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Center"
+       rolemaps-to="P"
+      >
+     <Figure xmlns="http://iso.org/pdf2/ssn"
+        id="ID.016"
+        alt="some alt text"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:BBox="{ 133.76837, 207.4539, 477.47946, 465.24379 }"
+       >
+      <?MarkedContent page="1" ?>
+     </Figure>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.017"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.018"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="2" ?>Some text
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-compatible/titlepic/titlepic-01.tex
+++ b/tagging-status/testfiles-compatible/titlepic/titlepic-01.tex
@@ -1,0 +1,22 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on
+  }
+% Pass titlepage to the article class
+\documentclass[titlepage]{article}
+% Centre the picture and the title vertically with cc (only works with titlepage mode)
+\usepackage[cc]{titlepic}
+% For \includegraphics
+\usepackage{graphicx}
+\title{Example}
+\author{John Doe}
+\date{\today}
+% Now, put a picture on the title page!
+\titlepic{\includegraphics[width=\textwidth,alt=some alt text]{example-image}}
+\begin{document}
+\maketitle
+Some text
+\end{document}

--- a/tagging-status/testfiles-compatible/versions/versions-01.pdftex.struct.xml
+++ b/tagging-status/testfiles-compatible/versions/versions-01.pdftex.struct.xml
@@ -1,0 +1,170 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.005"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.006"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Text for the short
+     <footnotemark xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.007"
+        rolemaps-to="Lbl"
+        referenced-as="2"
+       >
+       <?References objects="1" ?>
+      <?MarkedContent page="1" ?>
+      <Span xmlns="http://iso.org/pdf2/ssn"
+         id="ID.008"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextPosition="Sup"
+        >
+       <?MarkedContent page="1" ?>1
+      </Span>
+      <?MarkedContent page="1" ?>
+     </footnotemark>
+     <?MarkedContent page="1" ?>
+     <footnote xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.009"
+        rolemaps-to="FENote"
+        referenced-as="1"
+       >
+       <?References objects="2" ?>
+      <footnotelabel xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.012"
+         rolemaps-to="Lbl"
+        >
+       <?MarkedContent page="1" ?>
+       <Span xmlns="http://iso.org/pdf2/ssn"
+          id="ID.013"
+          xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+          Layout:TextPosition="Sup"
+         >
+        <?MarkedContent page="1" ?>1
+       </Span>
+       <?MarkedContent page="1" ?>
+      </footnotelabel>
+      <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.010"
+         rolemaps-to="Part"
+        >
+       <text xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.011"
+          xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+          Layout:TextAlign="Justify"
+          rolemaps-to="P"
+         >
+        <?MarkedContent page="1" ?>
+        <?MarkedContent page="1" ?>
+        <?MarkedContent page="1" ?>Some footnote
+        <?MarkedContent page="1" ?>
+       </text>
+      </text-unit>
+     </footnote>
+     <?MarkedContent page="1" ?>version of the paper.
+     <footnotemark xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.014"
+        rolemaps-to="Lbl"
+        referenced-as="4"
+       >
+       <?References objects="3" ?>
+      <?MarkedContent page="1" ?>
+      <Span xmlns="http://iso.org/pdf2/ssn"
+         id="ID.015"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextPosition="Sup"
+        >
+       <?MarkedContent page="1" ?>2
+      </Span>
+      <?MarkedContent page="1" ?>
+     </footnotemark>
+     <?MarkedContent page="1" ?>
+     <footnote xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.016"
+        rolemaps-to="FENote"
+        referenced-as="3"
+       >
+       <?References objects="4" ?>
+      <footnotelabel xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.019"
+         rolemaps-to="Lbl"
+        >
+       <?MarkedContent page="1" ?>
+       <Span xmlns="http://iso.org/pdf2/ssn"
+          id="ID.020"
+          xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+          Layout:TextPosition="Sup"
+         >
+        <?MarkedContent page="1" ?>2
+       </Span>
+       <?MarkedContent page="1" ?>
+      </footnotelabel>
+      <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.017"
+         rolemaps-to="Part"
+        >
+       <text xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.018"
+          xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+          Layout:TextAlign="Justify"
+          rolemaps-to="P"
+         >
+        <?MarkedContent page="1" ?>
+        <?MarkedContent page="1" ?>
+        <?MarkedContent page="1" ?>Show this
+        <?MarkedContent page="1" ?>
+       </text>
+      </text-unit>
+     </footnote>
+     <?MarkedContent page="1" ?>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.021"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.022"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Punctuation works correctly.redact
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.023"
+        title="math"
+        af="tag-AFfile1.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="tag-AFfile1.tex" xmlns="">
+       $>$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>>
+     </Formula>
+     <?MarkedContent page="1" ?>This information was withdrawn
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.024"
+        title="math"
+        af="tag-AFfile2.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="tag-AFfile2.tex" xmlns="">
+       $&lt;$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>&lt;
+     </Formula>
+     <?MarkedContent page="1" ?>redact
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-compatible/versions/versions-01.struct.xml
+++ b/tagging-status/testfiles-compatible/versions/versions-01.struct.xml
@@ -1,0 +1,156 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.006"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.007"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Text for the short
+     <footnotemark xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.008"
+        rolemaps-to="Lbl"
+        referenced-as="2"
+       >
+       <?References objects="1" ?>
+      <Span xmlns="http://iso.org/pdf2/ssn"
+         id="ID.009"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextPosition="Sup"
+        >
+       <?MarkedContent page="1" ?>1
+      </Span>
+     </footnotemark>
+     <footnote xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.010"
+        rolemaps-to="FENote"
+        referenced-as="1"
+       >
+       <?References objects="2" ?>
+      <footnotelabel xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.013"
+         rolemaps-to="Lbl"
+        >
+       <Span xmlns="http://iso.org/pdf2/ssn"
+          id="ID.014"
+          xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+          Layout:TextPosition="Sup"
+         >
+        <?MarkedContent page="1" ?>1
+       </Span>
+      </footnotelabel>
+      <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.011"
+         rolemaps-to="Part"
+        >
+       <text xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.012"
+          xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+          Layout:TextAlign="Justify"
+          rolemaps-to="P"
+         >
+        <?MarkedContent page="1" ?>Some footnote
+       </text>
+      </text-unit>
+     </footnote>
+     <?MarkedContent page="1" ?>version of the paper.
+     <footnotemark xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.015"
+        rolemaps-to="Lbl"
+        referenced-as="4"
+       >
+       <?References objects="3" ?>
+      <Span xmlns="http://iso.org/pdf2/ssn"
+         id="ID.016"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextPosition="Sup"
+        >
+       <?MarkedContent page="1" ?>2
+      </Span>
+     </footnotemark>
+     <footnote xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.017"
+        rolemaps-to="FENote"
+        referenced-as="3"
+       >
+       <?References objects="4" ?>
+      <footnotelabel xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.020"
+         rolemaps-to="Lbl"
+        >
+       <Span xmlns="http://iso.org/pdf2/ssn"
+          id="ID.021"
+          xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+          Layout:TextPosition="Sup"
+         >
+        <?MarkedContent page="1" ?>2
+       </Span>
+      </footnotelabel>
+      <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.018"
+         rolemaps-to="Part"
+        >
+       <text xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.019"
+          xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+          Layout:TextAlign="Justify"
+          rolemaps-to="P"
+         >
+        <?MarkedContent page="1" ?>Show this
+       </text>
+      </text-unit>
+     </footnote>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.022"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.023"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Punctuation works correctly. 
+     <?MarkedContent page="1" ?>redact
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.024"
+        title="math"
+        af="tag-AFfile1.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="tag-AFfile1.tex" xmlns="">
+       $>$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>>
+     </Formula>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>This information was withdrawn
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.025"
+        title="math"
+        af="tag-AFfile2.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="tag-AFfile2.tex" xmlns="">
+       $&lt;$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>&lt;
+     </Formula>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>redact
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-compatible/versions/versions-01.tex
+++ b/tagging-status/testfiles-compatible/versions/versions-01.tex
@@ -1,0 +1,33 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on,
+  }
+\documentclass{article}
+\usepackage{versions}
+
+\title{versions tagging test}
+
+\begin{document}
+
+\includeversion{abridged}
+\excludeversion{unabridged}
+\markversion{redact}
+Text for the
+\begin{abridged}
+short\footnote{Some footnote}%
+\end{abridged}
+\begin{unabridged}
+long and really longwinded, opaque and boring%
+\footnote{Another footnote}%
+\end{unabridged}
+version of the paper.\footnote{\processifversion{abridged}{Show this}\processifversion{unabridged}{Don't show this}}
+
+Punctuation works correctly\begin{unabridged}
+because sphack is used\end{unabridged}.
+\begin{comment} This is deleted by default. \end{comment}
+\begin{redact}This information was withdrawn\end{redact}
+
+\end{document}

--- a/tagging-status/testfiles-incompatible-mathml/pb-diagram/pb-diagram-01-BAD.pdftex.struct.xml
+++ b/tagging-status/testfiles-incompatible-mathml/pb-diagram/pb-diagram-01-BAD.pdftex.struct.xml
@@ -1,0 +1,37 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.02"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.05"
+      rolemaps-to="Part"
+     >
+    <Formula xmlns="http://iso.org/pdf2/ssn"
+       id="ID.06"
+       title="equation*"
+       af="mathml-1.xml tag-AFfile1.tex"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:Placement="Block"
+      >
+      <AssociatedFile name="mathml-1.xml" xmlns="">
+      <math display="block" xmlns="http://www.w3.org/1998/Math/MathML"> <mspace depth="0.2em" height="0.8em" mathbackground="currentColor" width="0.000pt"/> <mspace width="9.121pt"/> <mi> <mglyph/> </mi> <mspace depth="0.2em" height="0.8em" mathbackground="currentColor" width="0.000pt"/> <mspace width="89.417pt"/> <mspace depth="0.2em" height="0.8em" mathbackground="currentColor" width="0.000pt"/> <mspace width="8.897pt"/> </math>
+      </AssociatedFile>
+      <AssociatedFile name="tag-AFfile1.tex" xmlns="">
+      \begin {equation*}\begin {diagram} \node {A} \arrow {e,t}{a} \arrow {s,l}{c} \arrow {ese} \node {B^*} \arrow {e,t}{b^*} \node {C} \arrow {s,r}{d} \arrow {wsw} \\ \node {D} \arrow [2]{e,b}{e} \node [2]{E} \end {diagram}\end {equation*}
+      </AssociatedFile>
+     <?MarkedContent page="1" ?>
+     <Figure xmlns="http://iso.org/pdf2/ssn"
+        id="ID.07"
+        alt="picture environment"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:BBox="{ 260.67068, 648.30353, 260.67068, 648.30353 }"
+       >
+      <?MarkedContent page="1" ?>AB∗CDE[TEXT]
+     </Figure>
+     <?MarkedContent page="1" ?>
+    </Formula>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-incompatible-mathml/pb-diagram/pb-diagram-01-BAD.struct.xml
+++ b/tagging-status/testfiles-incompatible-mathml/pb-diagram/pb-diagram-01-BAD.struct.xml
@@ -1,0 +1,37 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.02"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.06"
+      rolemaps-to="Part"
+     >
+    <Formula xmlns="http://iso.org/pdf2/ssn"
+       id="ID.07"
+       title="equation*"
+       af="mathml-1.xml tag-AFfile1.tex"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:Placement="Block"
+      >
+      <AssociatedFile name="mathml-1.xml" xmlns="">
+      <math display="block" xmlns="http://www.w3.org/1998/Math/MathML"> <mspace depth="0.2em" height="0.8em" mathbackground="currentColor" width="0.000pt"/> <mspace width="9.121pt"/> <mi> <mglyph/> </mi> <mspace depth="0.2em" height="0.8em" mathbackground="currentColor" width="0.000pt"/> <mspace width="89.417pt"/> <mspace depth="0.2em" height="0.8em" mathbackground="currentColor" width="0.000pt"/> <mspace width="8.897pt"/> </math>
+      </AssociatedFile>
+      <AssociatedFile name="tag-AFfile1.tex" xmlns="">
+      \begin {equation*}\begin {diagram} \node {A} \arrow {e,t}{a} \arrow {s,l}{c} \arrow {ese} \node {B^*} \arrow {e,t}{b^*} \node {C} \arrow {s,r}{d} \arrow {wsw} \\ \node {D} \arrow [2]{e,b}{e} \node [2]{E} \end {diagram}\end {equation*}
+      </AssociatedFile>
+     <?MarkedContent page="1" ?>
+     <Figure xmlns="http://iso.org/pdf2/ssn"
+        id="ID.08"
+        alt="picture environment"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:BBox="{ 261.02724, 648.32571, 261.02724, 648.32571 }"
+       >
+      <?MarkedContent page="1" ?>𝐴𝐵∗𝐶𝐷𝐸[TEXT]
+     </Figure>
+     <?MarkedContent page="1" ?>
+    </Formula>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-incompatible-mathml/pb-diagram/pb-diagram-01-BAD.tex
+++ b/tagging-status/testfiles-incompatible-mathml/pb-diagram/pb-diagram-01-BAD.tex
@@ -1,0 +1,27 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on,
+  }
+\documentclass{article}
+\ifdefined\Uchar
+  \usepackage{unicode-math}
+\fi
+\usepackage{pb-diagram}
+
+\title{pb-diagram tagging test}
+
+\begin{document}
+
+\[
+\begin{diagram}
+\node{A} \arrow{e,t}{a} \arrow{s,l}{c} \arrow{ese}
+\node{B^*} \arrow{e,t}{b^*}
+\node{C} \arrow{s,r}{d} \arrow{wsw} \\
+\node{D} \arrow[2]{e,b}{e} \node[2]{E}
+\end{diagram}
+\]
+
+\end{document}

--- a/tagging-status/testfiles-partial/setouterhbox/setouterhbox-01.pdftex.struct.xml
+++ b/tagging-status/testfiles-partial/setouterhbox/setouterhbox-01.pdftex.struct.xml
@@ -1,0 +1,1 @@
+<run-error code="1" />

--- a/tagging-status/testfiles-partial/setouterhbox/setouterhbox-01.struct.xml
+++ b/tagging-status/testfiles-partial/setouterhbox/setouterhbox-01.struct.xml
@@ -1,0 +1,78 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.006"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.007"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Start"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>blub blub 
+     <Link xmlns="http://iso.org/pdf2/ssn"
+        id="ID.008"
+       >
+      <?MarkedContent page="1" ?>http://this.is.a.very.long.host.name/followed/by/a/very_long_long_long_path.html
+      <?ReferencedObject type="Annot" page="1" ?>
+      <?ReferencedObject type="Annot" page="1" ?>
+     </Link>
+    </text>
+   </text-unit>
+   <Link xmlns="http://iso.org/pdf2/ssn"
+      id="ID.009"
+     >
+    <?MarkedContent page="1" ?>http://this.is.a.very.long.host.name/followed/by/a/very_long_long_long_path.html
+    <?ReferencedObject type="Annot" page="1" ?>
+   </Link>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.010"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.011"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Start"
+       rolemaps-to="P"
+      >
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.012"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.013"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Start"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>blub blub 
+     <Link xmlns="http://iso.org/pdf2/ssn"
+        id="ID.014"
+       >
+      <?MarkedContent page="1" ?>http://this.is.a.very.long.host.name/followed/by/a/very_long_long_long_path.html
+      <?ReferencedObject type="Annot" page="1" ?>
+      <?ReferencedObject type="Annot" page="1" ?>
+     </Link>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.015"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.016"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Start"
+       rolemaps-to="P"
+      >
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-partial/setouterhbox/setouterhbox-01.tex
+++ b/tagging-status/testfiles-partial/setouterhbox/setouterhbox-01.tex
@@ -1,0 +1,43 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on
+  }
+\documentclass[a5paper]{article}
+\usepackage{hyperref}
+\usepackage{setouterhbox}
+
+\newsavebox{\testbox}
+
+\setlength{\parindent}{0pt}
+\setlength{\parskip}{2em}
+
+\title{setouterhbox tagging test}
+
+\begin{document}
+\raggedright
+
+% good
+blub blub
+\url{http://this.is.a.very.long.host.name/followed/%
+by/a/very_long_long_long_path.html}%
+
+% not good
+\sbox\testbox{%
+  blub blub
+  \url{http://this.is.a.very.long.host.name/followed/%
+  by/a/very_long_long_long_path.html}%
+}%
+\unhbox\testbox
+
+% good
+\begin{setouterhbox}{\testbox}%
+blub blub
+\url{http://this.is.a.very.long.host.name/followed/%
+by/a/very_long_long_long_path.html}%
+\end{setouterhbox}
+\unhbox\testbox
+
+\end{document}


### PR DESCRIPTION
Lists filedate, pdfcol, pdfsync, settobox, zref-dotfill, zref-hyperref, and zwgetfdate as compatible without tests.

Lists numerica-plus, optidef, pbalance, titlepic, and versions as compatible with tests.

Lists pb-diagram as incompatible with a test.

Lists setouterhbox as partially-compatible with a test.