### PR TITLE
status updates

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -3757,6 +3757,7 @@
 
 - name: csvsimple
   type: package
+  subpackages: [csvsimple-l3,csvsimple-legacy]
   status: partially-compatible
   included-in: [tlc3, arxiv01, ol0.1]
   priority: 2
@@ -11634,11 +11635,11 @@
 
 - name: pxgreeks
   type: package
-  status: unchecked
+  status: partially-compatible
   priority: 9
   tests: false
-  tasks: needs tests
-  updated: 2026-02-03
+  comments: "Incompatible with unicode-math."
+  updated: 2026-07-01
 
 - name: pxjahyper
   type: package
@@ -12773,21 +12774,21 @@
 
 - name: simplewick
   type: package
-  status: unchecked
+  status: partially-compatible
   included-in: [ol0.02]
   priority: 9
-  tests: false
-  tasks: needs tests
-  updated: 2026-01-23
+  tests: true
+  comments: "No luamml support."
+  updated: 2026-07-01
 
 - name: simpler-wick
   type: package
-  status: unchecked
+  status: partially-compatible
   included-in: [ol0.02]
   priority: 9
-  tests: false
-  tasks: needs tests
-  updated: 2026-01-23
+  tests: true
+  comments: "No luamml support."
+  updated: 2026-07-01
 
 - name: sistyle
   type: package
@@ -13016,12 +13017,12 @@
 
 - name: srcltx
   type: package
-  status: unchecked
+  status: compatible
   included-in: [ol0.1]
   priority: 9
   tests: false
-  tasks: needs tests
-  updated: 2026-01-23
+  comments: "Not useful with pdflatex or lualatex."
+  updated: 2026-07-01
 
 - name: stabular
   type: package
@@ -13169,9 +13170,8 @@
   priority: 2
   comments: Issue when both hyperref and listoffigures are used.
   issues: [85]
-  tests: false
-  tasks: needs tests
-  updated: 2024-07-06
+  tests: true
+  updated: 2026-07-01
 
 - name: subdepth
   type: package
@@ -14472,12 +14472,12 @@
 - name: tweaklist
   ctan-pkg: moderncv
   type: package
-  status: unchecked
+  status: currently-incompatible
   included-in: [ol0.1]
   priority: 9
-  tests: false
-  tasks: needs tests
-  updated: 2026-01-23
+  tests: true
+  comments: "Modifications of list environments are overwritten by the tagging code."
+  updated: 2026-07-01
 
 - name: twemojis
   type: package
@@ -14527,11 +14527,11 @@
 
 - name: txgreeks
   type: package
-  status: unchecked
+  status: partially-compatible
   priority: 9
   tests: false
-  tasks: needs tests
-  updated: 2026-02-03
+  comments: "Incompatible with unicode-math."
+  updated: 2026-07-01
 
 - name: txuprcal
   type: package
@@ -14709,12 +14709,12 @@
 
 - name: units
   type: package
-  status: unchecked
+  status: currently-incompatible
   included-in: [ol0.1]
   priority: 9
-  tests: false
-  tasks: needs tests
-  updated: 2026-01-23
+  tests: true
+  comments: "No luamml support. Depends on incompatible nicefrac."
+  updated: 2026-07-01
 
 - name: universalis
   type: package
@@ -14840,13 +14840,13 @@
 
 - name: vector
   type: package
-  status: unchecked
+  status: partially-compatible
   included-in: [ol0.02]
   priority: 9
-  tests: false
-  tasks: needs tests
-  comments: "Not distributed with texlive."
-  updated: 2026-01-23
+  tests: true
+  comments: "Not distributed with texlive. No luamml support for `\\uvec` and
+             `\\uuvec` with `wavy` package option."
+  updated: 2026-07-01
 
 - name: venndiagram
   type: package
@@ -14902,15 +14902,16 @@
 
 - name: verse
   type: package
-  status: compatible
+  status: partially-compatible
   included-in: [ol0.02]
   priority: 9
-  comments: firstaid is required for the fix of issue 49
+  comments: "firstaid is required for the fix of issue 49. `\\poemtitle` errors.
+             `\\flagverse` and line numbers not tagged ideally."
+  issues: [1468,1469]
   closed-issues: [49]
-  tests: false
-  tasks: needs tests
+  tests: true
   package-repository: "https://github.com/LaTeX-Package-Repositories/herries-press"
-  updated: 2024-07-06
+  updated: 2026-07-01
 
 - name: version
   type: package
@@ -14958,12 +14959,11 @@
 
 - name: vmargin
   type: package
-  status: unchecked
+  status: compatible
   included-in: [ol0.1]
   priority: 9
   tests: false
-  tasks: needs tests
-  updated: 2026-01-23
+  updated: 2026-07-01
 
 - name: vruler
   type: package

--- a/tagging-status/testfiles-incompatible-mathml/units/units-01-BAD.pdftex.struct.xml
+++ b/tagging-status/testfiles-incompatible-mathml/units/units-01-BAD.pdftex.struct.xml
@@ -1,0 +1,593 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.005"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.006"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>m
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.007"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.008"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.009"
+        title="math"
+        af="mathml-1.xml tag-AFfile1.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-1.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mi mathvariant="normal">m</mi> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile1.tex" xmlns="">
+       $\unit {m}$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>m
+     </Formula>
+     <?MarkedContent page="1" ?>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.010"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.011"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>1m
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.012"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.013"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.014"
+        title="math"
+        af="mathml-2.xml tag-AFfile2.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-2.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mn>1</mn> <mspace width="0.167em"/> <mi mathvariant="normal">m</mi> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile2.tex" xmlns="">
+       $\unit [1]{m}$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>1m
+     </Formula>
+     <?MarkedContent page="1" ?>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.015"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.016"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.017"
+        title="math"
+        af="mathml-3.xml tag-AFfile3.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-3.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mtext>m</mtext> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile3.tex" xmlns="">
+       $\relax \mbox {\fontsize \sf@size \z@ \selectfont {m}}$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>m
+     </Formula>
+     <?MarkedContent page="1" ?>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.018"
+        title="math"
+        af="mathml-4.xml tag-AFfile4.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-4.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mspace width="-0.111em"/> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile4.tex" xmlns="">
+       $\relax \mkern -2mu$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>
+     </Formula>
+     <?MarkedContent page="1" ?>/
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.019"
+        title="math"
+        af="mathml-5.xml tag-AFfile5.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-5.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mspace width="-0.056em"/> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile5.tex" xmlns="">
+       $\relax \mkern -1mu$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>
+     </Formula>
+     <?MarkedContent page="1" ?>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.020"
+        title="math"
+        af="mathml-6.xml tag-AFfile6.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-6.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mtext>s</mtext> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile6.tex" xmlns="">
+       $\relax \mbox {\fontsize \sf@size \z@ \selectfont {s}}$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>s
+     </Formula>
+     <?MarkedContent page="1" ?>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.021"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.022"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.023"
+        title="math"
+        af="mathml-7.xml tag-AFfile7.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-7.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mtext> <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="false" scriptlevel="1"> <mi mathvariant="normal">m</mi> </mstyle> </math> </mtext> <mspace width="-0.111em"/> <mo lspace="0" rspace="0">/</mo> <mspace width="-0.056em"/> <mrow> <mstyle displaystyle="false" scriptlevel="1"/> <mi mathvariant="normal">s</mi> </mrow> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile7.tex" xmlns="">
+       $\unitfrac {m}{s}$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>m/s
+     </Formula>
+     <?MarkedContent page="1" ?>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.024"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.025"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>1
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.026"
+        title="math"
+        af="mathml-3.xml tag-AFfile8.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-3.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mtext>m</mtext> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile8.tex" xmlns="">
+       $\relax \mbox {\fontsize \sf@size \z@ \selectfont {m}}$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>m
+     </Formula>
+     <?MarkedContent page="1" ?>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.027"
+        title="math"
+        af="mathml-4.xml tag-AFfile9.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-4.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mspace width="-0.111em"/> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile9.tex" xmlns="">
+       $\relax \mkern -2mu$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>
+     </Formula>
+     <?MarkedContent page="1" ?>/
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.028"
+        title="math"
+        af="mathml-5.xml tag-AFfile10.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-5.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mspace width="-0.056em"/> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile10.tex" xmlns="">
+       $\relax \mkern -1mu$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>
+     </Formula>
+     <?MarkedContent page="1" ?>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.029"
+        title="math"
+        af="mathml-6.xml tag-AFfile11.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-6.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mtext>s</mtext> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile11.tex" xmlns="">
+       $\relax \mbox {\fontsize \sf@size \z@ \selectfont {s}}$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>s
+     </Formula>
+     <?MarkedContent page="1" ?>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.030"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.031"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.032"
+        title="math"
+        af="mathml-12.xml tag-AFfile12.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-12.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mn>1</mn> <mspace width="0.167em"/> <mtext> <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="false" scriptlevel="1"> <mi mathvariant="normal">m</mi> </mstyle> </math> </mtext> <mspace width="-0.111em"/> <mo lspace="0" rspace="0">/</mo> <mspace width="-0.056em"/> <mrow> <mstyle displaystyle="false" scriptlevel="1"/> <mi mathvariant="normal">s</mi> </mrow> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile12.tex" xmlns="">
+       $\unitfrac [1]{m}{s}$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>1m/s
+     </Formula>
+     <?MarkedContent page="1" ?>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.033"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.034"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.035"
+        title="math"
+        af="mathml-13.xml tag-AFfile13.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-13.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mtext>1</mtext> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile13.tex" xmlns="">
+       $\relax \mbox {\fontsize \sf@size \z@ \selectfont {1}}$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>1
+     </Formula>
+     <?MarkedContent page="1" ?>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.036"
+        title="math"
+        af="mathml-4.xml tag-AFfile14.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-4.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mspace width="-0.111em"/> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile14.tex" xmlns="">
+       $\relax \mkern -2mu$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>
+     </Formula>
+     <?MarkedContent page="1" ?>/
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.037"
+        title="math"
+        af="mathml-5.xml tag-AFfile15.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-5.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mspace width="-0.056em"/> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile15.tex" xmlns="">
+       $\relax \mkern -1mu$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>
+     </Formula>
+     <?MarkedContent page="1" ?>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.038"
+        title="math"
+        af="mathml-16.xml tag-AFfile16.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-16.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mtext>2</mtext> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile16.tex" xmlns="">
+       $\relax \mbox {\fontsize \sf@size \z@ \selectfont {2}}$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>2
+     </Formula>
+     <?MarkedContent page="1" ?>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.039"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.040"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.041"
+        title="math"
+        af="mathml-17.xml tag-AFfile17.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-17.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mtext> <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="false" scriptlevel="1"> <mn>1</mn> </mstyle> </math> </mtext> <mspace width="-0.111em"/> <mo lspace="0" rspace="0">/</mo> <mspace width="-0.056em"/> <mrow> <mstyle displaystyle="false" scriptlevel="1"/> <mn>2</mn> </mrow> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile17.tex" xmlns="">
+       $\nicefrac {1}{2}$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>1/2
+     </Formula>
+     <?MarkedContent page="1" ?>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.042"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.043"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.044"
+        title="math"
+        af="mathml-18.xml tag-AFfile18.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-18.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mtext>1</mtext> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile18.tex" xmlns="">
+       $\relax \mbox {\fontsize \sf@size \z@ \selectfont \texttt {1}}$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>1
+     </Formula>
+     <?MarkedContent page="1" ?>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.045"
+        title="math"
+        af="mathml-4.xml tag-AFfile19.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-4.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mspace width="-0.111em"/> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile19.tex" xmlns="">
+       $\relax \mkern -2mu$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>
+     </Formula>
+     <?MarkedContent page="1" ?>/
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.046"
+        title="math"
+        af="mathml-5.xml tag-AFfile20.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-5.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mspace width="-0.056em"/> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile20.tex" xmlns="">
+       $\relax \mkern -1mu$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>
+     </Formula>
+     <?MarkedContent page="1" ?>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.047"
+        title="math"
+        af="mathml-21.xml tag-AFfile21.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-21.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mtext>2</mtext> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile21.tex" xmlns="">
+       $\relax \mbox {\fontsize \sf@size \z@ \selectfont \texttt {2}}$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>2
+     </Formula>
+     <?MarkedContent page="1" ?>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.048"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.049"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.050"
+        title="math"
+        af="mathml-22.xml tag-AFfile22.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-22.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mtext>1</mtext> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile22.tex" xmlns="">
+       $\relax \mbox {\fontsize \sf@size \z@ \selectfont \texttt {\textit {1}}}$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>1
+     </Formula>
+     <?MarkedContent page="1" ?>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.051"
+        title="math"
+        af="mathml-4.xml tag-AFfile23.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-4.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mspace width="-0.111em"/> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile23.tex" xmlns="">
+       $\relax \mkern -2mu$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>
+     </Formula>
+     <?MarkedContent page="1" ?>/
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.052"
+        title="math"
+        af="mathml-5.xml tag-AFfile24.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-5.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mspace width="-0.056em"/> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile24.tex" xmlns="">
+       $\relax \mkern -1mu$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>
+     </Formula>
+     <?MarkedContent page="1" ?>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.053"
+        title="math"
+        af="mathml-21.xml tag-AFfile25.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-21.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mtext>2</mtext> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile25.tex" xmlns="">
+       $\relax \mbox {\fontsize \sf@size \z@ \selectfont \texttt {2}}$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>2
+     </Formula>
+     <?MarkedContent page="1" ?>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.054"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.055"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.056"
+        title="math"
+        af="mathml-26.xml tag-AFfile26.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-26.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mtext> <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="false" scriptlevel="1"> <mi>𝒜</mi> </mstyle> </math> </mtext> <mspace width="-0.111em"/> <mo lspace="0" rspace="0">/</mo> <mspace width="-0.056em"/> <mrow> <mstyle displaystyle="false" scriptlevel="1"/> <mi mathvariant="normal">ℬ</mi> </mrow> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile26.tex" xmlns="">
+       $\nicefrac [\mathcal ]{A}{B}$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>A/B
+     </Formula>
+     <?MarkedContent page="1" ?>
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-incompatible-mathml/units/units-01-BAD.struct.xml
+++ b/tagging-status/testfiles-incompatible-mathml/units/units-01-BAD.struct.xml
@@ -1,0 +1,562 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.006"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.007"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>m
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.008"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.009"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.010"
+        title="math"
+        af="mathml-1.xml tag-AFfile1.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-1.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mi mathvariant="normal">m</mi> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile1.tex" xmlns="">
+       $\unit {m}$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>m
+     </Formula>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.011"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.012"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>1m
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.013"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.014"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.015"
+        title="math"
+        af="mathml-2.xml tag-AFfile2.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-2.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mn>1</mn> <mspace width="0.167em"/> <mi mathvariant="normal">m</mi> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile2.tex" xmlns="">
+       $\unit [1]{m}$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>1m
+     </Formula>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.016"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.017"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.018"
+        title="math"
+        af="mathml-3.xml tag-AFfile3.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-3.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mtext>m</mtext> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile3.tex" xmlns="">
+       $\relax \mbox {\fontsize \sf@size \z@ \selectfont {m}}$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>m
+     </Formula>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.019"
+        title="math"
+        af="mathml-4.xml tag-AFfile4.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-4.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mspace width="-0.111em"/> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile4.tex" xmlns="">
+       $\relax \mkern -2mu$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>
+     </Formula>
+     <?MarkedContent page="1" ?>/
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.020"
+        title="math"
+        af="mathml-5.xml tag-AFfile5.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-5.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mspace width="-0.056em"/> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile5.tex" xmlns="">
+       $\relax \mkern -1mu$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>
+     </Formula>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.021"
+        title="math"
+        af="mathml-6.xml tag-AFfile6.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-6.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mtext>s</mtext> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile6.tex" xmlns="">
+       $\relax \mbox {\fontsize \sf@size \z@ \selectfont {s}}$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>s
+     </Formula>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.022"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.023"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.024"
+        title="math"
+        af="mathml-7.xml tag-AFfile7.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-7.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mtext> <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="false" scriptlevel="1"> <mi mathvariant="normal">m</mi> </mstyle> </math> </mtext> <mspace width="-0.111em"/> <mo lspace="0" rspace="0">/</mo> <mspace width="-0.056em"/> <mrow> <mstyle displaystyle="false" scriptlevel="1"/> <mi mathvariant="normal">s</mi> </mrow> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile7.tex" xmlns="">
+       $\unitfrac {m}{s}$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>m/s
+     </Formula>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.025"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.026"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>1
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.027"
+        title="math"
+        af="mathml-3.xml tag-AFfile8.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-3.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mtext>m</mtext> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile8.tex" xmlns="">
+       $\relax \mbox {\fontsize \sf@size \z@ \selectfont {m}}$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>m
+     </Formula>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.028"
+        title="math"
+        af="mathml-4.xml tag-AFfile9.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-4.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mspace width="-0.111em"/> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile9.tex" xmlns="">
+       $\relax \mkern -2mu$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>
+     </Formula>
+     <?MarkedContent page="1" ?>/
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.029"
+        title="math"
+        af="mathml-5.xml tag-AFfile10.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-5.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mspace width="-0.056em"/> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile10.tex" xmlns="">
+       $\relax \mkern -1mu$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>
+     </Formula>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.030"
+        title="math"
+        af="mathml-6.xml tag-AFfile11.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-6.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mtext>s</mtext> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile11.tex" xmlns="">
+       $\relax \mbox {\fontsize \sf@size \z@ \selectfont {s}}$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>s
+     </Formula>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.031"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.032"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.033"
+        title="math"
+        af="mathml-12.xml tag-AFfile12.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-12.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mn>1</mn> <mspace width="0.167em"/> <mtext> <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="false" scriptlevel="1"> <mi mathvariant="normal">m</mi> </mstyle> </math> </mtext> <mspace width="-0.111em"/> <mo lspace="0" rspace="0">/</mo> <mspace width="-0.056em"/> <mrow> <mstyle displaystyle="false" scriptlevel="1"/> <mi mathvariant="normal">s</mi> </mrow> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile12.tex" xmlns="">
+       $\unitfrac [1]{m}{s}$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>1m/s
+     </Formula>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.034"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.035"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.036"
+        title="math"
+        af="mathml-13.xml tag-AFfile13.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-13.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mtext>1</mtext> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile13.tex" xmlns="">
+       $\relax \mbox {\fontsize \sf@size \z@ \selectfont {1}}$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>1
+     </Formula>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.037"
+        title="math"
+        af="mathml-4.xml tag-AFfile14.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-4.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mspace width="-0.111em"/> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile14.tex" xmlns="">
+       $\relax \mkern -2mu$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>
+     </Formula>
+     <?MarkedContent page="1" ?>/
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.038"
+        title="math"
+        af="mathml-5.xml tag-AFfile15.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-5.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mspace width="-0.056em"/> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile15.tex" xmlns="">
+       $\relax \mkern -1mu$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>
+     </Formula>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.039"
+        title="math"
+        af="mathml-16.xml tag-AFfile16.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-16.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mtext>2</mtext> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile16.tex" xmlns="">
+       $\relax \mbox {\fontsize \sf@size \z@ \selectfont {2}}$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>2
+     </Formula>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.040"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.041"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.042"
+        title="math"
+        af="mathml-17.xml tag-AFfile17.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-17.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mtext> <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="false" scriptlevel="1"> <mn>1</mn> </mstyle> </math> </mtext> <mspace width="-0.111em"/> <mo lspace="0" rspace="0">/</mo> <mspace width="-0.056em"/> <mrow> <mstyle displaystyle="false" scriptlevel="1"/> <mn>2</mn> </mrow> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile17.tex" xmlns="">
+       $\nicefrac {1}{2}$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>1/2
+     </Formula>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.043"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.044"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.045"
+        title="math"
+        af="mathml-18.xml tag-AFfile18.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-18.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mtext>1</mtext> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile18.tex" xmlns="">
+       $\relax \mbox {\fontsize \sf@size \z@ \selectfont \texttt {1}}$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>1
+     </Formula>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.046"
+        title="math"
+        af="mathml-4.xml tag-AFfile19.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-4.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mspace width="-0.111em"/> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile19.tex" xmlns="">
+       $\relax \mkern -2mu$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>
+     </Formula>
+     <?MarkedContent page="1" ?>/
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.047"
+        title="math"
+        af="mathml-5.xml tag-AFfile20.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-5.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mspace width="-0.056em"/> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile20.tex" xmlns="">
+       $\relax \mkern -1mu$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>
+     </Formula>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.048"
+        title="math"
+        af="mathml-21.xml tag-AFfile21.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-21.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mtext>2</mtext> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile21.tex" xmlns="">
+       $\relax \mbox {\fontsize \sf@size \z@ \selectfont \texttt {2}}$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>2
+     </Formula>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.049"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.050"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.051"
+        title="math"
+        af="mathml-22.xml tag-AFfile22.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-22.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mtext>1</mtext> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile22.tex" xmlns="">
+       $\relax \mbox {\fontsize \sf@size \z@ \selectfont \texttt {\textit {1}}}$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>1
+     </Formula>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.052"
+        title="math"
+        af="mathml-4.xml tag-AFfile23.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-4.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mspace width="-0.111em"/> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile23.tex" xmlns="">
+       $\relax \mkern -2mu$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>
+     </Formula>
+     <?MarkedContent page="1" ?>/
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.053"
+        title="math"
+        af="mathml-5.xml tag-AFfile24.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-5.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mspace width="-0.056em"/> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile24.tex" xmlns="">
+       $\relax \mkern -1mu$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>
+     </Formula>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.054"
+        title="math"
+        af="mathml-21.xml tag-AFfile25.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-21.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mtext>2</mtext> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile25.tex" xmlns="">
+       $\relax \mbox {\fontsize \sf@size \z@ \selectfont \texttt {2}}$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>2
+     </Formula>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.055"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.056"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.057"
+        title="math"
+        af="mathml-26.xml tag-AFfile26.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-26.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mtext> <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="false" scriptlevel="1"> <mi>𝒜</mi> </mstyle> </math> </mtext> <mspace width="-0.111em"/> <mo lspace="0" rspace="0">/</mo> <mspace width="-0.056em"/> <mrow> <mstyle displaystyle="false" scriptlevel="1"/> <mi mathvariant="normal">ℬ</mi> </mrow> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile26.tex" xmlns="">
+       $\nicefrac [\mathcal ]{A}{B}$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>𝒜/ℬ
+     </Formula>
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-incompatible-mathml/units/units-01-BAD.tex
+++ b/tagging-status/testfiles-incompatible-mathml/units/units-01-BAD.tex
@@ -1,0 +1,32 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on
+  }
+\documentclass{article}
+\ifdefined\Uchar
+  \usepackage{unicode-math}
+\fi
+\usepackage{units}
+
+\title{units tagging test}
+
+\begin{document}
+
+\sffamily\bfseries\unit{m}\par
+\sffamily\bfseries$\unit{m}$\par
+\sffamily\itshape\unit[1]{m}\par
+\sffamily\itshape$\unit[1]{m}$\par
+\sffamily\bfseries\unitfrac{m}{s}\par
+\sffamily\bfseries$\unitfrac{m}{s}$\par
+\sffamily\itshape\unitfrac[1]{m}{s}\par
+\sffamily\itshape$\unitfrac[1]{m}{s}$\par
+\bfseries\itshape\nicefrac{1}{2}\par
+\bfseries\itshape$\nicefrac{1}{2}$\par
+\nicefrac[\texttt]{1}{2}\par
+\nicefrac[\texttt]{\textit{1}}{2}\par
+$\nicefrac[\mathcal]{A}{B}$\par
+
+\end{document}

--- a/tagging-status/testfiles-incompatible/subcaption/subcaption-01-BAD.pdftex.struct.xml
+++ b/tagging-status/testfiles-incompatible/subcaption/subcaption-01-BAD.pdftex.struct.xml
@@ -1,0 +1,258 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <Sect xmlns="http://iso.org/pdf2/ssn"
+      id="ID.005"
+     >
+    <section xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.006"
+       title="List of Figures"
+       rolemaps-to="H1"
+      >
+     <?MarkedContent page="1" ?>List of Figures
+    </section>
+    <TOC xmlns="http://iso.org/pdf/ssn"
+       id="ID.007"
+       title="lof"
+      >
+     <TOCI xmlns="http://iso.org/pdf/ssn"
+        id="ID.008"
+        title="A figure with two subfigures: (a) first subfigure; (b) second subfigure."
+       >
+      <Reference xmlns="http://iso.org/pdf/ssn"
+         id="ID.009"
+        >
+       <?MarkedContent page="1" ?>
+       <Link xmlns="http://iso.org/pdf2/ssn"
+          id="ID.010"
+         >
+        <?MarkedContent page="1" ?>
+        <Lbl xmlns="http://iso.org/pdf2/ssn"
+           id="ID.011"
+          >
+         <?MarkedContent page="1" ?>1
+        </Lbl>
+        <?MarkedContent page="1" ?>A figure with two subfigures: (a) first subfigure; (b) second sub-figure.
+        <?ReferencedObject type="Annot" page="1" ?>
+       </Link>
+       <?MarkedContent page="1" ?>
+       <?MarkedContent page="1" ?>1
+      </Reference>
+     </TOCI>
+    </TOC>
+   </Sect>
+   <Sect xmlns="http://iso.org/pdf2/ssn"
+      id="ID.012"
+     >
+    <section xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.013"
+       title="Intro"
+       rolemaps-to="H1"
+      >
+     <section-number xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.014"
+        rolemaps-to="Span"
+       >
+      <?MarkedContent page="1" ?>1
+     </section-number>
+     <?MarkedContent page="1" ?>Intro
+    </section>
+    <Sect xmlns="http://iso.org/pdf2/ssn"
+       id="ID.015"
+      >
+     <subsection xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.016"
+        title="Subintro"
+        rolemaps-to="H2"
+       >
+      <section-number xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.017"
+         rolemaps-to="Span"
+        >
+       <?MarkedContent page="1" ?>1.1
+      </section-number>
+      <?MarkedContent page="1" ?>Subintro
+     </subsection>
+    </Sect>
+   </Sect>
+   <figures xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.003"
+      rolemaps-to="Sect"
+     >
+    <float xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.018"
+       rolemaps-to="Aside"
+      >
+     <Caption xmlns="http://iso.org/pdf2/ssn"
+        id="ID.043"
+       >
+      <Lbl xmlns="http://iso.org/pdf2/ssn"
+         id="ID.044"
+        >
+       <?MarkedContent page="1" ?>Figure 1:
+      </Lbl>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.045"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Justify"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>A figure with two subfigures: (a) first subfigure; (b) second subfigure.
+      </text>
+     </Caption>
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.019"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.020"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Justify"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>
+      </text>
+      <Div xmlns="http://iso.org/pdf2/ssn"
+         id="ID.021"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.022"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.023"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Center"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="1" ?>
+         <Figure xmlns="http://iso.org/pdf2/ssn"
+            id="ID.024"
+            alt="sample image"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:BBox="{ 134.61859, 414.02264, 303.05348, 540.35044 }"
+           >
+          <?MarkedContent page="1" ?>
+         </Figure>
+         <?MarkedContent page="1" ?>
+        </text>
+       </text-unit>
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.025"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.026"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Center"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="1" ?>
+        </text>
+        <Div xmlns="http://iso.org/pdf2/ssn"
+           id="ID.027"
+          >
+         <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.028"
+            rolemaps-to="Part"
+           >
+          <text xmlns="https://www.latex-project.org/ns/dflt"
+             id="ID.029"
+             xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+             Layout:TextAlign="Center"
+             rolemaps-to="P"
+            >
+           <?MarkedContent page="1" ?>(a)
+          </text>
+         </text-unit>
+        </Div>
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.030"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="1" ?>
+        </text>
+       </text-unit>
+      </Div>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.031"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>
+      </text>
+      <Div xmlns="http://iso.org/pdf2/ssn"
+         id="ID.032"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.033"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.034"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Center"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="1" ?>
+         <Figure xmlns="http://iso.org/pdf2/ssn"
+            id="ID.035"
+            alt="sample image"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:BBox="{ 308.07396, 414.02264, 476.50885, 540.35044 }"
+           >
+          <?MarkedContent page="1" ?>
+         </Figure>
+         <?MarkedContent page="1" ?>
+        </text>
+       </text-unit>
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.036"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.037"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Center"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="1" ?>
+        </text>
+        <Div xmlns="http://iso.org/pdf2/ssn"
+           id="ID.038"
+          >
+         <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.039"
+            rolemaps-to="Part"
+           >
+          <text xmlns="https://www.latex-project.org/ns/dflt"
+             id="ID.040"
+             xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+             Layout:TextAlign="Center"
+             rolemaps-to="P"
+            >
+           <?MarkedContent page="1" ?>(b)
+          </text>
+         </text-unit>
+        </Div>
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.041"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="1" ?>
+        </text>
+       </text-unit>
+      </Div>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.042"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>
+      </text>
+     </text-unit>
+    </float>
+   </figures>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-incompatible/subcaption/subcaption-01-BAD.struct.xml
+++ b/tagging-status/testfiles-incompatible/subcaption/subcaption-01-BAD.struct.xml
@@ -1,0 +1,249 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <Sect xmlns="http://iso.org/pdf2/ssn"
+      id="ID.006"
+     >
+    <section xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.007"
+       title="List of Figures"
+       rolemaps-to="H1"
+      >
+     <?MarkedContent page="1" ?>List of Figures
+    </section>
+    <TOC xmlns="http://iso.org/pdf/ssn"
+       id="ID.008"
+       title="lof"
+      >
+     <TOCI xmlns="http://iso.org/pdf/ssn"
+        id="ID.009"
+        title="A figure with two subfigures: (a) first subfigure; (b) second subfigure."
+       >
+      <Reference xmlns="http://iso.org/pdf/ssn"
+         id="ID.010"
+        >
+       <Link xmlns="http://iso.org/pdf2/ssn"
+          id="ID.011"
+         >
+        <?MarkedContent page="1" ?>
+        <?MarkedContent page="1" ?>
+        <Lbl xmlns="http://iso.org/pdf2/ssn"
+           id="ID.012"
+          >
+         <?MarkedContent page="1" ?>1
+        </Lbl>
+        <?MarkedContent page="1" ?>A figure with two subfigures: (a) first subfigure; (b) second sub
+        <?MarkedContent page="1" ?>
+        <?MarkedContent page="1" ?>figure.
+        <?ReferencedObject type="Annot" page="1" ?>
+        <?ReferencedObject type="Annot" page="1" ?>
+       </Link>
+       <?MarkedContent page="1" ?>1
+      </Reference>
+     </TOCI>
+    </TOC>
+   </Sect>
+   <Sect xmlns="http://iso.org/pdf2/ssn"
+      id="ID.013"
+     >
+    <section xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.014"
+       title="Intro"
+       rolemaps-to="H1"
+      >
+     <section-number xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.015"
+        rolemaps-to="Span"
+       >
+      <?MarkedContent page="1" ?>1 
+     </section-number>
+     <?MarkedContent page="1" ?>Intro
+    </section>
+    <Sect xmlns="http://iso.org/pdf2/ssn"
+       id="ID.016"
+      >
+     <subsection xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.017"
+        title="Subintro"
+        rolemaps-to="H2"
+       >
+      <section-number xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.018"
+         rolemaps-to="Span"
+        >
+       <?MarkedContent page="1" ?>1.1 
+      </section-number>
+      <?MarkedContent page="1" ?>Subintro
+     </subsection>
+    </Sect>
+   </Sect>
+   <figures xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.004"
+      rolemaps-to="Sect"
+     >
+    <float xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.019"
+       rolemaps-to="Aside"
+      >
+     <Caption xmlns="http://iso.org/pdf2/ssn"
+        id="ID.044"
+       >
+      <Lbl xmlns="http://iso.org/pdf2/ssn"
+         id="ID.045"
+        >
+       <?MarkedContent page="1" ?>Figure 1: 
+      </Lbl>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.046"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Justify"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>A figure with two subfigures: (a) first subfigure; (b) second subfigure.
+      </text>
+     </Caption>
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.020"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.021"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Justify"
+         rolemaps-to="P"
+        >
+      </text>
+      <Div xmlns="http://iso.org/pdf2/ssn"
+         id="ID.022"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.023"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.024"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Center"
+           rolemaps-to="P"
+          >
+         <Figure xmlns="http://iso.org/pdf2/ssn"
+            id="ID.025"
+            alt="sample image"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:BBox="{ 134.61859, 413.74695, 303.05348, 540.07475 }"
+           >
+          <?MarkedContent page="1" ?>
+         </Figure>
+        </text>
+       </text-unit>
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.026"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.027"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Center"
+           rolemaps-to="P"
+          >
+        </text>
+        <Div xmlns="http://iso.org/pdf2/ssn"
+           id="ID.028"
+          >
+         <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.029"
+            rolemaps-to="Part"
+           >
+          <text xmlns="https://www.latex-project.org/ns/dflt"
+             id="ID.030"
+             xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+             Layout:TextAlign="Center"
+             rolemaps-to="P"
+            >
+           <?MarkedContent page="1" ?>(a)
+          </text>
+         </text-unit>
+        </Div>
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.031"
+           rolemaps-to="P"
+          >
+        </text>
+       </text-unit>
+      </Div>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.032"
+         rolemaps-to="P"
+        >
+      </text>
+      <Div xmlns="http://iso.org/pdf2/ssn"
+         id="ID.033"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.034"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.035"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Center"
+           rolemaps-to="P"
+          >
+         <Figure xmlns="http://iso.org/pdf2/ssn"
+            id="ID.036"
+            alt="sample image"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:BBox="{ 308.07146, 413.74695, 476.50635, 540.07475 }"
+           >
+          <?MarkedContent page="1" ?>
+         </Figure>
+        </text>
+       </text-unit>
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.037"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.038"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Center"
+           rolemaps-to="P"
+          >
+        </text>
+        <Div xmlns="http://iso.org/pdf2/ssn"
+           id="ID.039"
+          >
+         <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.040"
+            rolemaps-to="Part"
+           >
+          <text xmlns="https://www.latex-project.org/ns/dflt"
+             id="ID.041"
+             xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+             Layout:TextAlign="Center"
+             rolemaps-to="P"
+            >
+           <?MarkedContent page="1" ?>(b)
+          </text>
+         </text-unit>
+        </Div>
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.042"
+           rolemaps-to="P"
+          >
+        </text>
+       </text-unit>
+      </Div>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.043"
+         rolemaps-to="P"
+        >
+      </text>
+     </text-unit>
+    </float>
+   </figures>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-incompatible/subcaption/subcaption-01-BAD.tex
+++ b/tagging-status/testfiles-incompatible/subcaption/subcaption-01-BAD.tex
@@ -1,0 +1,38 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on
+  }
+\documentclass{article}
+
+\usepackage{subcaption}
+\usepackage{graphicx}
+\usepackage{hyperref} 
+% leads to:
+% Package tagpdf Warning: Destination figure.caption.2 has no related structure.
+
+\title{subcaption tagging test}
+
+\begin{document}
+
+\listoffigures
+
+\section{Intro}
+
+\subsection{Subintro}
+
+\begin{figure}[b]
+	\begin{subfigure}[c]{0.495\textwidth}
+	\centering\includegraphics[alt={sample image},width=0.99\textwidth]{example-image-c}%
+	\subcaption{\label{fig:2a}}
+	\end{subfigure}
+	\begin{subfigure}[c]{0.495\textwidth}
+	\centering{\includegraphics[alt={sample image},width=0.99\textwidth]{example-image-c}}%
+	\subcaption{\label{fig:2b}}%
+	\end{subfigure}%
+	\caption{A figure with two subfigures: (a) first subfigure; (b) second subfigure.\label{fig:2}}
+\end{figure}
+
+\end{document}

--- a/tagging-status/testfiles-incompatible/tweaklist/tweaklist-01-BAD.pdftex.struct.xml
+++ b/tagging-status/testfiles-incompatible/tweaklist/tweaklist-01-BAD.pdftex.struct.xml
@@ -1,0 +1,78 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.005"
+      rolemaps-to="Part"
+     >
+    <enumerate xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.006"
+       xmlns:List="http://iso.org/pdf/ssn/List"
+       List:ListNumbering="Ordered"
+       rolemaps-to="L"
+      >
+     <item xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.007"
+        rolemaps-to="LI"
+       >
+      <itemlabel xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.008"
+         rolemaps-to="Lbl"
+        >
+       <?MarkedContent page="1" ?>1.
+      </itemlabel>
+      <itembody xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.009"
+         rolemaps-to="LBody"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.010"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.011"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="1" ?>first
+        </text>
+       </text-unit>
+      </itembody>
+     </item>
+     <item xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.012"
+        rolemaps-to="LI"
+       >
+      <itemlabel xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.013"
+         rolemaps-to="Lbl"
+        >
+       <?MarkedContent page="1" ?>2.
+      </itemlabel>
+      <itembody xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.014"
+         rolemaps-to="LBody"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.015"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.016"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="1" ?>second
+        </text>
+       </text-unit>
+      </itembody>
+     </item>
+    </enumerate>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-incompatible/tweaklist/tweaklist-01-BAD.struct.xml
+++ b/tagging-status/testfiles-incompatible/tweaklist/tweaklist-01-BAD.struct.xml
@@ -1,0 +1,78 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.006"
+      rolemaps-to="Part"
+     >
+    <enumerate xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.007"
+       xmlns:List="http://iso.org/pdf/ssn/List"
+       List:ListNumbering="Ordered"
+       rolemaps-to="L"
+      >
+     <item xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.008"
+        rolemaps-to="LI"
+       >
+      <itemlabel xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.009"
+         rolemaps-to="Lbl"
+        >
+       <?MarkedContent page="1" ?>1.
+      </itemlabel>
+      <itembody xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.010"
+         rolemaps-to="LBody"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.011"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.012"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="1" ?>first
+        </text>
+       </text-unit>
+      </itembody>
+     </item>
+     <item xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.013"
+        rolemaps-to="LI"
+       >
+      <itemlabel xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.014"
+         rolemaps-to="Lbl"
+        >
+       <?MarkedContent page="1" ?>2.
+      </itemlabel>
+      <itembody xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.015"
+         rolemaps-to="LBody"
+        >
+       <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.016"
+          rolemaps-to="Part"
+         >
+        <text xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.017"
+           xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+           Layout:TextAlign="Justify"
+           rolemaps-to="P"
+          >
+         <?MarkedContent page="1" ?>second
+        </text>
+       </text-unit>
+      </itembody>
+     </item>
+    </enumerate>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-incompatible/tweaklist/tweaklist-01-BAD.tex
+++ b/tagging-status/testfiles-incompatible/tweaklist/tweaklist-01-BAD.tex
@@ -1,0 +1,24 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on
+  }
+\documentclass{article}
+\let\description\relax
+\let\enddescription\relax
+\usepackage{tweaklist}
+
+\def\enumhook{AAAA}
+
+\title{tweaklist tagging test}
+
+\begin{document}
+
+\begin{enumerate}
+\item first
+\item second
+\end{enumerate}
+
+\end{document}

--- a/tagging-status/testfiles-partial-mathml/simpler-wick/simpler-wick-01-BAD.pdftex.struct.xml
+++ b/tagging-status/testfiles-partial-mathml/simpler-wick/simpler-wick-01-BAD.pdftex.struct.xml
@@ -1,0 +1,138 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.005"
+      rolemaps-to="Part"
+     >
+    <Formula xmlns="http://iso.org/pdf2/ssn"
+       id="ID.006"
+       title="equation"
+       af="mathml-1.xml tag-AFfile1.tex"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:Placement="Block"
+      >
+      <AssociatedFile name="mathml-1.xml" xmlns="">
+      <math display="block" xmlns="http://www.w3.org/1998/Math/MathML"> <mtable displaystyle="true" intent=":system-of-equations"> <mtr> <mtd intent=":equation-label"> <mtext> (1) </mtext> </mtd> <mtd intent=":pause-medium"> <mrow/> <mtext>   <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <mi>𝜙</mi> </mstyle> </math> </mtext> <mi>𝐴</mi> <mtext>   <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <mi>𝜙</mi> </mstyle> </math> </mtext> <mtext/> <mi> <mglyph/> </mi> </mtd> </mtr> </mtable> </math>
+      </AssociatedFile>
+      <AssociatedFile name="tag-AFfile1.tex" xmlns="">
+      \begin {equation}\wick {\c \phi A \c \phi }\end {equation}
+      </AssociatedFile>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>ϕ
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>A
+     <?MarkedContent page="1" ?>ϕ
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <Lbl xmlns="http://iso.org/pdf2/ssn"
+        id="ID.007"
+       >
+      <?MarkedContent page="1" ?>(1)
+     </Lbl>
+     <?MarkedContent page="1" ?>
+    </Formula>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.008"
+      rolemaps-to="Part"
+     >
+    <Formula xmlns="http://iso.org/pdf2/ssn"
+       id="ID.009"
+       title="equation"
+       af="mathml-2.xml tag-AFfile2.tex"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:Placement="Block"
+      >
+      <AssociatedFile name="mathml-2.xml" xmlns="">
+      <math display="block" xmlns="http://www.w3.org/1998/Math/MathML"> <mtable displaystyle="true" intent=":system-of-equations"> <mtr> <mtd intent=":equation-label"> <mtext> (2) </mtext> </mtd> <mtd intent=":pause-medium"> <mrow/> <mtext>   <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <mi>𝑎</mi> </mstyle> </math> </mtext> <mtext>   <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <mi>𝑏</mi> </mstyle> </math> </mtext> <mtext>   <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <mi>𝑐</mi> </mstyle> </math> </mtext> <mtext>   <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <mi>𝑎</mi> </mstyle> </math> </mtext> <mtext/> <mtext>   <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <mi>𝑑</mi> </mstyle> </math> </mtext> <mtext>   <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <mi>𝑒</mi> </mstyle> </math> </mtext> <mtext>   <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <mi>𝑒</mi> </mstyle> </math> </mtext> <mtext/> <mtext>   <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <mi>𝑎</mi> </mstyle> </math> </mtext> <mtext>   <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <mi>𝑏</mi> </mstyle> </math> </mtext> <mtext/> <mtext>   <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <mi>𝑐</mi> </mstyle> </math> </mtext> <mtext/> <mtext>   <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <mi>𝑎</mi> </mstyle> </math> </mtext> <mtext/> <mi> <mglyph/> </mi> </mtd> </mtr> </mtable> </math>
+      </AssociatedFile>
+      <AssociatedFile name="tag-AFfile2.tex" xmlns="">
+      \begin {equation}\wick { \c 1 a \c 2 b \c 3 c \c 1 a \c 4 d \c 1 e \c 1 e \c 1 a \c 2 b \c 3 c \c 1 a }\end {equation}
+      </AssociatedFile>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>a
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>b
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>c
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>a
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>d
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>e
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>e
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>a
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>b
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>c
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>a
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <Lbl xmlns="http://iso.org/pdf2/ssn"
+        id="ID.010"
+       >
+      <?MarkedContent page="1" ?>(2)
+     </Lbl>
+     <?MarkedContent page="1" ?>
+    </Formula>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.011"
+      rolemaps-to="Part"
+     >
+    <Formula xmlns="http://iso.org/pdf2/ssn"
+       id="ID.012"
+       title="equation"
+       af="mathml-3.xml tag-AFfile3.tex"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:Placement="Block"
+      >
+      <AssociatedFile name="mathml-3.xml" xmlns="">
+      <math display="block" xmlns="http://www.w3.org/1998/Math/MathML"> <mtable displaystyle="true" intent=":system-of-equations"> <mtr> <mtd intent=":equation-label"> <mtext> (3) </mtext> </mtd> <mtd intent=":pause-medium"> <mrow/> <mtext>   <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <mi>𝜙</mi> </mstyle> </math> </mtext> <mo lspace="0.167em" rspace="0.167em">∫</mo> <mfrac> <mrow> <mi>𝑑</mi> <mi>𝑥</mi> </mrow> <mi>𝑥</mi> </mfrac> <mtext>   <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <mi>𝜙</mi> </mstyle> </math> </mtext> <mtext/> <mi> <mglyph/> </mi> </mtd> </mtr> </mtable> </math>
+      </AssociatedFile>
+      <AssociatedFile name="tag-AFfile3.tex" xmlns="">
+      \begin {equation}\wick [offset=2em]{\c \phi \int \frac {dx}{x} \c \phi }\end {equation}
+      </AssociatedFile>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>ϕ
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>∫︂dxx
+     <?MarkedContent page="1" ?>ϕ
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <Lbl xmlns="http://iso.org/pdf2/ssn"
+        id="ID.013"
+       >
+      <?MarkedContent page="1" ?>(3)
+     </Lbl>
+     <?MarkedContent page="1" ?>
+    </Formula>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-partial-mathml/simpler-wick/simpler-wick-01-BAD.struct.xml
+++ b/tagging-status/testfiles-partial-mathml/simpler-wick/simpler-wick-01-BAD.struct.xml
@@ -1,0 +1,100 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.006"
+      rolemaps-to="Part"
+     >
+    <Formula xmlns="http://iso.org/pdf2/ssn"
+       id="ID.007"
+       title="equation"
+       af="mathml-1.xml tag-AFfile1.tex"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:Placement="Block"
+      >
+      <AssociatedFile name="mathml-1.xml" xmlns="">
+      <math display="block" xmlns="http://www.w3.org/1998/Math/MathML"> <mtable displaystyle="true" intent=":system-of-equations"> <mtr> <mtd intent=":equation-label"> <mtext> (1) </mtext> </mtd> <mtd intent=":pause-medium"> <mrow/> <mtext>   <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <mi>𝜙</mi> </mstyle> </math> </mtext> <mi>𝐴</mi> <mtext>   <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <mi>𝜙</mi> </mstyle> </math> </mtext> <mtext/> <mi> <mglyph/> </mi> </mtd> </mtr> </mtable> </math>
+      </AssociatedFile>
+      <AssociatedFile name="tag-AFfile1.tex" xmlns="">
+      \begin {equation}\wick {\c \phi A \c \phi }\end {equation}
+      </AssociatedFile>
+     <?MarkedContent page="1" ?>𝜙
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>𝐴
+     <?MarkedContent page="1" ?>𝜙
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>(1)
+    </Formula>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.008"
+      rolemaps-to="Part"
+     >
+    <Formula xmlns="http://iso.org/pdf2/ssn"
+       id="ID.009"
+       title="equation"
+       af="mathml-2.xml tag-AFfile2.tex"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:Placement="Block"
+      >
+      <AssociatedFile name="mathml-2.xml" xmlns="">
+      <math display="block" xmlns="http://www.w3.org/1998/Math/MathML"> <mtable displaystyle="true" intent=":system-of-equations"> <mtr> <mtd intent=":equation-label"> <mtext> (2) </mtext> </mtd> <mtd intent=":pause-medium"> <mrow/> <mtext>   <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <mi>𝑎</mi> </mstyle> </math> </mtext> <mtext>   <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <mi>𝑏</mi> </mstyle> </math> </mtext> <mtext>   <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <mi>𝑐</mi> </mstyle> </math> </mtext> <mtext>   <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <mi>𝑎</mi> </mstyle> </math> </mtext> <mtext/> <mtext>   <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <mi>𝑑</mi> </mstyle> </math> </mtext> <mtext>   <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <mi>𝑒</mi> </mstyle> </math> </mtext> <mtext>   <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <mi>𝑒</mi> </mstyle> </math> </mtext> <mtext/> <mtext>   <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <mi>𝑎</mi> </mstyle> </math> </mtext> <mtext>   <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <mi>𝑏</mi> </mstyle> </math> </mtext> <mtext/> <mtext>   <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <mi>𝑐</mi> </mstyle> </math> </mtext> <mtext/> <mtext>   <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <mi>𝑎</mi> </mstyle> </math> </mtext> <mtext/> <mi> <mglyph/> </mi> </mtd> </mtr> </mtable> </math>
+      </AssociatedFile>
+      <AssociatedFile name="tag-AFfile2.tex" xmlns="">
+      \begin {equation}\wick { \c 1 a \c 2 b \c 3 c \c 1 a \c 4 d \c 1 e \c 1 e \c 1 a \c 2 b \c 3 c \c 1 a }\end {equation}
+      </AssociatedFile>
+     <?MarkedContent page="1" ?>𝑎
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>𝑏
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>𝑐
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>𝑎
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>𝑑
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>𝑒
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>𝑒
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>𝑎
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>𝑏
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>𝑐
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>𝑎
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>(2)
+    </Formula>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.010"
+      rolemaps-to="Part"
+     >
+    <Formula xmlns="http://iso.org/pdf2/ssn"
+       id="ID.011"
+       title="equation"
+       af="mathml-3.xml tag-AFfile3.tex"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:Placement="Block"
+      >
+      <AssociatedFile name="mathml-3.xml" xmlns="">
+      <math display="block" xmlns="http://www.w3.org/1998/Math/MathML"> <mtable displaystyle="true" intent=":system-of-equations"> <mtr> <mtd intent=":equation-label"> <mtext> (3) </mtext> </mtd> <mtd intent=":pause-medium"> <mrow/> <mtext>   <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <mi>𝜙</mi> </mstyle> </math> </mtext> <mo lspace="0.167em" rspace="0.167em">∫</mo> <mfrac> <mrow> <mi>𝑑</mi> <mi>𝑥</mi> </mrow> <mi>𝑥</mi> </mfrac> <mtext>   <math xmlns="http://www.w3.org/1998/Math/MathML"> <mstyle displaystyle="true" scriptlevel="0"> <mi>𝜙</mi> </mstyle> </math> </mtext> <mtext/> <mi> <mglyph/> </mi> </mtd> </mtr> </mtable> </math>
+      </AssociatedFile>
+      <AssociatedFile name="tag-AFfile3.tex" xmlns="">
+      \begin {equation}\wick [offset=2em]{\c \phi \int \frac {dx}{x} \c \phi }\end {equation}
+      </AssociatedFile>
+     <?MarkedContent page="1" ?>𝜙
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>∫𝑑𝑥𝑥
+     <?MarkedContent page="1" ?>𝜙
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>(3)
+    </Formula>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-partial-mathml/simpler-wick/simpler-wick-01-BAD.tex
+++ b/tagging-status/testfiles-partial-mathml/simpler-wick/simpler-wick-01-BAD.tex
@@ -1,0 +1,33 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on
+  }
+\documentclass{article}
+\ifdefined\Uchar
+  \usepackage{unicode-math}
+\fi
+\usepackage{simpler-wick}
+
+\title{simpler-wick tagging test}
+
+\begin{document}
+
+\begin{equation}
+\wick{\c\phi A \c\phi}
+\end{equation}
+
+\begin{equation}
+\wick{
+\c1 a \c2 b \c3 c \c1 a \c4 d \c1 e
+\c1 e \c1 a \c2 b \c3 c \c1 a
+}
+\end{equation}
+
+\begin{equation}
+\wick[offset=2em]{\c\phi \int \frac{dx}{x} \c\phi}
+\end{equation} 
+
+\end{document}

--- a/tagging-status/testfiles-partial-mathml/simplewick/simplewick-01-BAD.pdftex.struct.xml
+++ b/tagging-status/testfiles-partial-mathml/simplewick/simplewick-01-BAD.pdftex.struct.xml
@@ -1,0 +1,28 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.02"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.05"
+      rolemaps-to="Part"
+     >
+    <Formula xmlns="http://iso.org/pdf2/ssn"
+       id="ID.06"
+       title="equation*"
+       af="mathml-1.xml tag-AFfile1.tex"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:Placement="Block"
+      >
+      <AssociatedFile name="mathml-1.xml" xmlns="">
+      <math display="block" xmlns="http://www.w3.org/1998/Math/MathML"> <mi> <mglyph/> </mi> <mi> <mglyph/> </mi> <mi> <mglyph/> </mi> <mi> <mglyph/> </mi> <msubsup> <mi>𝑎</mi> <mi>𝑖</mi> <mo lspace="0" rspace="0">†</mo> </msubsup> <mo lspace="0" rspace="0" stretchy="false">(</mo> <msub> <mi>𝑡</mi> <mn>1</mn> </msub> <mo lspace="0" rspace="0" stretchy="false">)</mo> <msubsup> <mi>𝑎</mi> <mi>𝑗</mi> <mo lspace="0" rspace="0">†</mo> </msubsup> <mo lspace="0" rspace="0" stretchy="false">(</mo> <msub> <mi>𝑡</mi> <mn>1</mn> </msub> <mo lspace="0" rspace="0" stretchy="false">)</mo> <msub> <mi>𝑎</mi> <mi>𝑗</mi> </msub> <mo lspace="0" rspace="0" stretchy="false">(</mo> <msub> <mi>𝑡</mi> <mn>1</mn> </msub> <mo lspace="0" rspace="0" stretchy="false">)</mo> <msub> <mi>𝑎</mi> <mi>𝑖</mi> </msub> <mo lspace="0" rspace="0" stretchy="false">(</mo> <msub> <mi>𝑡</mi> <mn>1</mn> </msub> <mo lspace="0" rspace="0" stretchy="false">)</mo> <msubsup> <mi>𝑎</mi> <mi>𝑖</mi> <mo lspace="0" rspace="0">†</mo> </msubsup> <mo lspace="0" rspace="0" stretchy="false">(</mo> <msub> <mi>𝑡</mi> <mn>2</mn> </msub> <mo lspace="0" rspace="0" stretchy="false">)</mo> <msubsup> <mi>𝑎</mi> <mi>𝑗</mi> <mo lspace="0" rspace="0">†</mo> </msubsup> <mo lspace="0" rspace="0" stretchy="false">(</mo> <msub> <mi>𝑡</mi> <mn>2</mn> </msub> <mo lspace="0" rspace="0" stretchy="false">)</mo> <msub> <mi>𝑎</mi> <mi>𝑗</mi> </msub> <mo lspace="0" rspace="0" stretchy="false">(</mo> <msub> <mi>𝑡</mi> <mn>2</mn> </msub> <mo lspace="0" rspace="0" stretchy="false">)</mo> <msub> <mi>𝑎</mi> <mi>𝑖</mi> </msub> <mo lspace="0" rspace="0" stretchy="false">(</mo> <msub> <mi>𝑡</mi> <mn>2</mn> </msub> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mspace width="0.167em"/> <mo lspace="0" rspace="0">.</mo> </math>
+      </AssociatedFile>
+      <AssociatedFile name="tag-AFfile1.tex" xmlns="">
+      \begin {equation*}\contraction {}{a}{{}^{\dagger }_i(t_1)a^{\dagger }_j(t_1)}{a} \contraction [2ex]{a^{\dagger }_i(t_1)}{a}{{}^{\dagger }_j(t_1)a_j(t_1)a_i(t_1)a^{\dagger }_i(t_2)a^{\dagger }_j(t_2)a_j(t_2)}{a} \contraction [3ex]{a^{\dagger }_i(t_1)a^{\dagger }_j(t_1)a_j(t_1)}{a}{{}_i(t_1)a^{\dagger }_i(t_2)}{a} \bcontraction {a^{\dagger }_i(t_1)a^{\dagger }_j(t_1)a_j(t_1)a_i(t_1)}{a}{{}^{\dagger }_i(t_2)a^{\dagger }_j(t_2)}{a} a^{\dagger }_i(t_1)a^{\dagger }_j(t_1)a_j(t_1)a_i(t_1) a^{\dagger }_i(t_2)a^{\dagger }_j(t_2)a_j(t_2)a_i(t_2)\,.\end {equation*}
+      </AssociatedFile>
+     <?MarkedContent page="1" ?>a†i(t1)a†j(t1)aj(t1)ai(t1)a†i(t2)a†j(t2)aj(t2)ai(t2).
+    </Formula>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-partial-mathml/simplewick/simplewick-01-BAD.struct.xml
+++ b/tagging-status/testfiles-partial-mathml/simplewick/simplewick-01-BAD.struct.xml
@@ -1,0 +1,28 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.02"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.06"
+      rolemaps-to="Part"
+     >
+    <Formula xmlns="http://iso.org/pdf2/ssn"
+       id="ID.07"
+       title="equation*"
+       af="mathml-1.xml tag-AFfile1.tex"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:Placement="Block"
+      >
+      <AssociatedFile name="mathml-1.xml" xmlns="">
+      <math display="block" xmlns="http://www.w3.org/1998/Math/MathML"> <mi> <mglyph/> </mi> <mi> <mglyph/> </mi> <mi> <mglyph/> </mi> <mi> <mglyph/> </mi> <msubsup> <mi>𝑎</mi> <mi>𝑖</mi> <mo lspace="0" rspace="0">†</mo> </msubsup> <mo lspace="0" rspace="0" stretchy="false">(</mo> <msub> <mi>𝑡</mi> <mn>1</mn> </msub> <mo lspace="0" rspace="0" stretchy="false">)</mo> <msubsup> <mi>𝑎</mi> <mi>𝑗</mi> <mo lspace="0" rspace="0">†</mo> </msubsup> <mo lspace="0" rspace="0" stretchy="false">(</mo> <msub> <mi>𝑡</mi> <mn>1</mn> </msub> <mo lspace="0" rspace="0" stretchy="false">)</mo> <msub> <mi>𝑎</mi> <mi>𝑗</mi> </msub> <mo lspace="0" rspace="0" stretchy="false">(</mo> <msub> <mi>𝑡</mi> <mn>1</mn> </msub> <mo lspace="0" rspace="0" stretchy="false">)</mo> <msub> <mi>𝑎</mi> <mi>𝑖</mi> </msub> <mo lspace="0" rspace="0" stretchy="false">(</mo> <msub> <mi>𝑡</mi> <mn>1</mn> </msub> <mo lspace="0" rspace="0" stretchy="false">)</mo> <msubsup> <mi>𝑎</mi> <mi>𝑖</mi> <mo lspace="0" rspace="0">†</mo> </msubsup> <mo lspace="0" rspace="0" stretchy="false">(</mo> <msub> <mi>𝑡</mi> <mn>2</mn> </msub> <mo lspace="0" rspace="0" stretchy="false">)</mo> <msubsup> <mi>𝑎</mi> <mi>𝑗</mi> <mo lspace="0" rspace="0">†</mo> </msubsup> <mo lspace="0" rspace="0" stretchy="false">(</mo> <msub> <mi>𝑡</mi> <mn>2</mn> </msub> <mo lspace="0" rspace="0" stretchy="false">)</mo> <msub> <mi>𝑎</mi> <mi>𝑗</mi> </msub> <mo lspace="0" rspace="0" stretchy="false">(</mo> <msub> <mi>𝑡</mi> <mn>2</mn> </msub> <mo lspace="0" rspace="0" stretchy="false">)</mo> <msub> <mi>𝑎</mi> <mi>𝑖</mi> </msub> <mo lspace="0" rspace="0" stretchy="false">(</mo> <msub> <mi>𝑡</mi> <mn>2</mn> </msub> <mo lspace="0" rspace="0" stretchy="false">)</mo> <mspace width="0.167em"/> <mo lspace="0" rspace="0">.</mo> </math>
+      </AssociatedFile>
+      <AssociatedFile name="tag-AFfile1.tex" xmlns="">
+      \begin {equation*}\contraction {}{a}{{}^{\dagger }_i(t_1)a^{\dagger }_j(t_1)}{a} \contraction [2ex]{a^{\dagger }_i(t_1)}{a}{{}^{\dagger }_j(t_1)a_j(t_1)a_i(t_1)a^{\dagger }_i(t_2)a^{\dagger }_j(t_2)a_j(t_2)}{a} \contraction [3ex]{a^{\dagger }_i(t_1)a^{\dagger }_j(t_1)a_j(t_1)}{a}{{}_i(t_1)a^{\dagger }_i(t_2)}{a} \bcontraction {a^{\dagger }_i(t_1)a^{\dagger }_j(t_1)a_j(t_1)a_i(t_1)}{a}{{}^{\dagger }_i(t_2)a^{\dagger }_j(t_2)}{a} a^{\dagger }_i(t_1)a^{\dagger }_j(t_1)a_j(t_1)a_i(t_1) a^{\dagger }_i(t_2)a^{\dagger }_j(t_2)a_j(t_2)a_i(t_2)\,.\end {equation*}
+      </AssociatedFile>
+     <?MarkedContent page="1" ?>𝑎†𝑖(𝑡1)𝑎†𝑗(𝑡1)𝑎𝑗(𝑡1)𝑎𝑖(𝑡1)𝑎†𝑖(𝑡2)𝑎†𝑗(𝑡2)𝑎𝑗(𝑡2)𝑎𝑖(𝑡2).
+    </Formula>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-partial-mathml/simplewick/simplewick-01-BAD.tex
+++ b/tagging-status/testfiles-partial-mathml/simplewick/simplewick-01-BAD.tex
@@ -1,0 +1,37 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on
+  }
+\documentclass{article}
+\ifdefined\Uchar
+  \usepackage{unicode-math}
+\fi
+\usepackage{simplewick}
+
+\title{simplewick tagging test}
+
+\begin{document}
+
+\[
+\contraction{}{a}{{}^{\dagger}_i(t_1)a^{\dagger}_j(t_1)}{a}
+%
+\contraction[2ex]{a^{\dagger}_i(t_1)}{a}{%
+{}^{\dagger}_j(t_1)a_j(t_1)a_i(t_1)%
+a^{\dagger}_i(t_2)a^{\dagger}_j(t_2)a_j(t_2)}{a}
+%
+\contraction[3ex]{a^{\dagger}_i(t_1)%
+a^{\dagger}_j(t_1)a_j(t_1)}{a}{{}_i(t_1)%
+a^{\dagger}_i(t_2)}{a}
+%
+\bcontraction{a^{\dagger}_i(t_1)%
+a^{\dagger}_j(t_1)a_j(t_1)a_i(t_1)}%
+{a}{{}^{\dagger}_i(t_2)a^{\dagger}_j(t_2)}{a}
+%
+a^{\dagger}_i(t_1)a^{\dagger}_j(t_1)a_j(t_1)a_i(t_1)
+a^{\dagger}_i(t_2)a^{\dagger}_j(t_2)a_j(t_2)a_i(t_2)\,.
+\]
+
+\end{document}

--- a/tagging-status/testfiles-partial-mathml/vector/vector-01-BAD.pdftex.struct.xml
+++ b/tagging-status/testfiles-partial-mathml/vector/vector-01-BAD.pdftex.struct.xml
@@ -1,0 +1,269 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.005"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.006"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.007"
+        title="math"
+        af="mathml-1.xml tag-AFfile1.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-1.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mi mathvariant="normal">a</mi> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile1.tex" xmlns="">
+       $\relax \mathbf {a}$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>a
+     </Formula>
+     <?MarkedContent page="1" ?>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.008"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.009"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.010"
+        title="math"
+        af="mathml-2.xml tag-AFfile2.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-2.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mover> <mi mathvariant="normal">a</mi> <mo stretchy="false">ˆ</mo> </mover> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile2.tex" xmlns="">
+       $\relax \mathbf {\hat {a}}$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>ˆa
+     </Formula>
+     <?MarkedContent page="1" ?>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.011"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.012"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.013"
+        title="math"
+        af="mathml-3.xml tag-AFfile3.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-3.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mi mathvariant="normal">a</mi> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile3.tex" xmlns="">
+       $\relax \mathsf {a}$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>a
+     </Formula>
+     <?MarkedContent page="1" ?>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.014"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.015"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.016"
+        title="math"
+        af="mathml-4.xml tag-AFfile4.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-4.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mover> <mi mathvariant="normal">a</mi> <mo stretchy="false">ˆ</mo> </mover> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile4.tex" xmlns="">
+       $\relax \mathsf {\hat {a}}$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>ˆa
+     </Formula>
+     <?MarkedContent page="1" ?>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.017"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.018"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.019"
+        title="math"
+        af="mathml-5.xml tag-AFfile5.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-5.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mi> <mglyph/> </mi> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile5.tex" xmlns="">
+       $\relax \undertilde {a}$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>a˜
+     </Formula>
+     <?MarkedContent page="1" ?>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.020"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.021"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.022"
+        title="math"
+        af="mathml-6.xml tag-AFfile6.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-6.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mover> <mi> <mglyph/> </mi> <mo stretchy="false">ˆ</mo> </mover> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile6.tex" xmlns="">
+       $\relax \hat {\undertilde {a}}$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>ˆa˜
+     </Formula>
+     <?MarkedContent page="1" ?>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.023"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.024"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.025"
+        title="math"
+        af="mathml-7.xml tag-AFfile7.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-7.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <msub> <mi>𝑎</mi> <mn>1</mn> </msub> <mo lspace="0" rspace="0">,</mo> <mo lspace="0.167em" rspace="0">…</mo> <mo lspace="0.167em" rspace="0.167em">,</mo> <msub> <mi>𝑎</mi> <mi>𝑛</mi> </msub> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile7.tex" xmlns="">
+       $\relax {a}_{\first@element },\ldots ,{a}_{n}$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>a1,...,an
+     </Formula>
+     <?MarkedContent page="1" ?>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.026"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.027"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.028"
+        title="math"
+        af="mathml-8.xml tag-AFfile8.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-8.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <msub> <mi>𝑎</mi> <mn>1</mn> </msub> <mo lspace="0" rspace="0">,</mo> <mo lspace="0.167em" rspace="0">…</mo> <mo lspace="0.167em" rspace="0.167em">,</mo> <msub> <mi>𝑎</mi> <mn>4</mn> </msub> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile8.tex" xmlns="">
+       $\relax {a}_{\first@element },\ldots ,{a}_{4}$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>a1,...,a4
+     </Formula>
+     <?MarkedContent page="1" ?>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.029"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.030"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.031"
+        title="math"
+        af="mathml-9.xml tag-AFfile9.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-9.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <msub> <mi>𝑎</mi> <mn>0</mn> </msub> <mo lspace="0" rspace="0">,</mo> <mo lspace="0.167em" rspace="0">…</mo> <mo lspace="0.167em" rspace="0.167em">,</mo> <msub> <mi>𝑎</mi> <mn>9</mn> </msub> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile9.tex" xmlns="">
+       $\relax {a}_{\first@element },\ldots ,{a}_{9}$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>a0,...,a9
+     </Formula>
+     <?MarkedContent page="1" ?>
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-partial-mathml/vector/vector-01-BAD.struct.xml
+++ b/tagging-status/testfiles-partial-mathml/vector/vector-01-BAD.struct.xml
@@ -1,0 +1,251 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.006"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.007"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.008"
+        title="math"
+        af="mathml-1.xml tag-AFfile1.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-1.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mi mathvariant="normal">a</mi> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile1.tex" xmlns="">
+       $\relax \mathbf {a}$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>a
+     </Formula>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.009"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.010"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.011"
+        title="math"
+        af="mathml-2.xml tag-AFfile2.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-2.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mover> <mi mathvariant="normal">a</mi> <mo stretchy="false">ˆ</mo> </mover> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile2.tex" xmlns="">
+       $\relax \mathbf {\hat {a}}$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>̂a
+     </Formula>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.012"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.013"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.014"
+        title="math"
+        af="mathml-3.xml tag-AFfile3.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-3.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mi mathvariant="normal">a</mi> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile3.tex" xmlns="">
+       $\relax \mathsf {a}$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>a
+     </Formula>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.015"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.016"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.017"
+        title="math"
+        af="mathml-4.xml tag-AFfile4.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-4.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mover> <mi mathvariant="normal">a</mi> <mo stretchy="false">ˆ</mo> </mover> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile4.tex" xmlns="">
+       $\relax \mathsf {\hat {a}}$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>̂a
+     </Formula>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.018"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.019"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.020"
+        title="math"
+        af="mathml-5.xml tag-AFfile5.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-5.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mi> <mglyph/> </mi> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile5.tex" xmlns="">
+       $\relax \undertilde {a}$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>𝑎̃
+     </Formula>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.021"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.022"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.023"
+        title="math"
+        af="mathml-6.xml tag-AFfile6.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-6.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <mover> <mi> <mglyph/> </mi> <mo stretchy="false">ˆ</mo> </mover> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile6.tex" xmlns="">
+       $\relax \hat {\undertilde {a}}$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>̂𝑎̃
+     </Formula>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.024"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.025"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.026"
+        title="math"
+        af="mathml-7.xml tag-AFfile7.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-7.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <msub> <mi>𝑎</mi> <mn>1</mn> </msub> <mo lspace="0" rspace="0">,</mo> <mo lspace="0.167em" rspace="0">…</mo> <mo lspace="0.167em" rspace="0.167em">,</mo> <msub> <mi>𝑎</mi> <mi>𝑛</mi> </msub> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile7.tex" xmlns="">
+       $\relax {a}_{\first@element },\ldots ,{a}_{n}$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>𝑎1,…,𝑎𝑛
+     </Formula>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.027"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.028"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.029"
+        title="math"
+        af="mathml-8.xml tag-AFfile8.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-8.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <msub> <mi>𝑎</mi> <mn>1</mn> </msub> <mo lspace="0" rspace="0">,</mo> <mo lspace="0.167em" rspace="0">…</mo> <mo lspace="0.167em" rspace="0.167em">,</mo> <msub> <mi>𝑎</mi> <mn>4</mn> </msub> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile8.tex" xmlns="">
+       $\relax {a}_{\first@element },\ldots ,{a}_{4}$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>𝑎1,…,𝑎4
+     </Formula>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.030"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.031"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.032"
+        title="math"
+        af="mathml-9.xml tag-AFfile9.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Inline"
+       >
+       <AssociatedFile name="mathml-9.xml" xmlns="">
+       <math xmlns="http://www.w3.org/1998/Math/MathML"> <msub> <mi>𝑎</mi> <mn>0</mn> </msub> <mo lspace="0" rspace="0">,</mo> <mo lspace="0.167em" rspace="0">…</mo> <mo lspace="0.167em" rspace="0.167em">,</mo> <msub> <mi>𝑎</mi> <mn>9</mn> </msub> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile9.tex" xmlns="">
+       $\relax {a}_{\first@element },\ldots ,{a}_{9}$
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>𝑎0,…,𝑎9
+     </Formula>
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-partial-mathml/vector/vector-01-BAD.tex
+++ b/tagging-status/testfiles-partial-mathml/vector/vector-01-BAD.tex
@@ -1,0 +1,100 @@
+\begin{filecontents}{vector.sty}
+%%
+%% This is file `vector.sty',
+%% generated with the docstrip utility.
+%%
+%% The original source files were:
+%%
+%% vector.dtx  (with options: `package')
+%% 
+%% Copyright (C) 1994 by Nick Efford
+%% 
+%% This file is distributed in the hope that it will be useful,
+%% but WITHOUT ANY WARRANTY; without even the implied warranty of
+%% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+%% 
+\NeedsTeXFormat{LaTeX2e}
+\ProvidesPackage{vector}[1994/09/16 v1.0 vector macros for LaTeX2e (nde)]
+\RequirePackage{ifthen}
+\RequirePackage{calc}
+\newboolean{@wavy}
+\DeclareOption{wavy}{\setboolean{@wavy}{true}}
+\ProcessOptions
+\newcommand{\bvec}[1]{\ensuremath{\mathbf{#1}}}
+\newcommand{\buvec}[1]{\ensuremath{\mathbf{\hat{#1}}}}
+\newcommand{\svec}[1]{\ensuremath{\mathsf{#1}}}
+\newcommand{\suvec}[1]{\ensuremath{\mathsf{\hat{#1}}}}
+\ifthenelse{\boolean{@wavy}}{%
+  \PackageInfo{vector}{wavy underlining selected}
+  \newcommand{\undertilde}[1]{\mathord{\vtop{\ialign{##\crcr
+    $\hfil\displaystyle{#1}\hfil$\crcr\noalign{\kern1.5pt\nointerlineskip}
+    $\hfil\tilde{}\hfil$\crcr\noalign{\kern1.5pt}}}}}
+  \newcommand{\uvec}[1]{\ensuremath{\undertilde{#1}}}
+  \newcommand{\uuvec}[1]{\ensuremath{\hat{\undertilde{#1}}}}}{%
+  \newcommand{\uvec}[1]{\ensuremath{\underline{#1}}}
+  \newcommand{\uuvec}[1]{\ensuremath{\hat{\underline{#1}}}}}
+\def\first@element{1}
+\newcommand{\firstelement}[1]{\def\first@element{#1}}
+\newcommand{\irvec}[2][n]{\ensuremath{{#2}_{\first@element},\ldots,{#2}_{#1}}}
+\newcommand{\icvec}[2][n]{%
+  \begin{array}{c}
+    {#2}_{\first@element}\\ \vdots\\ {#2}_{#1}
+  \end{array}}
+\newcounter{vec@elem}
+\newcommand{\rvec}[3]{%
+  \ensuremath{%
+    \ifthenelse{#3 > #2}{%
+      \setcounter{vec@elem}{#2}
+      \whiledo{\value{vec@elem} < #3}%
+        {{#1}_{\thevec@elem}, \stepcounter{vec@elem}}%
+      {#1}_{#3}}{{#1}_{#2}}}}
+\newcommand{\cvec}[3]{%
+  \ifthenelse{#3 > #2}{%
+    \setcounter{vec@elem}{#2}
+    \begin{array}{c}
+      \whiledo{\value{vec@elem} < #3}%
+        {{#1}_{\thevec@elem} \\ \stepcounter{vec@elem}}%
+      {#1}_{#3}
+    \end{array}}{{#1}_{#2}}}
+\endinput
+%%
+%% End of file `vector.sty'.
+\end{filecontents}
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on
+  }
+\documentclass{article}
+\ifdefined\Uchar
+  \usepackage{unicode-math}
+\fi
+\usepackage[wavy]{vector}
+
+\title{vector tagging test}
+
+\begin{document}
+
+\bvec{a}
+
+\buvec{a}
+
+\svec{a}
+
+\suvec{a}
+
+\uvec{a}
+
+\uuvec{a}
+
+\irvec{a}
+
+\irvec[4]{a}
+
+\firstelement{0}
+
+\irvec[9]{a}
+
+\end{document}

--- a/tagging-status/testfiles-partial/verse/verse-01-BAD.pdftex.struct.xml
+++ b/tagging-status/testfiles-partial/verse/verse-01-BAD.pdftex.struct.xml
@@ -1,0 +1,1 @@
+<run-error code="1" />

--- a/tagging-status/testfiles-partial/verse/verse-01-BAD.struct.xml
+++ b/tagging-status/testfiles-partial/verse/verse-01-BAD.struct.xml
@@ -1,0 +1,1 @@
+<run-error code="1" />

--- a/tagging-status/testfiles-partial/verse/verse-01-BAD.tex
+++ b/tagging-status/testfiles-partial/verse/verse-01-BAD.tex
@@ -1,0 +1,138 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on
+  }
+\documentclass{article}
+
+\usepackage{verse}
+
+\title{verse tagging test}
+
+\newcommand{\garden}{
+I used to love my garden \\
+But now my love is dead \\
+For I found a bachelor's button \\
+In black-eyed Susan's bed.
+}
+
+\begin{document}
+
+\tableofcontents
+
+\renewcommand{\poemtoc}{subsection}
+\poemtitle{A Limerick}
+\settowidth{\versewidth}{There was an old party of Lyme}
+\begin{verse}[\versewidth]
+There was an old party of Lyme \\
+Who married three wives at one time. \\
+\vin When asked: `Why the third?' \\
+\vin He replied: `One's absurd, \\
+And bigamy, sir, is a crime.' \\
+\end{verse}
+
+\settowidth{\versewidth}{But now my love is dead}
+\poemtitle{Love's lost}
+\begin{verse}[\versewidth]
+\begin{altverse}
+\garden
+\end{altverse}
+\end{verse}
+
+\settowidth{\versewidth}{There was a young lady of Ryde}
+\poemtitle{The Young Lady of Ryde}
+\begin{verse}[\versewidth]
+\poemlines{3}
+\indentpattern{00110}
+\begin{patverse}
+There was a young lady of Ryde \\
+Who ate some apples and died. \\
+The apples fermented \\
+Inside the lamented \\
+And made cider inside her inside. \\
+\end{patverse}
+\poemlines{0}
+\end{verse}
+
+\settowidth{\versewidth}{In a cavern, in a canyon,}
+\poemtitle{Clementine}
+\begin{verse}[\versewidth]
+\poemlines{2}
+\begin{altverse}
+\flagverse{1.} In a cavern, in a canyon, \\
+Excavating for a mine, \\
+Lived a miner, forty-niner, \label{vs:49} \\
+And his daughter, Clementine. \\!
+\end{altverse}
+\begin{altverse}
+\flagverse{\textsc{chorus}} Oh my darling, Oh my darling, \\
+Oh my darling Clementine. \\
+Thou art lost and gone forever, \\
+Oh my darling Clementine \\!
+\end{altverse}
+\poemlines{0}
+\end{verse}
+
+\poemtitle{Mouse's Tale}
+\settowidth{\versewidth}{a mouse that morning}
+\indentpattern{0135554322112346898779775545653222345544456688778899}
+\begin{verse}[\versewidth]
+\setlength{\vgap}{1em}
+\begin{patverse}
+\large Fury said to \\
+  a mouse, That \\
+  he met \\
+  in the \\
+  house, \\
+\normalsize `Let us \\
+  both go \\
+  to law: \\
+  \emph{I} will \\
+  prosecute \\
+  \textit{you.} --- \\
+  Come, I'll \\
+\small take no \\
+  denial; \\
+  We must \\
+  have a \\
+  trial: \\
+  For \\
+\footnotesize really \\
+  this \\
+  morning \\
+  I've \\
+  nothing \\
+  to do.' \\
+  Said the \\
+  mouse to \\
+\scriptsize the cur, \\
+  Such a \\
+  trial, \\
+  dear sir, \\
+  With no \\
+  jury or \\
+  judge, \\
+  would be \\
+  wasting \\
+  our breath.' \\
+\tiny  `I'll be \\
+  judge, \\
+  I'll be \\
+  jury.' \\
+  Said \\
+  cunning \\
+  old Fury; \\
+  `I'll try \\
+  the whole \\
+  cause \\
+  and \\
+  condemn \\
+  you \\
+  to \\
+  death.'  \par
+\end{patverse}
+\end{verse}
+
+\end{document}


### PR DESCRIPTION
Lists pxgreeks and txgreeks as partially compatible without tests.

Lists simplewick, simpler-wick, vector, and verse as partially compatible with tests.

Lists srcltx and vmargin as compatible without tests.

Lists tweaklist and units as incompatible with tests.

Adds a test for subcaption.