### PR TITLE
update tests

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -4676,7 +4676,7 @@
              can use, for example, `\\begin{itemize}[...]` out of the box."
   tasks: Check which keys are not yet supported and what else is missing.
   references: [1]
-  issues: [61,1301,1441]
+  issues: [61,1301,1441,1518]
   closed-issues: [4]
   tests: false
   package-repository: "https://github.com/jbezos/enumitem"

--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -15152,13 +15152,12 @@
   status: partially-compatible
   included-in: [ol0.02]
   priority: 9
-  comments: "firstaid is required for the fix of issue 49. `\\poemtitle` errors.
-             `\\flagverse` and line numbers not tagged ideally."
-  issues: [1468,1469]
-  closed-issues: [49]
+  comments: "`\\flagverse` and line numbers not tagged ideally."
+  issues: [1469]
+  closed-issues: [49,1468]
   tests: true
   package-repository: "https://github.com/LaTeX-Package-Repositories/herries-press"
-  updated: 2026-07-01
+  updated: 2026-08-10
 
 - name: version
   type: package

--- a/tagging-status/testfiles-compatible-luatex/marginalia/marginalia-01.struct.xml
+++ b/tagging-status/testfiles-compatible-luatex/marginalia/marginalia-01.struct.xml
@@ -19,6 +19,7 @@
      <?MarkedContent page="1" ?>
      <?MarkedContent page="1" ?> Some final body text.
      <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
     </text>
     <Aside xmlns="http://iso.org/pdf2/ssn"
        id="ID.008"

--- a/tagging-status/testfiles-partial/verse/verse-01-BAD.pdftex.struct.xml
+++ b/tagging-status/testfiles-partial/verse/verse-01-BAD.pdftex.struct.xml
@@ -1,1 +1,0 @@
-<run-error code="1" />

--- a/tagging-status/testfiles-partial/verse/verse-01-BAD.struct.xml
+++ b/tagging-status/testfiles-partial/verse/verse-01-BAD.struct.xml
@@ -1,1 +1,0 @@
-<run-error code="1" />

--- a/tagging-status/testfiles-partial/verse/verse-01.pdftex.struct.xml
+++ b/tagging-status/testfiles-partial/verse/verse-01.pdftex.struct.xml
@@ -1,0 +1,336 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <Sect xmlns="http://iso.org/pdf2/ssn"
+      id="ID.005"
+     >
+    <section xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.006"
+       title="Contents"
+       rolemaps-to="H1"
+      >
+     <?MarkedContent page="1" ?>Contents
+    </section>
+    <TOC xmlns="http://iso.org/pdf/ssn"
+       id="ID.007"
+       title="toc"
+      >
+     <TOCI xmlns="http://iso.org/pdf/ssn"
+        id="ID.008"
+        title="Something beside ``A Limerick'' in the ToC"
+       >
+       <?References objects="1" ?>
+      <Reference xmlns="http://iso.org/pdf/ssn"
+         id="ID.009"
+        >
+       <?MarkedContent page="1" ?>Something beside “A Limerick” in the ToC
+       <?MarkedContent page="1" ?>1
+      </Reference>
+     </TOCI>
+     <TOCI xmlns="http://iso.org/pdf/ssn"
+        id="ID.010"
+        title="Love's lost"
+       >
+       <?References objects="2" ?>
+      <Reference xmlns="http://iso.org/pdf/ssn"
+         id="ID.011"
+        >
+       <?MarkedContent page="1" ?>Love’s lost
+       <?MarkedContent page="1" ?>1
+      </Reference>
+     </TOCI>
+    </TOC>
+   </Sect>
+   <Sect xmlns="http://iso.org/pdf2/ssn"
+      id="ID.012"
+     >
+    <chapter xmlns="https://www.latex-project.org/ns/book"
+       id="ID.013"
+       title="A Limerick"
+       rolemaps-to="H1"
+       referenced-as="1"
+      >
+     <?MarkedContent page="1" ?>A Limerick
+    </chapter>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.014"
+       rolemaps-to="Part"
+      >
+     <list xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.015"
+        xmlns:List="http://iso.org/pdf/ssn/List"
+        List:ListNumbering="Unordered"
+        rolemaps-to="L"
+       >
+      <item xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.016"
+         rolemaps-to="LI"
+        >
+       <itemlabel xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.017"
+          rolemaps-to="Lbl"
+         >
+        <?MarkedContent page="1" ?>
+       </itemlabel>
+       <itembody xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.018"
+          rolemaps-to="LBody"
+         >
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.019"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.020"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>There was an old party of Lyme
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.021"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.022"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>Who married three wives at one time.
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.023"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.024"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>When asked: ‘Why the third?’
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.025"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.026"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>He replied: ‘One’s absurd,
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.027"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.028"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>And bigamy, sir, is a crime.’
+         </text>
+        </text-unit>
+       </itembody>
+      </item>
+     </list>
+    </text-unit>
+   </Sect>
+   <Sect xmlns="http://iso.org/pdf2/ssn"
+      id="ID.029"
+     >
+    <chapter xmlns="https://www.latex-project.org/ns/book"
+       id="ID.030"
+       title="Love's lost"
+       rolemaps-to="H1"
+       referenced-as="2"
+      >
+     <?MarkedContent page="1" ?>Love’s lost
+    </chapter>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.031"
+       rolemaps-to="Part"
+      >
+     <list xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.032"
+        xmlns:List="http://iso.org/pdf/ssn/List"
+        List:ListNumbering="Unordered"
+        rolemaps-to="L"
+       >
+      <item xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.033"
+         rolemaps-to="LI"
+        >
+       <itemlabel xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.034"
+          rolemaps-to="Lbl"
+         >
+        <?MarkedContent page="1" ?>
+       </itemlabel>
+       <itembody xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.035"
+          rolemaps-to="LBody"
+         >
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.036"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.037"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>I used to love my garden
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.038"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.039"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>But now my love is dead
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.040"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.041"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>For I found a bachelor’s button
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.042"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.043"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>In black-eyed Susan’s bed.
+         </text>
+        </text-unit>
+       </itembody>
+      </item>
+     </list>
+    </text-unit>
+   </Sect>
+   <Sect xmlns="http://iso.org/pdf2/ssn"
+      id="ID.044"
+     >
+    <chapter xmlns="https://www.latex-project.org/ns/book"
+       id="ID.045"
+       title="Yet another love's lost"
+       rolemaps-to="H1"
+      >
+     <?MarkedContent page="1" ?>Yet another love’s lost
+    </chapter>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.046"
+       rolemaps-to="Part"
+      >
+     <list xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.047"
+        xmlns:List="http://iso.org/pdf/ssn/List"
+        List:ListNumbering="Unordered"
+        rolemaps-to="L"
+       >
+      <item xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.048"
+         rolemaps-to="LI"
+        >
+       <itemlabel xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.049"
+          rolemaps-to="Lbl"
+         >
+        <?MarkedContent page="1" ?>
+       </itemlabel>
+       <itembody xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.050"
+          rolemaps-to="LBody"
+         >
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.051"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.052"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>I used to love my garden
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.053"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.054"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>But now my love is dead
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.055"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.056"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>For I found a bachelor’s button
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.057"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.058"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>In black-eyed Susan’s bed.
+         </text>
+        </text-unit>
+       </itembody>
+      </item>
+     </list>
+    </text-unit>
+   </Sect>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-partial/verse/verse-01.struct.xml
+++ b/tagging-status/testfiles-partial/verse/verse-01.struct.xml
@@ -1,0 +1,333 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <Sect xmlns="http://iso.org/pdf2/ssn"
+      id="ID.006"
+     >
+    <section xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.007"
+       title="Contents"
+       rolemaps-to="H1"
+      >
+     <?MarkedContent page="1" ?>Contents
+    </section>
+    <TOC xmlns="http://iso.org/pdf/ssn"
+       id="ID.008"
+       title="toc"
+      >
+     <TOCI xmlns="http://iso.org/pdf/ssn"
+        id="ID.009"
+        title="Something beside ``A Limerick'' in the ToC"
+       >
+       <?References objects="1" ?>
+      <Reference xmlns="http://iso.org/pdf/ssn"
+         id="ID.010"
+        >
+       <?MarkedContent page="1" ?>Something beside “A Limerick” in the ToC
+       <?MarkedContent page="1" ?>1
+      </Reference>
+     </TOCI>
+     <TOCI xmlns="http://iso.org/pdf/ssn"
+        id="ID.011"
+        title="Love's lost"
+       >
+       <?References objects="2" ?>
+      <Reference xmlns="http://iso.org/pdf/ssn"
+         id="ID.012"
+        >
+       <?MarkedContent page="1" ?>Love’s lost
+       <?MarkedContent page="1" ?>1
+      </Reference>
+     </TOCI>
+    </TOC>
+   </Sect>
+   <Sect xmlns="http://iso.org/pdf2/ssn"
+      id="ID.013"
+     >
+    <chapter xmlns="https://www.latex-project.org/ns/book"
+       id="ID.014"
+       title="A Limerick"
+       rolemaps-to="H1"
+       referenced-as="1"
+      >
+     <?MarkedContent page="1" ?>A Limerick
+    </chapter>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.015"
+       rolemaps-to="Part"
+      >
+     <list xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.016"
+        xmlns:List="http://iso.org/pdf/ssn/List"
+        List:ListNumbering="Unordered"
+        rolemaps-to="L"
+       >
+      <item xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.017"
+         rolemaps-to="LI"
+        >
+       <itemlabel xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.018"
+          rolemaps-to="Lbl"
+         >
+       </itemlabel>
+       <itembody xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.019"
+          rolemaps-to="LBody"
+         >
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.020"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.021"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>There was an old party of Lyme
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.022"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.023"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>Who married three wives at one time.
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.024"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.025"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?> When asked: ‘Why the third?’
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.026"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.027"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?> He replied: ‘One’s absurd,
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.028"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.029"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>And bigamy, sir, is a crime.’
+         </text>
+        </text-unit>
+       </itembody>
+      </item>
+     </list>
+    </text-unit>
+   </Sect>
+   <Sect xmlns="http://iso.org/pdf2/ssn"
+      id="ID.030"
+     >
+    <chapter xmlns="https://www.latex-project.org/ns/book"
+       id="ID.031"
+       title="Love's lost"
+       rolemaps-to="H1"
+       referenced-as="2"
+      >
+     <?MarkedContent page="1" ?>Love’s lost
+    </chapter>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.032"
+       rolemaps-to="Part"
+      >
+     <list xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.033"
+        xmlns:List="http://iso.org/pdf/ssn/List"
+        List:ListNumbering="Unordered"
+        rolemaps-to="L"
+       >
+      <item xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.034"
+         rolemaps-to="LI"
+        >
+       <itemlabel xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.035"
+          rolemaps-to="Lbl"
+         >
+       </itemlabel>
+       <itembody xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.036"
+          rolemaps-to="LBody"
+         >
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.037"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.038"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>I used to love my garden
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.039"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.040"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?> But now my love is dead
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.041"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.042"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>For I found a bachelor’s button
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.043"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.044"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?> In black-eyed Susan’s bed.
+         </text>
+        </text-unit>
+       </itembody>
+      </item>
+     </list>
+    </text-unit>
+   </Sect>
+   <Sect xmlns="http://iso.org/pdf2/ssn"
+      id="ID.045"
+     >
+    <chapter xmlns="https://www.latex-project.org/ns/book"
+       id="ID.046"
+       title="Yet another love's lost"
+       rolemaps-to="H1"
+      >
+     <?MarkedContent page="1" ?>Yet another love’s lost
+    </chapter>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.047"
+       rolemaps-to="Part"
+      >
+     <list xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.048"
+        xmlns:List="http://iso.org/pdf/ssn/List"
+        List:ListNumbering="Unordered"
+        rolemaps-to="L"
+       >
+      <item xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.049"
+         rolemaps-to="LI"
+        >
+       <itemlabel xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.050"
+          rolemaps-to="Lbl"
+         >
+       </itemlabel>
+       <itembody xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.051"
+          rolemaps-to="LBody"
+         >
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.052"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.053"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>I used to love my garden
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.054"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.055"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?> But now my love is dead
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.056"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.057"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>For I found a bachelor’s button
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.058"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.059"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?> In black-eyed Susan’s bed.
+         </text>
+        </text-unit>
+       </itembody>
+      </item>
+     </list>
+    </text-unit>
+   </Sect>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-partial/verse/verse-01.tex
+++ b/tagging-status/testfiles-partial/verse/verse-01.tex
@@ -1,0 +1,51 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on
+  }
+\documentclass{article}
+
+\usepackage{verse}
+
+\title{verse tagging test}
+
+\newcommand{\garden}{
+I used to love my garden \\
+But now my love is dead \\
+For I found a bachelor's button \\
+In black-eyed Susan's bed.
+}
+
+\begin{document}
+
+\tableofcontents
+
+\renewcommand{\poemtoc}{subsection}
+\poemtitle[Something beside ``A Limerick'' in the ToC]{A Limerick}
+\settowidth{\versewidth}{There was an old party of Lyme}
+\begin{verse}[\versewidth]
+There was an old party of Lyme \\
+Who married three wives at one time. \\
+\vin When asked: `Why the third?' \\
+\vin He replied: `One's absurd, \\
+And bigamy, sir, is a crime.' \\
+\end{verse}
+
+\settowidth{\versewidth}{But now my love is dead}
+\poemtitle{Love's lost}
+\begin{verse}[\versewidth]
+\begin{altverse}
+\garden
+\end{altverse}
+\end{verse}
+
+\poemtitle*{Yet another love's lost}
+\begin{verse}[\versewidth]
+\begin{altverse}
+\garden
+\end{altverse}
+\end{verse}
+
+\end{document}

--- a/tagging-status/testfiles-partial/verse/verse-02-BAD.pdftex.struct.xml
+++ b/tagging-status/testfiles-partial/verse/verse-02-BAD.pdftex.struct.xml
@@ -1,0 +1,859 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.0002"
+    >
+   <Sect xmlns="http://iso.org/pdf2/ssn"
+      id="ID.0005"
+     >
+    <chapter xmlns="https://www.latex-project.org/ns/book"
+       id="ID.0006"
+       title="Clementine"
+       rolemaps-to="H1"
+      >
+     <?MarkedContent page="1" ?>Clementine
+    </chapter>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0007"
+       rolemaps-to="Part"
+      >
+     <list xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.0008"
+        xmlns:List="http://iso.org/pdf/ssn/List"
+        List:ListNumbering="Unordered"
+        rolemaps-to="L"
+       >
+      <item xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0009"
+         rolemaps-to="LI"
+        >
+       <itemlabel xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.0010"
+          rolemaps-to="Lbl"
+         >
+        <?MarkedContent page="1" ?>
+       </itemlabel>
+       <itembody xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.0011"
+          rolemaps-to="LBody"
+         >
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0012"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0013"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>1. In a cavern, in a canyon,
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0014"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0015"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>Excavating for a mine, 2
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0016"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0017"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>Lived a miner, forty-niner,
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0018"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0019"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>And his daughter, Clementine. 4
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0020"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0021"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>chorus Oh my darling, Oh my darling,
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0022"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0023"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>Oh my darling Clementine. 6
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0024"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0025"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>Thou art lost and gone forever,
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0026"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0027"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>Oh my darling Clementine 8
+         </text>
+        </text-unit>
+       </itembody>
+      </item>
+     </list>
+    </text-unit>
+   </Sect>
+   <Sect xmlns="http://iso.org/pdf2/ssn"
+      id="ID.0028"
+     >
+    <chapter xmlns="https://www.latex-project.org/ns/book"
+       id="ID.0029"
+       title="Mouse's Tale"
+       rolemaps-to="H1"
+      >
+     <?MarkedContent page="1" ?>Mouse’s Tale
+    </chapter>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0030"
+       rolemaps-to="Part"
+      >
+     <list xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.0031"
+        xmlns:List="http://iso.org/pdf/ssn/List"
+        List:ListNumbering="Unordered"
+        rolemaps-to="L"
+       >
+      <item xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0032"
+         rolemaps-to="LI"
+        >
+       <itemlabel xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.0033"
+          rolemaps-to="Lbl"
+         >
+        <?MarkedContent page="1" ?>
+       </itemlabel>
+       <itembody xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.0034"
+          rolemaps-to="LBody"
+         >
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0035"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0036"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>Fury said to
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0037"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0038"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>a mouse, That
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0039"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0040"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>he met
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0041"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0042"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>in the
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0043"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0044"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>house,
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0045"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0046"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>‘Let us
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0047"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0048"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>both go
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0049"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0050"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>to law:
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0051"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0052"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>
+          <Em xmlns="http://iso.org/pdf2/ssn"
+             id="ID.0053"
+            >
+           <?MarkedContent page="1" ?>I
+          </Em>
+          <?MarkedContent page="1" ?>will
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0054"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0055"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>prosecute
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0056"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0057"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>you. —
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0058"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0059"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>Come, I’ll
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0060"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0061"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>take no
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0062"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0063"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>denial;
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0064"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0065"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>We must
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0066"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0067"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>have a
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0068"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0069"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>trial:
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0070"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0071"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>For
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0072"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0073"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>really
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0074"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0075"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>this
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0076"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0077"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>morning
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0078"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0079"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>I’ve
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0080"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0081"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>nothing
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0082"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0083"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>to do.’
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0084"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0085"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>Said the
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0086"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0087"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>mouse to
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0088"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0089"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>the cur,
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0090"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0091"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>Such a
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0092"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0093"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>trial,
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0094"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0095"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>dear sir,
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0096"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0097"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>With no
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0098"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0099"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>jury or
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0100"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0101"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>judge,
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0102"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0103"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>would be
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0104"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0105"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>wasting
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0106"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0107"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>our breath.’
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0108"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0109"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="2" ?>‘I’ll be
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0110"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0111"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="2" ?>judge,
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0112"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0113"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="2" ?>I’ll be
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0114"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0115"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="2" ?>jury.’
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0116"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0117"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="2" ?>Said
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0118"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0119"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="2" ?>cunning
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0120"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0121"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="2" ?>old Fury;
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0122"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0123"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="2" ?>‘I’ll try
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0124"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0125"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="2" ?>the whole
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0126"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0127"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="2" ?>cause
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0128"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0129"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="2" ?>and
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0130"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0131"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="2" ?>condemn
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0132"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0133"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="2" ?>you
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0134"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0135"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="2" ?>to
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0136"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0137"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="2" ?>death.’
+         </text>
+        </text-unit>
+       </itembody>
+      </item>
+     </list>
+    </text-unit>
+   </Sect>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-partial/verse/verse-02-BAD.struct.xml
+++ b/tagging-status/testfiles-partial/verse/verse-02-BAD.struct.xml
@@ -1,0 +1,857 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.0002"
+    >
+   <Sect xmlns="http://iso.org/pdf2/ssn"
+      id="ID.0006"
+     >
+    <chapter xmlns="https://www.latex-project.org/ns/book"
+       id="ID.0007"
+       title="Clementine"
+       rolemaps-to="H1"
+      >
+     <?MarkedContent page="1" ?>Clementine
+    </chapter>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0008"
+       rolemaps-to="Part"
+      >
+     <list xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.0009"
+        xmlns:List="http://iso.org/pdf/ssn/List"
+        List:ListNumbering="Unordered"
+        rolemaps-to="L"
+       >
+      <item xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0010"
+         rolemaps-to="LI"
+        >
+       <itemlabel xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.0011"
+          rolemaps-to="Lbl"
+         >
+       </itemlabel>
+       <itembody xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.0012"
+          rolemaps-to="LBody"
+         >
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0013"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0014"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>1. In a cavern, in a canyon,
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0015"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0016"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?> Excavating for a mine,2
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0017"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0018"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>Lived a miner, forty-niner, 
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0019"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0020"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?> And his daughter, Clementine.4
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0021"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0022"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>chorus Oh my darling, Oh my darling,
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0023"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0024"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?> Oh my darling Clementine.6
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0025"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0026"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>Thou art lost and gone forever,
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0027"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0028"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?> Oh my darling Clementine8
+         </text>
+        </text-unit>
+       </itembody>
+      </item>
+     </list>
+    </text-unit>
+   </Sect>
+   <Sect xmlns="http://iso.org/pdf2/ssn"
+      id="ID.0029"
+     >
+    <chapter xmlns="https://www.latex-project.org/ns/book"
+       id="ID.0030"
+       title="Mouse's Tale"
+       rolemaps-to="H1"
+      >
+     <?MarkedContent page="1" ?>Mouse’s Tale
+    </chapter>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0031"
+       rolemaps-to="Part"
+      >
+     <list xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.0032"
+        xmlns:List="http://iso.org/pdf/ssn/List"
+        List:ListNumbering="Unordered"
+        rolemaps-to="L"
+       >
+      <item xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0033"
+         rolemaps-to="LI"
+        >
+       <itemlabel xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.0034"
+          rolemaps-to="Lbl"
+         >
+       </itemlabel>
+       <itembody xmlns="https://www.latex-project.org/ns/dflt"
+          id="ID.0035"
+          rolemaps-to="LBody"
+         >
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0036"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0037"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?>Fury said to
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0038"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0039"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?> a mouse, That
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0040"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0041"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?> he met
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0042"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0043"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?> in the
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0044"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0045"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?> house,
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0046"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0047"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?> ‘Let us
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0048"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0049"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?> both go
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0050"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0051"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?> to law:
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0052"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0053"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?> 
+          <Em xmlns="http://iso.org/pdf2/ssn"
+             id="ID.0054"
+            >
+           <?MarkedContent page="1" ?>I
+          </Em>
+          <?MarkedContent page="1" ?> will
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0055"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0056"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?> prosecute
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0057"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0058"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?> you. —
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0059"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0060"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?> Come, I’ll
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0061"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0062"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?> take no
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0063"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0064"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?> denial;
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0065"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0066"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?> We must
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0067"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0068"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?> have a
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0069"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0070"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?> trial:
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0071"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0072"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?> For
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0073"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0074"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?> really
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0075"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0076"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?> this
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0077"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0078"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?> morning
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0079"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0080"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?> I’ve
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0081"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0082"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?> nothing
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0083"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0084"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?> to do.’
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0085"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0086"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?> Said the
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0087"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0088"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?> mouse to
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0089"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0090"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?> the cur,
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0091"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0092"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?> Such a
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0093"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0094"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?> trial,
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0095"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0096"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?> dear sir,
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0097"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0098"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?> With no
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0099"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0100"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?> jury or
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0101"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0102"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?> judge,
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0103"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0104"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?> would be
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0105"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0106"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?> wasting
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0107"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0108"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="1" ?> our breath.’
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0109"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0110"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="2" ?> ‘I’ll be
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0111"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0112"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="2" ?> judge,
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0113"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0114"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="2" ?> I’ll be
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0115"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0116"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="2" ?> jury.’
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0117"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0118"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="2" ?> Said
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0119"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0120"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="2" ?> cunning
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0121"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0122"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="2" ?> old Fury;
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0123"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0124"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="2" ?> ‘I’ll try
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0125"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0126"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="2" ?> the whole
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0127"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0128"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="2" ?> cause
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0129"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0130"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="2" ?> and
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0131"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0132"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="2" ?> condemn
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0133"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0134"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="2" ?> you
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0135"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0136"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="2" ?> to
+         </text>
+        </text-unit>
+        <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+           id="ID.0137"
+           rolemaps-to="Part"
+          >
+         <text xmlns="https://www.latex-project.org/ns/dflt"
+            id="ID.0138"
+            xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+            Layout:TextAlign="Justify"
+            rolemaps-to="P"
+           >
+          <?MarkedContent page="2" ?> death.’
+         </text>
+        </text-unit>
+       </itembody>
+      </item>
+     </list>
+    </text-unit>
+   </Sect>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-partial/verse/verse-02-BAD.tex
+++ b/tagging-status/testfiles-partial/verse/verse-02-BAD.tex
@@ -9,52 +9,9 @@
 
 \usepackage{verse}
 
-\title{verse tagging test}
-
-\newcommand{\garden}{
-I used to love my garden \\
-But now my love is dead \\
-For I found a bachelor's button \\
-In black-eyed Susan's bed.
-}
+\title{verse tagging test -- 2}
 
 \begin{document}
-
-\tableofcontents
-
-\renewcommand{\poemtoc}{subsection}
-\poemtitle{A Limerick}
-\settowidth{\versewidth}{There was an old party of Lyme}
-\begin{verse}[\versewidth]
-There was an old party of Lyme \\
-Who married three wives at one time. \\
-\vin When asked: `Why the third?' \\
-\vin He replied: `One's absurd, \\
-And bigamy, sir, is a crime.' \\
-\end{verse}
-
-\settowidth{\versewidth}{But now my love is dead}
-\poemtitle{Love's lost}
-\begin{verse}[\versewidth]
-\begin{altverse}
-\garden
-\end{altverse}
-\end{verse}
-
-\settowidth{\versewidth}{There was a young lady of Ryde}
-\poemtitle{The Young Lady of Ryde}
-\begin{verse}[\versewidth]
-\poemlines{3}
-\indentpattern{00110}
-\begin{patverse}
-There was a young lady of Ryde \\
-Who ate some apples and died. \\
-The apples fermented \\
-Inside the lamented \\
-And made cider inside her inside. \\
-\end{patverse}
-\poemlines{0}
-\end{verse}
 
 \settowidth{\versewidth}{In a cavern, in a canyon,}
 \poemtitle{Clementine}


### PR DESCRIPTION
The marginalia test added an extra MC after a package update.

I broke the verse tests into two now that the only open issue is #1469, assuming the current tagging of poems makes sense.