### PR TITLE
update tests

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -10812,19 +10812,19 @@
   type: package
   status: currently-incompatible
   priority: 9
-  tests: false
+  tests: true
   comments: "See parallel package."
   package-repository: "https://github.com/LaTeX-Package-Repositories/oberdiek"
-  updated: 2026-07-04
+  updated: 2026-08-12
 
 - name: pdfcolparcolumns
   type: package
   status: currently-incompatible
   priority: 9
-  tests: false
+  tests: true
   comments: "See parcolumns package."
   package-repository: "https://github.com/LaTeX-Package-Repositories/oberdiek"
-  updated: 2026-07-04
+  updated: 2026-08-12
 
 - name: pdfcomment
   type: package
@@ -10932,11 +10932,10 @@
 
 - name: perltex
   type: package
-  status: unchecked
+  status: compatible
   priority: 9
-  tests: false
-  tasks: needs tests
-  updated: 2024-07-18
+  tests: excluded
+  updated: 2026-08-12
 
 - name: perpage
   type: package
@@ -11485,31 +11484,31 @@
 
 - name: program
   type: package
-  status: unchecked
+  status: currently-incompatible
   included-in: [ol0.1]
   priority: 9
-  tests: false
-  tasks: needs tests
-  updated: 2026-01-23
+  tests: true
+  issues: [1524]
+  updated: 2026-08-12
 
 - name: progressbar
   type: package
-  status: unchecked
+  status: partially-compatible
   included-in: [ol0.02]
   priority: 9
-  tests: false
-  tasks: needs tests
-  updated: 2026-01-23
+  tests: true
+  comments: "No way to pass alt text to underlying tikzpicture."
+  updated: 2026-08-12
 
 - name: proof
   ctan-pkg: lkproof
   type: package
-  status: unchecked
+  status: partially-compatible
   included-in: [ol0.02]
   priority: 9
-  tests: false
-  tasks: needs tests
-  updated: 2026-01-23
+  tests: true
+  comments: "No luamml support."
+  updated: 2026-08-12
 
 - name: prooftrees
   type: package
@@ -11540,12 +11539,12 @@
 
 - name: pseudocode
   type: package
-  status: unchecked
+  status: currently-incompatible
   included-in: [ol0.02]
   priority: 9
-  tests: false
-  tasks: needs tests
-  updated: 2026-01-23
+  tests: true
+  issues: [1525]
+  updated: 2026-08-12
 
 - name: psfrag
   type: package
@@ -11968,12 +11967,12 @@
 
 - name: qcircuit
   type: package
-  status: unchecked
+  status: currently-incompatible
   included-in: [ol0.1]
   priority: 9
-  tests: false
-  tasks: needs tests
-  updated: 2026-01-23
+  tests: true
+  comments: "See xy package."
+  updated: 2026-08-12
 
 - name: qrcode
   type: package
@@ -11986,21 +11985,21 @@
 
 - name: qtree
   type: package
-  status: unchecked
+  status: currently-incompatible
   included-in: [ol0.1]
   priority: 9
-  tests: false
-  tasks: needs tests
-  updated: 2026-01-23
+  tests: true
+  issues: [1526]
+  updated: 2026-08-12
 
 - name: quantikz
   type: package
-  status: unchecked
+  status: currently-incompatible
   included-in: [ol0.1]
   priority: 9
-  tests: false
-  tasks: needs tests
-  updated: 2026-01-23
+  tests: true
+  comments: "See tikz-cd."
+  updated: 2026-08-12
 
 - name: quattrocento
   type: package
@@ -12491,12 +12490,12 @@
 
 - name: schemata
   type: package
-  status: unchecked
+  status: partially-compatible
   included-in: [ol0.02]
   priority: 9
-  tests: false
-  tasks: needs tests
-  updated: 2026-01-23
+  tests: true
+  comments: "Schema are tagged as math but there is no luamml support."
+  updated: 2026-08-12
 
 - name: schola-otf
   type: package

--- a/tagging-status/testfiles-excluded/perltex/perltex-01.tex
+++ b/tagging-status/testfiles-excluded/perltex/perltex-01.tex
@@ -1,0 +1,42 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on,
+  }
+\documentclass{article}
+\usepackage{perltex}
+\ifdefined\Uchar
+  \usepackage{unicode-math}
+\fi
+
+\title{perltex tagging test}
+
+\begin{document}
+\perlnewcommand{\hilbertmatrix}[1]{
+  my $result = '
+\[
+\renewcommand{\arraystretch}{1.3}
+';
+  $result .= '\begin{array}{' . 'c' x $_[0] . "}\n";
+  foreach $j (0 .. $_[0]-1) {
+    my @row;
+    foreach $i (0 .. $_[0]-1) {
+      push @row, ($i+$j) ? (sprintf '\frac{1}{%d}', $i+$j+1) : '1';
+    }
+    $result .= join (' & ', @row) . " \\\\\n";
+  }
+  $result .= '\end{array}
+\]';
+  return $result;
+}
+
+\hilbertmatrix{20}
+
+\perlnewcommand{\substr}[3]{substr $_[0], $_[1], $_[2]}
+
+\newcommand{\str}{superlative}
+A sample substring of ``\str'' is ``\substr{\str}{2}{4}''.
+
+\end{document}

--- a/tagging-status/testfiles-incompatible-mathml/program/program-01-BAD.pdftex.struct.xml
+++ b/tagging-status/testfiles-incompatible-mathml/program/program-01-BAD.pdftex.struct.xml
@@ -1,0 +1,1 @@
+<run-error code="1" />

--- a/tagging-status/testfiles-incompatible-mathml/program/program-01-BAD.struct.xml
+++ b/tagging-status/testfiles-incompatible-mathml/program/program-01-BAD.struct.xml
@@ -1,0 +1,1 @@
+<run-error code="1" />

--- a/tagging-status/testfiles-incompatible-mathml/program/program-01-BAD.tex
+++ b/tagging-status/testfiles-incompatible-mathml/program/program-01-BAD.tex
@@ -1,0 +1,28 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on,
+  }
+\documentclass{article}
+
+\ifdefined\Uchar
+  \usepackage{unicode-math}
+\fi
+\usepackage{program}
+
+\title{program tagging test}
+
+\begin{document}
+
+\begin{program}
+t := \set{x | \displaystyle\frac{x}{y} = z};
+t := t \setminus u;
+z := a \tab {} + b + c + d
+	    {} + e + f + g
+	    {} + h + i + j; \untab
+\IF x = 0 \THEN y :=0 \FI
+\end{program}
+
+\end{document}

--- a/tagging-status/testfiles-incompatible-mathml/pseudocode/pseudocode-01-BAD.pdftex.struct.xml
+++ b/tagging-status/testfiles-incompatible-mathml/pseudocode/pseudocode-01-BAD.pdftex.struct.xml
@@ -1,0 +1,1 @@
+<run-error code="1" />

--- a/tagging-status/testfiles-incompatible-mathml/pseudocode/pseudocode-01-BAD.struct.xml
+++ b/tagging-status/testfiles-incompatible-mathml/pseudocode/pseudocode-01-BAD.struct.xml
@@ -1,0 +1,1 @@
+<run-error code="1" />

--- a/tagging-status/testfiles-incompatible-mathml/pseudocode/pseudocode-01-BAD.tex
+++ b/tagging-status/testfiles-incompatible-mathml/pseudocode/pseudocode-01-BAD.tex
@@ -1,0 +1,21 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on,
+  }
+\documentclass{article}
+\ifdefined\Uchar
+  \usepackage{unicode-math}
+\fi
+\usepackage{pseudocode}
+
+\begin{document}
+
+\begin{pseudocode}{CelsiusToFahrenheit}{c}
+f \GETS {9c/5} + 32\\
+\RETURN{f}
+\end{pseudocode}
+
+\end{document}

--- a/tagging-status/testfiles-incompatible-mathml/qcircuit/qcircuit-01-BAD.pdftex.struct.xml
+++ b/tagging-status/testfiles-incompatible-mathml/qcircuit/qcircuit-01-BAD.pdftex.struct.xml
@@ -1,0 +1,28 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.02"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.05"
+      rolemaps-to="Part"
+     >
+    <Formula xmlns="http://iso.org/pdf2/ssn"
+       id="ID.06"
+       title="equation*"
+       af="mathml-1.xml tag-AFfile1.tex"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:Placement="Block"
+      >
+      <AssociatedFile name="mathml-1.xml" xmlns="">
+      <math display="block" xmlns="http://www.w3.org/1998/Math/MathML"> <mtext> � <math xmlns="http://www.w3.org/1998/Math/MathML"/> <math xmlns="http://www.w3.org/1998/Math/MathML"> <mi>𝑈</mi> </math> �� <math xmlns="http://www.w3.org/1998/Math/MathML"/> // <math xmlns="http://www.w3.org/1998/Math/MathML"/> <math xmlns="http://www.w3.org/1998/Math/MathML"> <msup> <mi>𝑈</mi> <mo lspace="0" rspace="0">†</mo> </msup> </math> �� <math xmlns="http://www.w3.org/1998/Math/MathML"/> // </mtext> </math>
+      </AssociatedFile>
+      <AssociatedFile name="tag-AFfile1.tex" xmlns="">
+      \begin {equation*}\Qcircuit @C=1em @R=.7em { &amp; \gate {U} &amp; \qwa \\ &amp; \gate {U^\dag } &amp; \qwa }\end {equation*}
+      </AssociatedFile>
+     <?MarkedContent page="1" ?>U[TEXT]
+    </Formula>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-incompatible-mathml/qcircuit/qcircuit-01-BAD.struct.xml
+++ b/tagging-status/testfiles-incompatible-mathml/qcircuit/qcircuit-01-BAD.struct.xml
@@ -1,0 +1,28 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.02"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.06"
+      rolemaps-to="Part"
+     >
+    <Formula xmlns="http://iso.org/pdf2/ssn"
+       id="ID.07"
+       title="equation*"
+       af="mathml-1.xml tag-AFfile1.tex"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:Placement="Block"
+      >
+      <AssociatedFile name="mathml-1.xml" xmlns="">
+      <math display="block" xmlns="http://www.w3.org/1998/Math/MathML"> <mtext> � <math xmlns="http://www.w3.org/1998/Math/MathML"/> <math xmlns="http://www.w3.org/1998/Math/MathML"> <mi>𝑈</mi> </math> �� <math xmlns="http://www.w3.org/1998/Math/MathML"/> // <math xmlns="http://www.w3.org/1998/Math/MathML"/> <math xmlns="http://www.w3.org/1998/Math/MathML"> <msup> <mi>𝑈</mi> <mo lspace="0" rspace="0">†</mo> </msup> </math> �� <math xmlns="http://www.w3.org/1998/Math/MathML"/> // </mtext> </math>
+      </AssociatedFile>
+      <AssociatedFile name="tag-AFfile1.tex" xmlns="">
+      \begin {equation*}\Qcircuit @C=1em @R=.7em { &amp; \gate {U} &amp; \qwa \\ &amp; \gate {U^\dag } &amp; \qwa }\end {equation*}
+      </AssociatedFile>
+     <?MarkedContent page="1" ?>𝑈[TEXT]
+    </Formula>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-incompatible-mathml/qcircuit/qcircuit-01-BAD.tex
+++ b/tagging-status/testfiles-incompatible-mathml/qcircuit/qcircuit-01-BAD.tex
@@ -1,0 +1,27 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on,
+  }
+\documentclass{article}
+\ifdefined\Uchar
+  \usepackage{luatex85}
+  \usepackage{unicode-math}
+\fi
+\usepackage{qcircuit}
+
+\begin{document}
+
+\Qcircuit @C=1em @R=.7em {
+& \gate{H} & \gate{Z} & \gate{H} & \qw \\
+& \qw & \gate{X} & \qw & \qw
+}
+
+\[ \Qcircuit @C=1em @R=.7em {
+& \gate{U} & \qwa \\
+& \gate{U^\dag} & \qwa
+} \]
+
+\end{document}

--- a/tagging-status/testfiles-incompatible-mathml/quantikz/quantikz-01-BAD.pdftex.struct.xml
+++ b/tagging-status/testfiles-incompatible-mathml/quantikz/quantikz-01-BAD.pdftex.struct.xml
@@ -1,0 +1,1 @@
+<run-error code="1" />

--- a/tagging-status/testfiles-incompatible-mathml/quantikz/quantikz-01-BAD.struct.xml
+++ b/tagging-status/testfiles-incompatible-mathml/quantikz/quantikz-01-BAD.struct.xml
@@ -1,0 +1,1 @@
+<run-error code="1" />

--- a/tagging-status/testfiles-incompatible-mathml/quantikz/quantikz-01-BAD.tex
+++ b/tagging-status/testfiles-incompatible-mathml/quantikz/quantikz-01-BAD.tex
@@ -1,0 +1,34 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on,
+  }
+\documentclass{article}
+
+\ifdefined\Uchar
+  \usepackage{unicode-math}
+\fi
+\usepackage{quantikz}
+
+\title{quantikz tagging test}
+
+\begin{document}
+
+\begin{quantikz}
+& \ctrl{1} & \targ{} & \swap{1} & \ctrl[vertical
+wire=c]{2} &&\\
+& \control{} & \ctrl[open]{-1} & \targX{} && \gate{X} &\\
+&&&& \gate{U} & \meter{} \wire[u][1]{c}
+\end{quantikz}
+
+\[
+\begin{quantikz}
+& \ctrl{2} & \gate{U} & \\
+& \targ{} & \ctrl{1}\wire[u]{q} & \\
+& \targ{} & \gate{V} &
+\end{quantikz}
+\]
+
+\end{document}

--- a/tagging-status/testfiles-incompatible/pdfcolparallel/pdfcolparallel-01-BAD.pdftex.struct.xml
+++ b/tagging-status/testfiles-incompatible/pdfcolparallel/pdfcolparallel-01-BAD.pdftex.struct.xml
@@ -1,0 +1,60 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.005"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.006"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>text
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.007"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.008"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Justify"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>Jisu thakddunsi pulo, “Philip,Jesus said to him, “Have Ine lapu-an arni keding nangtum been with you all this time,along nangkedodun anta nang- Philip, and you still do not knowtum nephan nechininelangma? me? Whoever has seen me hasNephan nekethek-long abang ke seen the Father. How can youPo aphanta thek-long-lo. Tangte say, ‘Show us the Father’?nang kopisi, ‘Netum aphan Ponepaklangtha,’ pu kepulangma?
+      </text>
+     </text-unit>
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.009"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.010"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Justify"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>Jesus said to him, “Have Ine lapu-an arni keding nangtum been with you all this time,along nangkedodun anta nang- Philip, and you still do not knowtum nephan nechininelangma? me? Whoever has seen me hasNephan nekethek-long abang ke seen the Father. How can youPo aphanta thek-long-lo. Tangte say, ‘Show us the Father’?
+      </text>
+     </text-unit>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.011"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.012"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Jisu thakddunsi pulo, “Philip,Jesus said to him, “Have Ine lapu-an arni keding nangtum been with you all this time,along nangkedodun anta nang- Philip, and you still do not knowtum nephan nechininelangma? me? Whoever has seen me hasNephan nekethek-long abang ke seen the Father. How can youPo aphanta thek-long-lo. Tangte say, ‘Show us the Father’?nang kopisi, ‘Netum aphan Ponepaklangtha,’ pu kepulangma?
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-incompatible/pdfcolparallel/pdfcolparallel-01-BAD.struct.xml
+++ b/tagging-status/testfiles-incompatible/pdfcolparallel/pdfcolparallel-01-BAD.struct.xml
@@ -1,0 +1,87 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.006"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.007"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>text 
+     <?MarkedContent page="1" ?>
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.008"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.009"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Justify"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>Jisu thakddunsi pulo, “Philip, 
+       <?MarkedContent page="1" ?>ne lapu-an arni keding nangtum 
+       <?MarkedContent page="1" ?>along nangkedodun anta nang
+       <?MarkedContent page="1" ?>
+       <?MarkedContent page="1" ?>tum nephan nechininelangma? 
+       <?MarkedContent page="1" ?>Nephan nekethek-long abang ke 
+       <?MarkedContent page="1" ?>Po aphanta thek-long-lo. Tangte 
+       <?MarkedContent page="1" ?>nang kopisi, ‘Netum aphan Po 
+       <?MarkedContent page="1" ?>nepaklangtha,’ pu kepulangma?
+      </text>
+     </text-unit>
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.010"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.011"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Justify"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>Jesus said to him, “Have 
+       <?MarkedContent page="1" ?>I been with you all this time, 
+       <?MarkedContent page="1" ?>Philip, and you still do not know 
+       <?MarkedContent page="1" ?>me? Whoever has seen me has 
+       <?MarkedContent page="1" ?>seen the Father. How can you 
+       <?MarkedContent page="1" ?>say, ‘Show us the Father’?
+      </text>
+     </text-unit>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.012"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.013"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-incompatible/pdfcolparallel/pdfcolparallel-01-BAD.tex
+++ b/tagging-status/testfiles-incompatible/pdfcolparallel/pdfcolparallel-01-BAD.tex
@@ -1,0 +1,22 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on
+  }
+\documentclass{article}
+
+\usepackage{xcolor}
+\usepackage{pdfcolparallel}
+
+\title{pdfcolparallel tagging test}
+
+\begin{document}
+text % this produces parent-child warnings
+\begin{Parallel}{5cm}{5cm}  
+\ParallelLText{Jisu thakddunsi pulo, \textcolor{red}{``Philip, ne lapu-an arni keding nangtum along nangkedodun anta nangtum nephan nechininelangma? Nephan nekethek-long abang ke Po aphanta thek-long-lo. Tangte nang kopisi, `Netum aphan Po nepaklangtha,' pu kepulangma?}}
+\ParallelRText{Jesus said to him, \textcolor{red}{``Have I been with you all this time, Philip, and you still do not know me? Whoever has seen me has seen the Father. How can you say, `Show us the Father'?}}
+\ParallelPar
+\end{Parallel}
+\end{document}

--- a/tagging-status/testfiles-incompatible/pdfcolparcolumns/pdfcolparcolumns-01-BAD.pdftex.struct.xml
+++ b/tagging-status/testfiles-incompatible/pdfcolparcolumns/pdfcolparcolumns-01-BAD.pdftex.struct.xml
@@ -1,0 +1,1 @@
+<run-error code="1" />

--- a/tagging-status/testfiles-incompatible/pdfcolparcolumns/pdfcolparcolumns-01-BAD.struct.xml
+++ b/tagging-status/testfiles-incompatible/pdfcolparcolumns/pdfcolparcolumns-01-BAD.struct.xml
@@ -1,0 +1,1 @@
+<run-error code="1" />

--- a/tagging-status/testfiles-incompatible/pdfcolparcolumns/pdfcolparcolumns-01-BAD.tex
+++ b/tagging-status/testfiles-incompatible/pdfcolparcolumns/pdfcolparcolumns-01-BAD.tex
@@ -1,0 +1,23 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on
+  }
+\documentclass{article}
+
+\usepackage{pdfcolparcolumns}
+\usepackage{xcolor}
+
+\title{pdfcolparcolumns tagging test}
+
+\begin{document}
+
+\begin{parcolumns}{2}
+\colchunk{Jisu thakddunsi pulo, \textcolor{red}{``Philip, ne lapu-an arni keding nangtum along nangkedodun anta nangtum nephan nechininelangma? Nephan nekethek-long abang ke Po aphanta thek-long-lo. Tangte nang kopisi, `Netum aphan Po nepaklangtha,' pu kepulangma?}}
+\colchunk{Jesus said to him, \textcolor{red}{``Have I been with you all this time, Philip, and you still do not know me? Whoever has seen me has seen the Father. How can you say, `Show us the Father'?}}
+\colplacechunks
+\end{parcolumns}
+
+\end{document}

--- a/tagging-status/testfiles-incompatible/qtree/qtree-01-BAD.pdftex.struct.xml
+++ b/tagging-status/testfiles-incompatible/qtree/qtree-01-BAD.pdftex.struct.xml
@@ -1,0 +1,984 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.0002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.0005"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0006"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+    </text>
+    <Table xmlns="http://iso.org/pdf2/ssn"
+       id="ID.0007"
+      >
+     <TR xmlns="http://iso.org/pdf2/ssn"
+        id="ID.0008"
+       >
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.0009"
+        >
+       <?MarkedContent page="1" ?>This
+      </TD>
+     </TR>
+    </Table>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0010"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+    </text>
+    <Table xmlns="http://iso.org/pdf2/ssn"
+       id="ID.0011"
+      >
+     <TR xmlns="http://iso.org/pdf2/ssn"
+        id="ID.0012"
+       >
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.0013"
+        >
+       <?MarkedContent page="1" ?>is
+      </TD>
+     </TR>
+    </Table>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0014"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+    </text>
+    <Table xmlns="http://iso.org/pdf2/ssn"
+       id="ID.0015"
+      >
+     <TR xmlns="http://iso.org/pdf2/ssn"
+        id="ID.0016"
+       >
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.0017"
+        >
+       <?MarkedContent page="1" ?>V
+      </TD>
+     </TR>
+    </Table>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0018"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+    </text>
+    <Div xmlns="http://iso.org/pdf2/ssn"
+       id="ID.0019"
+      >
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.0020"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0021"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Start"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>
+      </text>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0022"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Start"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>
+       <Figure xmlns="http://iso.org/pdf2/ssn"
+          id="ID.0023"
+          alt="picture environment"
+          xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+          Layout:BBox="{ 290.83763, 593.95006, 290.83763, 602.5269 }"
+         >
+        <?MarkedContent page="1" ?>
+       </Figure>
+       <?MarkedContent page="1" ?>
+      </text>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0024"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Start"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>
+      </text>
+     </text-unit>
+    </Div>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0025"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+    </text>
+    <Table xmlns="http://iso.org/pdf2/ssn"
+       id="ID.0026"
+      >
+     <TR xmlns="http://iso.org/pdf2/ssn"
+        id="ID.0027"
+       >
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.0028"
+        >
+       <?MarkedContent page="1" ?>
+       <Table xmlns="http://iso.org/pdf2/ssn"
+          id="ID.0029"
+         >
+        <TR xmlns="http://iso.org/pdf2/ssn"
+           id="ID.0030"
+          >
+         <TD xmlns="http://iso.org/pdf2/ssn"
+            id="ID.0031"
+           >
+          <?MarkedContent page="1" ?>a simple tree
+         </TD>
+        </TR>
+       </Table>
+       <?MarkedContent page="1" ?>
+       <Table xmlns="http://iso.org/pdf2/ssn"
+          id="ID.0032"
+         >
+        <TR xmlns="http://iso.org/pdf2/ssn"
+           id="ID.0033"
+          >
+         <TD xmlns="http://iso.org/pdf2/ssn"
+            id="ID.0034"
+           >
+          <?MarkedContent page="1" ?>
+          <Table xmlns="http://iso.org/pdf2/ssn"
+             id="ID.0035"
+            >
+           <TR xmlns="http://iso.org/pdf2/ssn"
+              id="ID.0036"
+             >
+            <TD xmlns="http://iso.org/pdf2/ssn"
+               id="ID.0037"
+              >
+             <?MarkedContent page="1" ?>NP
+            </TD>
+           </TR>
+          </Table>
+          <?MarkedContent page="1" ?>
+         </TD>
+        </TR>
+        <TR xmlns="http://iso.org/pdf2/ssn"
+           id="ID.0038"
+          >
+         <TD xmlns="http://iso.org/pdf2/ssn"
+            id="ID.0039"
+           >
+          <?MarkedContent page="1" ?>
+          <Figure xmlns="http://iso.org/pdf2/ssn"
+             id="ID.0040"
+             alt="picture environment"
+             xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+             Layout:BBox="{ 306.52794, 592.8667, 370.46683, 603.52318 }"
+            >
+           <?MarkedContent page="1" ?>
+          </Figure>
+          <?MarkedContent page="1" ?>
+         </TD>
+        </TR>
+        <TR xmlns="http://iso.org/pdf2/ssn"
+           id="ID.0041"
+          >
+         <TD xmlns="http://iso.org/pdf2/ssn"
+            id="ID.0042"
+           >
+          <?MarkedContent page="1" ?>
+         </TD>
+        </TR>
+       </Table>
+       <?MarkedContent page="1" ?>
+      </TD>
+     </TR>
+    </Table>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0043"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+    </text>
+    <Table xmlns="http://iso.org/pdf2/ssn"
+       id="ID.0044"
+      >
+     <TR xmlns="http://iso.org/pdf2/ssn"
+        id="ID.0045"
+       >
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.0046"
+        >
+       <?MarkedContent page="1" ?>VP
+      </TD>
+     </TR>
+    </Table>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0047"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+    </text>
+    <Div xmlns="http://iso.org/pdf2/ssn"
+       id="ID.0048"
+      >
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.0049"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0050"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Start"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>
+      </text>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0051"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Start"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>
+       <Figure xmlns="http://iso.org/pdf2/ssn"
+          id="ID.0052"
+          alt="picture environment"
+          xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+          Layout:BBox="{ 290.83763, 615.47835, 338.49734, 627.39326 }"
+         >
+        <?MarkedContent page="1" ?>
+       </Figure>
+       <?MarkedContent page="1" ?>
+      </text>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0053"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Start"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>
+      </text>
+     </text-unit>
+    </Div>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0054"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+    </text>
+    <Table xmlns="http://iso.org/pdf2/ssn"
+       id="ID.0055"
+      >
+     <TR xmlns="http://iso.org/pdf2/ssn"
+        id="ID.0056"
+       >
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.0057"
+        >
+       <?MarkedContent page="1" ?>S
+      </TD>
+     </TR>
+    </Table>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0058"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+    </text>
+    <Div xmlns="http://iso.org/pdf2/ssn"
+       id="ID.0059"
+      >
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.0060"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0061"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Start"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>
+      </text>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0062"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Start"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>
+       <Figure xmlns="http://iso.org/pdf2/ssn"
+          id="ID.0063"
+          alt="picture environment"
+          xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+          Layout:BBox="{ 265.43617, 640.3447, 314.66748, 652.65253 }"
+         >
+        <?MarkedContent page="1" ?>
+       </Figure>
+       <?MarkedContent page="1" ?>
+      </text>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0064"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Start"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>
+      </text>
+     </text-unit>
+    </Div>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0065"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.0066"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0067"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>normal text
+    </text>
+    <Table xmlns="http://iso.org/pdf2/ssn"
+       id="ID.0068"
+      >
+     <TR xmlns="http://iso.org/pdf2/ssn"
+        id="ID.0069"
+       >
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.0070"
+        >
+       <?MarkedContent page="1" ?>Roses
+      </TD>
+     </TR>
+    </Table>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0071"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+    </text>
+    <Table xmlns="http://iso.org/pdf2/ssn"
+       id="ID.0072"
+      >
+     <TR xmlns="http://iso.org/pdf2/ssn"
+        id="ID.0073"
+       >
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.0074"
+        >
+       <?MarkedContent page="1" ?>NP
+      </TD>
+     </TR>
+    </Table>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0075"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+    </text>
+    <Div xmlns="http://iso.org/pdf2/ssn"
+       id="ID.0076"
+      >
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.0077"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0078"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Start"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>
+      </text>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0079"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Start"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>
+       <Figure xmlns="http://iso.org/pdf2/ssn"
+          id="ID.0080"
+          alt="picture environment"
+          xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+          Layout:BBox="{ 278.86758, 531.08116, 278.86758, 539.658 }"
+         >
+        <?MarkedContent page="1" ?>
+       </Figure>
+       <?MarkedContent page="1" ?>
+      </text>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0081"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Start"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>
+      </text>
+     </text-unit>
+    </Div>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0082"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+    </text>
+    <Table xmlns="http://iso.org/pdf2/ssn"
+       id="ID.0083"
+      >
+     <TR xmlns="http://iso.org/pdf2/ssn"
+        id="ID.0084"
+       >
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.0085"
+        >
+       <?MarkedContent page="1" ?>are
+      </TD>
+     </TR>
+    </Table>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0086"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+    </text>
+    <Table xmlns="http://iso.org/pdf2/ssn"
+       id="ID.0087"
+      >
+     <TR xmlns="http://iso.org/pdf2/ssn"
+        id="ID.0088"
+       >
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.0089"
+        >
+       <?MarkedContent page="1" ?>I
+       <Formula xmlns="http://iso.org/pdf2/ssn"
+          id="ID.0090"
+          title="math"
+          af="tag-AFfile1.tex"
+          xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+          Layout:Placement="Inline"
+         >
+         <AssociatedFile name="tag-AFfile1.tex" xmlns="">
+         $\relax \sp {0}$
+         </AssociatedFile>
+        <?MarkedContent page="1" ?>0
+       </Formula>
+       <?MarkedContent page="1" ?>
+      </TD>
+     </TR>
+    </Table>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0091"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+    </text>
+    <Div xmlns="http://iso.org/pdf2/ssn"
+       id="ID.0092"
+      >
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.0093"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0094"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Start"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>
+      </text>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0095"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Start"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>
+       <Figure xmlns="http://iso.org/pdf2/ssn"
+          id="ID.0096"
+          alt="picture environment"
+          xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+          Layout:BBox="{ 309.77483, 519.85303, 309.77483, 528.42989 }"
+         >
+        <?MarkedContent page="1" ?>
+       </Figure>
+       <?MarkedContent page="1" ?>
+      </text>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0097"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Start"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>
+      </text>
+     </text-unit>
+    </Div>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0098"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+    </text>
+    <Table xmlns="http://iso.org/pdf2/ssn"
+       id="ID.0099"
+      >
+     <TR xmlns="http://iso.org/pdf2/ssn"
+        id="ID.0100"
+       >
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.0101"
+        >
+       <?MarkedContent page="1" ?>t
+      </TD>
+     </TR>
+    </Table>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0102"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+    </text>
+    <Table xmlns="http://iso.org/pdf2/ssn"
+       id="ID.0103"
+      >
+     <TR xmlns="http://iso.org/pdf2/ssn"
+        id="ID.0104"
+       >
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.0105"
+        >
+       <?MarkedContent page="1" ?>turning
+      </TD>
+     </TR>
+    </Table>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0106"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+    </text>
+    <Table xmlns="http://iso.org/pdf2/ssn"
+       id="ID.0107"
+      >
+     <TR xmlns="http://iso.org/pdf2/ssn"
+        id="ID.0108"
+       >
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.0109"
+        >
+       <?MarkedContent page="1" ?>V
+       <Formula xmlns="http://iso.org/pdf2/ssn"
+          id="ID.0110"
+          title="math"
+          af="tag-AFfile2.tex"
+          xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+          Layout:Placement="Inline"
+         >
+         <AssociatedFile name="tag-AFfile2.tex" xmlns="">
+         $\relax \sp {0}$
+         </AssociatedFile>
+        <?MarkedContent page="1" ?>0
+       </Formula>
+       <?MarkedContent page="1" ?>
+      </TD>
+     </TR>
+    </Table>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0111"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+    </text>
+    <Div xmlns="http://iso.org/pdf2/ssn"
+       id="ID.0112"
+      >
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.0113"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0114"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Start"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>
+      </text>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0115"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Start"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>
+       <Figure xmlns="http://iso.org/pdf2/ssn"
+          id="ID.0116"
+          alt="picture environment"
+          xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+          Layout:BBox="{ 363.6607, 481.94069, 363.6607, 490.51753 }"
+         >
+        <?MarkedContent page="1" ?>
+       </Figure>
+       <?MarkedContent page="1" ?>
+      </text>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0117"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Start"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>
+      </text>
+     </text-unit>
+    </Div>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0118"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+    </text>
+    <Table xmlns="http://iso.org/pdf2/ssn"
+       id="ID.0119"
+      >
+     <TR xmlns="http://iso.org/pdf2/ssn"
+        id="ID.0120"
+       >
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.0121"
+        >
+       <?MarkedContent page="1" ?>pink
+      </TD>
+     </TR>
+    </Table>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0122"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+    </text>
+    <Table xmlns="http://iso.org/pdf2/ssn"
+       id="ID.0123"
+      >
+     <TR xmlns="http://iso.org/pdf2/ssn"
+        id="ID.0124"
+       >
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.0125"
+        >
+       <?MarkedContent page="1" ?>NP
+      </TD>
+     </TR>
+    </Table>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0126"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+    </text>
+    <Div xmlns="http://iso.org/pdf2/ssn"
+       id="ID.0127"
+      >
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.0128"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0129"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Start"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>
+      </text>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0130"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Start"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>
+       <Figure xmlns="http://iso.org/pdf2/ssn"
+          id="ID.0131"
+          alt="picture environment"
+          xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+          Layout:BBox="{ 401.22192, 481.94069, 401.22192, 490.51753 }"
+         >
+        <?MarkedContent page="1" ?>
+       </Figure>
+       <?MarkedContent page="1" ?>
+      </text>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0132"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Start"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>
+      </text>
+     </text-unit>
+    </Div>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0133"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+    </text>
+    <Table xmlns="http://iso.org/pdf2/ssn"
+       id="ID.0134"
+      >
+    </Table>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0135"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+    </text>
+    <Div xmlns="http://iso.org/pdf2/ssn"
+       id="ID.0136"
+      >
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.0137"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0138"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Start"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>
+       <Figure xmlns="http://iso.org/pdf2/ssn"
+          id="ID.0139"
+          alt="picture environment"
+          xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+          Layout:BBox="{ 363.6607, 503.46896, 401.22191, 512.85925 }"
+         >
+        <?MarkedContent page="1" ?>
+       </Figure>
+       <?MarkedContent page="1" ?>
+      </text>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0140"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Start"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>
+      </text>
+     </text-unit>
+    </Div>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0141"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+    </text>
+    <Table xmlns="http://iso.org/pdf2/ssn"
+       id="ID.0142"
+      >
+     <TR xmlns="http://iso.org/pdf2/ssn"
+        id="ID.0143"
+       >
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.0144"
+        >
+       <?MarkedContent page="1" ?>VP
+      </TD>
+     </TR>
+    </Table>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0145"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+    </text>
+    <Div xmlns="http://iso.org/pdf2/ssn"
+       id="ID.0146"
+      >
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.0147"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0148"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Start"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>
+      </text>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0149"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Start"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>
+       <Figure xmlns="http://iso.org/pdf2/ssn"
+          id="ID.0150"
+          alt="picture environment"
+          xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+          Layout:BBox="{ 333.70798, 512.85925, 382.44131, 525.04259 }"
+         >
+        <?MarkedContent page="1" ?>
+       </Figure>
+       <?MarkedContent page="1" ?>
+      </text>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0151"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Start"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>
+      </text>
+     </text-unit>
+    </Div>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0152"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+    </text>
+    <Table xmlns="http://iso.org/pdf2/ssn"
+       id="ID.0153"
+      >
+    </Table>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0154"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+    </text>
+    <Div xmlns="http://iso.org/pdf2/ssn"
+       id="ID.0155"
+      >
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.0156"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0157"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Start"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>
+       <Figure xmlns="http://iso.org/pdf2/ssn"
+          id="ID.0158"
+          alt="picture environment"
+          xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+          Layout:BBox="{ 309.77483, 541.38132, 354.68735, 552.60944 }"
+         >
+        <?MarkedContent page="1" ?>
+       </Figure>
+       <?MarkedContent page="1" ?>
+      </text>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0159"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Start"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>
+      </text>
+     </text-unit>
+    </Div>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0160"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+    </text>
+    <Table xmlns="http://iso.org/pdf2/ssn"
+       id="ID.0161"
+      >
+     <TR xmlns="http://iso.org/pdf2/ssn"
+        id="ID.0162"
+       >
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.0163"
+        >
+       <?MarkedContent page="1" ?>IP
+      </TD>
+     </TR>
+    </Table>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0164"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+    </text>
+    <Div xmlns="http://iso.org/pdf2/ssn"
+       id="ID.0165"
+      >
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.0166"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0167"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Start"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>
+      </text>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0168"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Start"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>
+       <Figure xmlns="http://iso.org/pdf2/ssn"
+          id="ID.0169"
+          alt="picture environment"
+          xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+          Layout:BBox="{ 278.86758, 552.60944, 332.23106, 565.95032 }"
+         >
+        <?MarkedContent page="1" ?>
+       </Figure>
+       <?MarkedContent page="1" ?>
+      </text>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0170"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Start"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>
+      </text>
+     </text-unit>
+    </Div>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0171"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-incompatible/qtree/qtree-01-BAD.struct.xml
+++ b/tagging-status/testfiles-incompatible/qtree/qtree-01-BAD.struct.xml
@@ -1,0 +1,940 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.0002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.0006"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0007"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+    </text>
+    <Table xmlns="http://iso.org/pdf2/ssn"
+       id="ID.0008"
+      >
+     <TR xmlns="http://iso.org/pdf2/ssn"
+        id="ID.0009"
+       >
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.0010"
+        >
+       <?MarkedContent page="1" ?>This
+      </TD>
+     </TR>
+    </Table>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0011"
+       rolemaps-to="P"
+      >
+    </text>
+    <Table xmlns="http://iso.org/pdf2/ssn"
+       id="ID.0012"
+      >
+     <TR xmlns="http://iso.org/pdf2/ssn"
+        id="ID.0013"
+       >
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.0014"
+        >
+       <?MarkedContent page="1" ?>is
+      </TD>
+     </TR>
+    </Table>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0015"
+       rolemaps-to="P"
+      >
+    </text>
+    <Table xmlns="http://iso.org/pdf2/ssn"
+       id="ID.0016"
+      >
+     <TR xmlns="http://iso.org/pdf2/ssn"
+        id="ID.0017"
+       >
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.0018"
+        >
+       <?MarkedContent page="1" ?>V
+      </TD>
+     </TR>
+    </Table>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0019"
+       rolemaps-to="P"
+      >
+    </text>
+    <Div xmlns="http://iso.org/pdf2/ssn"
+       id="ID.0020"
+      >
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.0021"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0022"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Start"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>
+      </text>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0023"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Start"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?> 
+       <Figure xmlns="http://iso.org/pdf2/ssn"
+          id="ID.0024"
+          alt="picture environment"
+          xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+          Layout:BBox="{ 290.83939, 593.93771, 290.83939, 602.52551 }"
+         >
+        <?MarkedContent page="1" ?>
+       </Figure>
+      </text>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0025"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Start"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?> 
+      </text>
+     </text-unit>
+    </Div>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0026"
+       rolemaps-to="P"
+      >
+    </text>
+    <Table xmlns="http://iso.org/pdf2/ssn"
+       id="ID.0027"
+      >
+     <TR xmlns="http://iso.org/pdf2/ssn"
+        id="ID.0028"
+       >
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.0029"
+        >
+       <Table xmlns="http://iso.org/pdf2/ssn"
+          id="ID.0030"
+         >
+        <TR xmlns="http://iso.org/pdf2/ssn"
+           id="ID.0031"
+          >
+         <TD xmlns="http://iso.org/pdf2/ssn"
+            id="ID.0032"
+           >
+          <?MarkedContent page="1" ?>a simple tree
+         </TD>
+        </TR>
+       </Table>
+       <Table xmlns="http://iso.org/pdf2/ssn"
+          id="ID.0033"
+         >
+        <TR xmlns="http://iso.org/pdf2/ssn"
+           id="ID.0034"
+          >
+         <TD xmlns="http://iso.org/pdf2/ssn"
+            id="ID.0035"
+           >
+          <Table xmlns="http://iso.org/pdf2/ssn"
+             id="ID.0036"
+            >
+           <TR xmlns="http://iso.org/pdf2/ssn"
+              id="ID.0037"
+             >
+            <TD xmlns="http://iso.org/pdf2/ssn"
+               id="ID.0038"
+              >
+             <?MarkedContent page="1" ?>NP
+            </TD>
+           </TR>
+          </Table>
+         </TD>
+        </TR>
+        <TR xmlns="http://iso.org/pdf2/ssn"
+           id="ID.0039"
+          >
+         <TD xmlns="http://iso.org/pdf2/ssn"
+            id="ID.0040"
+           >
+          <Figure xmlns="http://iso.org/pdf2/ssn"
+             id="ID.0041"
+             alt="picture environment"
+             xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+             Layout:BBox="{ 306.53062, 592.8651, 370.47069, 603.52177 }"
+            >
+           <?MarkedContent page="1" ?>
+          </Figure>
+         </TD>
+        </TR>
+        <TR xmlns="http://iso.org/pdf2/ssn"
+           id="ID.0042"
+          >
+         <TD xmlns="http://iso.org/pdf2/ssn"
+            id="ID.0043"
+           >
+         </TD>
+        </TR>
+       </Table>
+      </TD>
+     </TR>
+    </Table>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0044"
+       rolemaps-to="P"
+      >
+    </text>
+    <Table xmlns="http://iso.org/pdf2/ssn"
+       id="ID.0045"
+      >
+     <TR xmlns="http://iso.org/pdf2/ssn"
+        id="ID.0046"
+       >
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.0047"
+        >
+       <?MarkedContent page="1" ?>VP
+      </TD>
+     </TR>
+    </Table>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0048"
+       rolemaps-to="P"
+      >
+    </text>
+    <Div xmlns="http://iso.org/pdf2/ssn"
+       id="ID.0049"
+      >
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.0050"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0051"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Start"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?> 
+      </text>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0052"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Start"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?> 
+       <Figure xmlns="http://iso.org/pdf2/ssn"
+          id="ID.0053"
+          alt="picture environment"
+          xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+          Layout:BBox="{ 290.83939, 615.47694, 338.50063, 627.39226 }"
+         >
+        <?MarkedContent page="1" ?>
+       </Figure>
+      </text>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0054"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Start"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>
+       <?MarkedContent page="1" ?>
+      </text>
+     </text-unit>
+    </Div>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0055"
+       rolemaps-to="P"
+      >
+    </text>
+    <Table xmlns="http://iso.org/pdf2/ssn"
+       id="ID.0056"
+      >
+     <TR xmlns="http://iso.org/pdf2/ssn"
+        id="ID.0057"
+       >
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.0058"
+        >
+       <?MarkedContent page="1" ?>S
+      </TD>
+     </TR>
+    </Table>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0059"
+       rolemaps-to="P"
+      >
+    </text>
+    <Div xmlns="http://iso.org/pdf2/ssn"
+       id="ID.0060"
+      >
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.0061"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0062"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Start"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?> 
+      </text>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0063"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Start"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?> 
+       <Figure xmlns="http://iso.org/pdf2/ssn"
+          id="ID.0064"
+          alt="picture environment"
+          xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+          Layout:BBox="{ 265.43463, 640.34369, 314.66998, 652.65253 }"
+         >
+        <?MarkedContent page="1" ?>
+       </Figure>
+      </text>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0065"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Start"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>
+       <?MarkedContent page="1" ?>
+      </text>
+     </text-unit>
+    </Div>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0066"
+       rolemaps-to="P"
+      >
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.0067"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0068"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>normal text 
+    </text>
+    <Table xmlns="http://iso.org/pdf2/ssn"
+       id="ID.0069"
+      >
+     <TR xmlns="http://iso.org/pdf2/ssn"
+        id="ID.0070"
+       >
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.0071"
+        >
+       <?MarkedContent page="1" ?>Roses
+      </TD>
+     </TR>
+    </Table>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0072"
+       rolemaps-to="P"
+      >
+    </text>
+    <Table xmlns="http://iso.org/pdf2/ssn"
+       id="ID.0073"
+      >
+     <TR xmlns="http://iso.org/pdf2/ssn"
+        id="ID.0074"
+       >
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.0075"
+        >
+       <?MarkedContent page="1" ?>NP
+      </TD>
+     </TR>
+    </Table>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0076"
+       rolemaps-to="P"
+      >
+    </text>
+    <Div xmlns="http://iso.org/pdf2/ssn"
+       id="ID.0077"
+      >
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.0078"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0079"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Start"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?> 
+      </text>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0080"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Start"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?> 
+       <Figure xmlns="http://iso.org/pdf2/ssn"
+          id="ID.0081"
+          alt="picture environment"
+          xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+          Layout:BBox="{ 278.84929, 531.07079, 278.84929, 539.65857 }"
+         >
+        <?MarkedContent page="1" ?>
+       </Figure>
+      </text>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0082"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Start"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>
+      </text>
+     </text-unit>
+    </Div>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0083"
+       rolemaps-to="P"
+      >
+    </text>
+    <Table xmlns="http://iso.org/pdf2/ssn"
+       id="ID.0084"
+      >
+     <TR xmlns="http://iso.org/pdf2/ssn"
+        id="ID.0085"
+       >
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.0086"
+        >
+       <?MarkedContent page="1" ?>are
+      </TD>
+     </TR>
+    </Table>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0087"
+       rolemaps-to="P"
+      >
+    </text>
+    <Table xmlns="http://iso.org/pdf2/ssn"
+       id="ID.0088"
+      >
+     <TR xmlns="http://iso.org/pdf2/ssn"
+        id="ID.0089"
+       >
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.0090"
+        >
+       <?MarkedContent page="1" ?>I
+       <Formula xmlns="http://iso.org/pdf2/ssn"
+          id="ID.0091"
+          title="math"
+          af="tag-AFfile1.tex"
+          xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+          Layout:Placement="Inline"
+         >
+         <AssociatedFile name="tag-AFfile1.tex" xmlns="">
+         $\relax \sp {0}$
+         </AssociatedFile>
+        <?MarkedContent page="1" ?>0
+       </Formula>
+      </TD>
+     </TR>
+    </Table>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0092"
+       rolemaps-to="P"
+      >
+    </text>
+    <Div xmlns="http://iso.org/pdf2/ssn"
+       id="ID.0093"
+      >
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.0094"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0095"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Start"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?> 
+      </text>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0096"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Start"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?> 
+       <Figure xmlns="http://iso.org/pdf2/ssn"
+          id="ID.0097"
+          alt="picture environment"
+          xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+          Layout:BBox="{ 309.75342, 519.83884, 309.75342, 528.42662 }"
+         >
+        <?MarkedContent page="1" ?>
+       </Figure>
+      </text>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0098"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Start"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>
+      </text>
+     </text-unit>
+    </Div>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0099"
+       rolemaps-to="P"
+      >
+    </text>
+    <Table xmlns="http://iso.org/pdf2/ssn"
+       id="ID.0100"
+      >
+     <TR xmlns="http://iso.org/pdf2/ssn"
+        id="ID.0101"
+       >
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.0102"
+        >
+       <?MarkedContent page="1" ?>t
+      </TD>
+     </TR>
+    </Table>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0103"
+       rolemaps-to="P"
+      >
+    </text>
+    <Table xmlns="http://iso.org/pdf2/ssn"
+       id="ID.0104"
+      >
+     <TR xmlns="http://iso.org/pdf2/ssn"
+        id="ID.0105"
+       >
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.0106"
+        >
+       <?MarkedContent page="1" ?>turning
+      </TD>
+     </TR>
+    </Table>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0107"
+       rolemaps-to="P"
+      >
+    </text>
+    <Table xmlns="http://iso.org/pdf2/ssn"
+       id="ID.0108"
+      >
+     <TR xmlns="http://iso.org/pdf2/ssn"
+        id="ID.0109"
+       >
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.0110"
+        >
+       <?MarkedContent page="1" ?>V
+       <Formula xmlns="http://iso.org/pdf2/ssn"
+          id="ID.0111"
+          title="math"
+          af="tag-AFfile2.tex"
+          xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+          Layout:Placement="Inline"
+         >
+         <AssociatedFile name="tag-AFfile2.tex" xmlns="">
+         $\relax \sp {0}$
+         </AssociatedFile>
+        <?MarkedContent page="1" ?>0
+       </Formula>
+      </TD>
+     </TR>
+    </Table>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0112"
+       rolemaps-to="P"
+      >
+    </text>
+    <Div xmlns="http://iso.org/pdf2/ssn"
+       id="ID.0113"
+      >
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.0114"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0115"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Start"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?> 
+      </text>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0116"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Start"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?> 
+       <Figure xmlns="http://iso.org/pdf2/ssn"
+          id="ID.0117"
+          alt="picture environment"
+          xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+          Layout:BBox="{ 363.6563, 481.91418, 363.6563, 490.50198 }"
+         >
+        <?MarkedContent page="1" ?>
+       </Figure>
+      </text>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0118"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Start"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>
+      </text>
+     </text-unit>
+    </Div>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0119"
+       rolemaps-to="P"
+      >
+    </text>
+    <Table xmlns="http://iso.org/pdf2/ssn"
+       id="ID.0120"
+      >
+     <TR xmlns="http://iso.org/pdf2/ssn"
+        id="ID.0121"
+       >
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.0122"
+        >
+       <?MarkedContent page="1" ?>pink
+      </TD>
+     </TR>
+    </Table>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0123"
+       rolemaps-to="P"
+      >
+    </text>
+    <Table xmlns="http://iso.org/pdf2/ssn"
+       id="ID.0124"
+      >
+     <TR xmlns="http://iso.org/pdf2/ssn"
+        id="ID.0125"
+       >
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.0126"
+        >
+       <?MarkedContent page="1" ?>NP
+      </TD>
+     </TR>
+    </Table>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0127"
+       rolemaps-to="P"
+      >
+    </text>
+    <Div xmlns="http://iso.org/pdf2/ssn"
+       id="ID.0128"
+      >
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.0129"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0130"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Start"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?> 
+      </text>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0131"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Start"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?> 
+       <Figure xmlns="http://iso.org/pdf2/ssn"
+          id="ID.0132"
+          alt="picture environment"
+          xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+          Layout:BBox="{ 401.24037, 481.91418, 401.24037, 490.50198 }"
+         >
+        <?MarkedContent page="1" ?>
+       </Figure>
+      </text>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0133"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Start"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>
+      </text>
+     </text-unit>
+    </Div>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0134"
+       rolemaps-to="P"
+      >
+    </text>
+    <Table xmlns="http://iso.org/pdf2/ssn"
+       id="ID.0135"
+      >
+    </Table>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0136"
+       rolemaps-to="P"
+      >
+    </text>
+    <Div xmlns="http://iso.org/pdf2/ssn"
+       id="ID.0137"
+      >
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.0138"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0139"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Start"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?> 
+       <Figure xmlns="http://iso.org/pdf2/ssn"
+          id="ID.0140"
+          alt="picture environment"
+          xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+          Layout:BBox="{ 363.6563, 503.45341, 401.24037, 512.84943 }"
+         >
+        <?MarkedContent page="1" ?>
+       </Figure>
+      </text>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0141"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Start"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>
+       <?MarkedContent page="1" ?>
+      </text>
+     </text-unit>
+    </Div>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0142"
+       rolemaps-to="P"
+      >
+    </text>
+    <Table xmlns="http://iso.org/pdf2/ssn"
+       id="ID.0143"
+      >
+     <TR xmlns="http://iso.org/pdf2/ssn"
+        id="ID.0144"
+       >
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.0145"
+        >
+       <?MarkedContent page="1" ?>VP
+      </TD>
+     </TR>
+    </Table>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0146"
+       rolemaps-to="P"
+      >
+    </text>
+    <Div xmlns="http://iso.org/pdf2/ssn"
+       id="ID.0147"
+      >
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.0148"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0149"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Start"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?> 
+      </text>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0150"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Start"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?> 
+       <Figure xmlns="http://iso.org/pdf2/ssn"
+          id="ID.0151"
+          alt="picture environment"
+          xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+          Layout:BBox="{ 333.68867, 512.84943, 382.44833, 525.03934 }"
+         >
+        <?MarkedContent page="1" ?>
+       </Figure>
+      </text>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0152"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Start"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>
+       <?MarkedContent page="1" ?>
+      </text>
+     </text-unit>
+    </Div>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0153"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+    </text>
+    <Table xmlns="http://iso.org/pdf2/ssn"
+       id="ID.0154"
+      >
+    </Table>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0155"
+       rolemaps-to="P"
+      >
+    </text>
+    <Div xmlns="http://iso.org/pdf2/ssn"
+       id="ID.0156"
+      >
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.0157"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0158"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Start"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?> 
+       <Figure xmlns="http://iso.org/pdf2/ssn"
+          id="ID.0159"
+          alt="picture environment"
+          xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+          Layout:BBox="{ 309.75342, 541.37805, 354.6812, 552.61 }"
+         >
+        <?MarkedContent page="1" ?>
+       </Figure>
+      </text>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0160"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Start"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>
+       <?MarkedContent page="1" ?>
+      </text>
+     </text-unit>
+    </Div>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0161"
+       rolemaps-to="P"
+      >
+    </text>
+    <Table xmlns="http://iso.org/pdf2/ssn"
+       id="ID.0162"
+      >
+     <TR xmlns="http://iso.org/pdf2/ssn"
+        id="ID.0163"
+       >
+      <TD xmlns="http://iso.org/pdf2/ssn"
+         id="ID.0164"
+        >
+       <?MarkedContent page="1" ?>IP
+      </TD>
+     </TR>
+    </Table>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0165"
+       rolemaps-to="P"
+      >
+    </text>
+    <Div xmlns="http://iso.org/pdf2/ssn"
+       id="ID.0166"
+      >
+     <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.0167"
+        rolemaps-to="Part"
+       >
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0168"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Start"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?> 
+      </text>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0169"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Start"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?> 
+       <Figure xmlns="http://iso.org/pdf2/ssn"
+          id="ID.0170"
+          alt="picture environment"
+          xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+          Layout:BBox="{ 278.84929, 552.61, 332.21732, 565.952 }"
+         >
+        <?MarkedContent page="1" ?>
+       </Figure>
+      </text>
+      <text xmlns="https://www.latex-project.org/ns/dflt"
+         id="ID.0171"
+         xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+         Layout:TextAlign="Start"
+         rolemaps-to="P"
+        >
+       <?MarkedContent page="1" ?>
+       <?MarkedContent page="1" ?>
+      </text>
+     </text-unit>
+    </Div>
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.0172"
+       rolemaps-to="P"
+      >
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-incompatible/qtree/qtree-01-BAD.tex
+++ b/tagging-status/testfiles-incompatible/qtree/qtree-01-BAD.tex
@@ -1,0 +1,20 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on,
+  }
+\documentclass{article}
+
+\usepackage{qtree}
+
+\begin{document}
+
+\Tree [.S This [.VP [.V is ] \qroof{a simple tree}.NP ] ]
+
+normal text
+\Tree [.IP [.NP Roses ] [ [.I^0 are ]
+[.VP t [ [.V^0 turning ] [.NP pink ] ] ].VP !{\qframesubtree} ]]
+
+\end{document}

--- a/tagging-status/testfiles-partial-mathml/proof/proof-01-BAD.pdftex.struct.xml
+++ b/tagging-status/testfiles-partial-mathml/proof/proof-01-BAD.pdftex.struct.xml
@@ -1,0 +1,374 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <Sect xmlns="http://iso.org/pdf2/ssn"
+      id="ID.005"
+     >
+    <section xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.006"
+       title="Examples of proof.sty"
+       rolemaps-to="H1"
+      >
+     <?MarkedContent page="1" ?>Examples of proof.sty
+    </section>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.007"
+       rolemaps-to="Part"
+      >
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.008"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextAlign="Justify"
+        rolemaps-to="P"
+       >
+      <?MarkedContent page="1" ?>
+      <Code xmlns="http://iso.org/pdf/ssn"
+         id="ID.009"
+        >
+       <?MarkedContent page="1" ?>\infer
+      </Code>
+      <?MarkedContent page="1" ?>draws beautiful proof figures easily:
+     </text>
+    </text-unit>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.010"
+       rolemaps-to="Part"
+      >
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.011"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextAlign="Justify"
+        rolemaps-to="P"
+       >
+      <?MarkedContent page="1" ?>(1)
+     </text>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.012"
+        title="equation*"
+        af="mathml-1.xml tag-AFfile1.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Block"
+       >
+       <AssociatedFile name="mathml-1.xml" xmlns="">
+       <math display="block" xmlns="http://www.w3.org/1998/Math/MathML"> <mi> <mglyph/> </mi> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile1.tex" xmlns="">
+       \begin {equation*}\infer {A}{ \infer {B}{ B11\land B12\land B13 &amp; B21\land B22\land B23 } &amp; C }\end {equation*}
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>B11 &amp;B12 &amp;B13B21 &amp;B22 &amp;B23BCA
+     </Formula>
+    </text-unit>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.013"
+       rolemaps-to="Part"
+      >
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.014"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextAlign="Justify"
+        rolemaps-to="P"
+       >
+      <?MarkedContent page="1" ?>(2)
+     </text>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.015"
+        title="equation*"
+        af="mathml-2.xml tag-AFfile2.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Block"
+       >
+       <AssociatedFile name="mathml-2.xml" xmlns="">
+       <math display="block" xmlns="http://www.w3.org/1998/Math/MathML"> <mi> <mglyph/> </mi> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile2.tex" xmlns="">
+       \begin {equation*}\infer {A1\land A2\land A3\land A4\land A5\land A6}{ \infer {B}{ B11\land B12\land B13 &amp; B21\land B22\land B23 } &amp; C }\end {equation*}
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>B11 &amp;B12 &amp;B13B21 &amp;B22 &amp;B23BCA1 &amp;A2 &amp;A3 &amp;A4 &amp;A5 &amp;A6
+     </Formula>
+    </text-unit>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.016"
+       rolemaps-to="Part"
+      >
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.017"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextAlign="Justify"
+        rolemaps-to="P"
+       >
+      <?MarkedContent page="1" ?>(3)
+     </text>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.018"
+        title="equation*"
+        af="mathml-3.xml tag-AFfile3.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Block"
+       >
+       <AssociatedFile name="mathml-3.xml" xmlns="">
+       <math display="block" xmlns="http://www.w3.org/1998/Math/MathML"> <mi> <mglyph/> </mi> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile3.tex" xmlns="">
+       \begin {equation*}\infer {A1\land A2\land A3\land A4\land A5\land A6}{ C &amp; \infer {B}{ B11\land B12\land B13 &amp; B21\land B22\land B23 } }\end {equation*}
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>CB11 &amp;B12 &amp;B13B21 &amp;B22 &amp;B23BA1 &amp;A2 &amp;A3 &amp;A4 &amp;A5 &amp;A6
+     </Formula>
+    </text-unit>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.019"
+       rolemaps-to="Part"
+      >
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.020"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextAlign="Justify"
+        rolemaps-to="P"
+       >
+      <?MarkedContent page="1" ?>You can use also some variations:
+     </text>
+    </text-unit>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.021"
+       rolemaps-to="Part"
+      >
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.022"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextAlign="Justify"
+        rolemaps-to="P"
+       >
+      <?MarkedContent page="1" ?>(4)
+     </text>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.023"
+        title="equation*"
+        af="mathml-4.xml tag-AFfile4.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Block"
+       >
+       <AssociatedFile name="mathml-4.xml" xmlns="">
+       <math display="block" xmlns="http://www.w3.org/1998/Math/MathML"> <mtext> � <math xmlns="http://www.w3.org/1998/Math/MathML"> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mn>1</mn> <mo lspace="0" rspace="0" stretchy="false">)</mo> </math> </mtext> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile4.tex" xmlns="">
+       \begin {equation*}\infer [(1)]{A}{ \infer *{B}{ B11\land B12\land B13 &amp; B21\land B22\land B23 } &amp; C }\end {equation*}
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>B11 &amp;B12 &amp;B13B21 &amp;B22 &amp;B23....BCA(1)
+     </Formula>
+    </text-unit>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.024"
+       rolemaps-to="Part"
+      >
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.025"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextAlign="Justify"
+        rolemaps-to="P"
+       >
+      <?MarkedContent page="1" ?>(5)
+     </text>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.026"
+        title="equation*"
+        af="mathml-5.xml tag-AFfile5.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Block"
+       >
+       <AssociatedFile name="mathml-5.xml" xmlns="">
+       <math display="block" xmlns="http://www.w3.org/1998/Math/MathML"> <mi> <mglyph/> </mi> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile5.tex" xmlns="">
+       \begin {equation*}\infer *[(1)]{A1\land A2\land A3\land A4\land A5\land A6}{ \deduce [{\displaystyle \sum }]{B}{ B11\land B12\land B13 &amp; B21\land B22\land B23 } &amp; \deduce {C}{(2)} }\end {equation*}
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>B11 &amp;B12 &amp;B13B21 &amp;B22 &amp;B23∑︂B(2)C....(1)A1 &amp;A2 &amp;A3 &amp;A4 &amp;A5 &amp;A6
+     </Formula>
+    </text-unit>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.027"
+       rolemaps-to="Part"
+      >
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.028"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextAlign="Justify"
+        rolemaps-to="P"
+       >
+      <?MarkedContent page="1" ?>(6)
+     </text>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.029"
+        title="equation*"
+        af="mathml-6.xml tag-AFfile6.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Block"
+       >
+       <AssociatedFile name="mathml-6.xml" xmlns="">
+       <math display="block" xmlns="http://www.w3.org/1998/Math/MathML"> <mi> <mglyph/> </mi> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile6.tex" xmlns="">
+       \begin {equation*}\infer ={A}{A \land B \land C}\end {equation*}
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>A &amp;B &amp;CA
+     </Formula>
+    </text-unit>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.030"
+       rolemaps-to="Part"
+      >
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.031"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextAlign="Justify"
+        rolemaps-to="P"
+       >
+      <?MarkedContent page="1" ?>Here are more practical examples:
+     </text>
+    </text-unit>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.032"
+       rolemaps-to="Part"
+      >
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.033"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextAlign="Justify"
+        rolemaps-to="P"
+       >
+      <?MarkedContent page="1" ?>(7)
+     </text>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.034"
+        title="equation*"
+        af="mathml-7.xml tag-AFfile7.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Block"
+       >
+       <AssociatedFile name="mathml-7.xml" xmlns="">
+       <math display="block" xmlns="http://www.w3.org/1998/Math/MathML"> <mtext> � <math xmlns="http://www.w3.org/1998/Math/MathML"> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mo lspace="0" rspace="0">&amp;</mo> <mi>𝐼</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </math> </mtext> <mspace width="19.925pt"/> <mtext> � <math xmlns="http://www.w3.org/1998/Math/MathML"> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mo lspace="0" rspace="0">&amp;</mo> <msub> <mi>𝐸</mi> <mi>𝑙</mi> </msub> <mo lspace="0" rspace="0" stretchy="false">)</mo> </math> </mtext> <mspace width="19.925pt"/> <mtext> � <math xmlns="http://www.w3.org/1998/Math/MathML"> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mo lspace="0" rspace="0">&amp;</mo> <msub> <mi>𝐸</mi> <mi>𝑟</mi> </msub> <mo lspace="0" rspace="0" stretchy="false">)</mo> </math> </mtext> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile7.tex" xmlns="">
+       \begin {equation*}\infer [(\land I)]{A \land B}{A &amp; B} \qquad \infer [(\land E_l)]A{A\land B} \qquad \infer [(\land E_r)]B{A\land B}\end {equation*}
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>ABA &amp;B(&amp;I)A &amp;BA(&amp;El)A &amp;BB(&amp;Er)
+     </Formula>
+    </text-unit>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.035"
+       rolemaps-to="Part"
+      >
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.036"
+        title="equation*"
+        af="mathml-8.xml tag-AFfile8.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Block"
+       >
+       <AssociatedFile name="mathml-8.xml" xmlns="">
+       <math display="block" xmlns="http://www.w3.org/1998/Math/MathML"> <mtext> � <math xmlns="http://www.w3.org/1998/Math/MathML"> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mo lspace="0" rspace="0.278em" stretchy="false">→</mo> <mi>𝐼</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </math> </mtext> <mspace width="19.925pt"/> <mtext> � <math xmlns="http://www.w3.org/1998/Math/MathML"> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mo lspace="0" rspace="0.278em" stretchy="false">→</mo> <mi>𝐸</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </math> </mtext> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile8.tex" xmlns="">
+       \begin {equation*}\infer [(\imp I)]{A \imp B}{ \infer *{B}{[A]} } \qquad \infer [(\imp E)]{B}{ A \imp B &amp; A }\end {equation*}
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>[A]....BA→B(→I)A→BAB(→E)
+     </Formula>
+    </text-unit>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.037"
+       rolemaps-to="Part"
+      >
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.038"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextAlign="Justify"
+        rolemaps-to="P"
+       >
+      <?MarkedContent page="1" ?>Some techniques: Use
+      <Code xmlns="http://iso.org/pdf/ssn"
+         id="ID.039"
+        >
+       <?MarkedContent page="1" ?>\vcenter
+      </Code>
+      <?MarkedContent page="1" ?>for an equation of proofs.
+     </text>
+    </text-unit>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.040"
+       rolemaps-to="Part"
+      >
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.041"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextAlign="Justify"
+        rolemaps-to="P"
+       >
+      <?MarkedContent page="1" ?>(8)
+     </text>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.042"
+        title="equation*"
+        af="mathml-9.xml tag-AFfile9.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Block"
+       >
+       <AssociatedFile name="mathml-9.xml" xmlns="">
+       <math display="block" xmlns="http://www.w3.org/1998/Math/MathML"> <mi>𝜋</mi> <mo lspace="0.278em" rspace="0.278em">=</mo> <mi> <mglyph/> </mi> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile9.tex" xmlns="">
+       \begin {equation*}\pi = \vcenter { \infer {E}{ A &amp; \infer {D}{B &amp; C} } }\end {equation*}
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>π =ABCDE
+     </Formula>
+    </text-unit>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.043"
+       rolemaps-to="Part"
+      >
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.044"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextAlign="Justify"
+        rolemaps-to="P"
+       >
+      <?MarkedContent page="2" ?>Use
+      <Code xmlns="http://iso.org/pdf/ssn"
+         id="ID.045"
+        >
+       <?MarkedContent page="2" ?>\kern
+      </Code>
+      <?MarkedContent page="2" ?>to adjust the form of a proof.
+     </text>
+    </text-unit>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.046"
+       rolemaps-to="Part"
+      >
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.047"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextAlign="Justify"
+        rolemaps-to="P"
+       >
+      <?MarkedContent page="2" ?>(9)
+     </text>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.048"
+        title="equation*"
+        af="mathml-10.xml tag-AFfile10.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Block"
+       >
+       <AssociatedFile name="mathml-10.xml" xmlns="">
+       <math display="block" xmlns="http://www.w3.org/1998/Math/MathML"> <mi> <mglyph/> </mi> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile10.tex" xmlns="">
+       \begin {equation*}\infer {E}{ A &amp; \infer {D}{B &amp; C} \kern 0.5cm }\end {equation*}
+       </AssociatedFile>
+      <?MarkedContent page="2" ?>ABCDE
+     </Formula>
+    </text-unit>
+   </Sect>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-partial-mathml/proof/proof-01-BAD.struct.xml
+++ b/tagging-status/testfiles-partial-mathml/proof/proof-01-BAD.struct.xml
@@ -1,0 +1,373 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <Sect xmlns="http://iso.org/pdf2/ssn"
+      id="ID.006"
+     >
+    <section xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.007"
+       title="Examples of proof.sty"
+       rolemaps-to="H1"
+      >
+     <?MarkedContent page="1" ?>Examples of proof.sty
+    </section>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.008"
+       rolemaps-to="Part"
+      >
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.009"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextAlign="Justify"
+        rolemaps-to="P"
+       >
+      <Code xmlns="http://iso.org/pdf/ssn"
+         id="ID.010"
+        >
+       <?MarkedContent page="1" ?>\infer
+      </Code>
+      <?MarkedContent page="1" ?> draws beautiful proof figures easily:
+     </text>
+    </text-unit>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.011"
+       rolemaps-to="Part"
+      >
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.012"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextAlign="Justify"
+        rolemaps-to="P"
+       >
+      <?MarkedContent page="1" ?>(1)
+     </text>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.013"
+        title="equation*"
+        af="mathml-1.xml tag-AFfile1.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Block"
+       >
+       <AssociatedFile name="mathml-1.xml" xmlns="">
+       <math display="block" xmlns="http://www.w3.org/1998/Math/MathML"> <mi> <mglyph/> </mi> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile1.tex" xmlns="">
+       \begin {equation*}\infer {A}{ \infer {B}{ B11\land B12\land B13 &amp; B21\land B22\land B23 } &amp; C }\end {equation*}
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>𝐵11&amp;𝐵12&amp;𝐵13𝐵21&amp;𝐵22&amp;𝐵23𝐵𝐶𝐴
+     </Formula>
+    </text-unit>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.014"
+       rolemaps-to="Part"
+      >
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.015"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextAlign="Justify"
+        rolemaps-to="P"
+       >
+      <?MarkedContent page="1" ?>(2)
+     </text>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.016"
+        title="equation*"
+        af="mathml-2.xml tag-AFfile2.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Block"
+       >
+       <AssociatedFile name="mathml-2.xml" xmlns="">
+       <math display="block" xmlns="http://www.w3.org/1998/Math/MathML"> <mi> <mglyph/> </mi> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile2.tex" xmlns="">
+       \begin {equation*}\infer {A1\land A2\land A3\land A4\land A5\land A6}{ \infer {B}{ B11\land B12\land B13 &amp; B21\land B22\land B23 } &amp; C }\end {equation*}
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>𝐵11&amp;𝐵12&amp;𝐵13𝐵21&amp;𝐵22&amp;𝐵23𝐵𝐶𝐴1&amp;𝐴2&amp;𝐴3&amp;𝐴4&amp;𝐴5&amp;𝐴6
+     </Formula>
+    </text-unit>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.017"
+       rolemaps-to="Part"
+      >
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.018"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextAlign="Justify"
+        rolemaps-to="P"
+       >
+      <?MarkedContent page="1" ?>(3)
+     </text>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.019"
+        title="equation*"
+        af="mathml-3.xml tag-AFfile3.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Block"
+       >
+       <AssociatedFile name="mathml-3.xml" xmlns="">
+       <math display="block" xmlns="http://www.w3.org/1998/Math/MathML"> <mi> <mglyph/> </mi> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile3.tex" xmlns="">
+       \begin {equation*}\infer {A1\land A2\land A3\land A4\land A5\land A6}{ C &amp; \infer {B}{ B11\land B12\land B13 &amp; B21\land B22\land B23 } }\end {equation*}
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>𝐶𝐵11&amp;𝐵12&amp;𝐵13𝐵21&amp;𝐵22&amp;𝐵23𝐵𝐴1&amp;𝐴2&amp;𝐴3&amp;𝐴4&amp;𝐴5&amp;𝐴6
+     </Formula>
+    </text-unit>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.020"
+       rolemaps-to="Part"
+      >
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.021"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextAlign="Justify"
+        rolemaps-to="P"
+       >
+      <?MarkedContent page="1" ?>You can use also some variations:
+     </text>
+    </text-unit>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.022"
+       rolemaps-to="Part"
+      >
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.023"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextAlign="Justify"
+        rolemaps-to="P"
+       >
+      <?MarkedContent page="1" ?>(4)
+     </text>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.024"
+        title="equation*"
+        af="mathml-4.xml tag-AFfile4.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Block"
+       >
+       <AssociatedFile name="mathml-4.xml" xmlns="">
+       <math display="block" xmlns="http://www.w3.org/1998/Math/MathML"> <mtext> � <math xmlns="http://www.w3.org/1998/Math/MathML"> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mn>1</mn> <mo lspace="0" rspace="0" stretchy="false">)</mo> </math> </mtext> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile4.tex" xmlns="">
+       \begin {equation*}\infer [(1)]{A}{ \infer *{B}{ B11\land B12\land B13 &amp; B21\land B22\land B23 } &amp; C }\end {equation*}
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>𝐵11&amp;𝐵12&amp;𝐵13𝐵21&amp;𝐵22&amp;𝐵23....𝐵𝐶𝐴(1)
+     </Formula>
+    </text-unit>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.025"
+       rolemaps-to="Part"
+      >
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.026"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextAlign="Justify"
+        rolemaps-to="P"
+       >
+      <?MarkedContent page="1" ?>(5)
+     </text>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.027"
+        title="equation*"
+        af="mathml-5.xml tag-AFfile5.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Block"
+       >
+       <AssociatedFile name="mathml-5.xml" xmlns="">
+       <math display="block" xmlns="http://www.w3.org/1998/Math/MathML"> <mi> <mglyph/> </mi> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile5.tex" xmlns="">
+       \begin {equation*}\infer *[(1)]{A1\land A2\land A3\land A4\land A5\land A6}{ \deduce [{\displaystyle \sum }]{B}{ B11\land B12\land B13 &amp; B21\land B22\land B23 } &amp; \deduce {C}{(2)} }\end {equation*}
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>𝐵11&amp;𝐵12&amp;𝐵13𝐵21&amp;𝐵22&amp;𝐵23∑𝐵(2)𝐶....(1)𝐴1&amp;𝐴2&amp;𝐴3&amp;𝐴4&amp;𝐴5&amp;𝐴6
+     </Formula>
+    </text-unit>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.028"
+       rolemaps-to="Part"
+      >
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.029"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextAlign="Justify"
+        rolemaps-to="P"
+       >
+      <?MarkedContent page="1" ?>(6)
+     </text>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.030"
+        title="equation*"
+        af="mathml-6.xml tag-AFfile6.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Block"
+       >
+       <AssociatedFile name="mathml-6.xml" xmlns="">
+       <math display="block" xmlns="http://www.w3.org/1998/Math/MathML"> <mi> <mglyph/> </mi> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile6.tex" xmlns="">
+       \begin {equation*}\infer ={A}{A \land B \land C}\end {equation*}
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>𝐴&amp;𝐵&amp;𝐶𝐴
+     </Formula>
+    </text-unit>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.031"
+       rolemaps-to="Part"
+      >
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.032"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextAlign="Justify"
+        rolemaps-to="P"
+       >
+      <?MarkedContent page="1" ?>Here are more practical examples:
+     </text>
+    </text-unit>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.033"
+       rolemaps-to="Part"
+      >
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.034"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextAlign="Justify"
+        rolemaps-to="P"
+       >
+      <?MarkedContent page="1" ?>(7)
+     </text>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.035"
+        title="equation*"
+        af="mathml-7.xml tag-AFfile7.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Block"
+       >
+       <AssociatedFile name="mathml-7.xml" xmlns="">
+       <math display="block" xmlns="http://www.w3.org/1998/Math/MathML"> <mtext> � <math xmlns="http://www.w3.org/1998/Math/MathML"> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mo lspace="0" rspace="0">&amp;</mo> <mi>𝐼</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </math> </mtext> <mspace width="19.925pt"/> <mtext> � <math xmlns="http://www.w3.org/1998/Math/MathML"> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mo lspace="0" rspace="0">&amp;</mo> <msub> <mi>𝐸</mi> <mi>𝑙</mi> </msub> <mo lspace="0" rspace="0" stretchy="false">)</mo> </math> </mtext> <mspace width="19.925pt"/> <mtext> � <math xmlns="http://www.w3.org/1998/Math/MathML"> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mo lspace="0" rspace="0">&amp;</mo> <msub> <mi>𝐸</mi> <mi>𝑟</mi> </msub> <mo lspace="0" rspace="0" stretchy="false">)</mo> </math> </mtext> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile7.tex" xmlns="">
+       \begin {equation*}\infer [(\land I)]{A \land B}{A &amp; B} \qquad \infer [(\land E_l)]A{A\land B} \qquad \infer [(\land E_r)]B{A\land B}\end {equation*}
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>𝐴𝐵𝐴&amp;𝐵(&amp;𝐼)𝐴&amp;𝐵𝐴(&amp;𝐸𝑙)𝐴&amp;𝐵𝐵(&amp;𝐸𝑟)
+     </Formula>
+    </text-unit>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.036"
+       rolemaps-to="Part"
+      >
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.037"
+        title="equation*"
+        af="mathml-8.xml tag-AFfile8.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Block"
+       >
+       <AssociatedFile name="mathml-8.xml" xmlns="">
+       <math display="block" xmlns="http://www.w3.org/1998/Math/MathML"> <mtext> � <math xmlns="http://www.w3.org/1998/Math/MathML"> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mo lspace="0" rspace="0.278em" stretchy="false">→</mo> <mi>𝐼</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </math> </mtext> <mspace width="19.925pt"/> <mtext> � <math xmlns="http://www.w3.org/1998/Math/MathML"> <mo lspace="0" rspace="0" stretchy="false">(</mo> <mo lspace="0" rspace="0.278em" stretchy="false">→</mo> <mi>𝐸</mi> <mo lspace="0" rspace="0" stretchy="false">)</mo> </math> </mtext> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile8.tex" xmlns="">
+       \begin {equation*}\infer [(\imp I)]{A \imp B}{ \infer *{B}{[A]} } \qquad \infer [(\imp E)]{B}{ A \imp B &amp; A }\end {equation*}
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>[𝐴]....𝐵𝐴→𝐵(→𝐼)𝐴→𝐵𝐴𝐵(→𝐸)
+     </Formula>
+    </text-unit>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.038"
+       rolemaps-to="Part"
+      >
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.039"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextAlign="Justify"
+        rolemaps-to="P"
+       >
+      <?MarkedContent page="1" ?>Some techniques: Use 
+      <Code xmlns="http://iso.org/pdf/ssn"
+         id="ID.040"
+        >
+       <?MarkedContent page="1" ?>\vcenter
+      </Code>
+      <?MarkedContent page="1" ?> for an equation of proofs.
+     </text>
+    </text-unit>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.041"
+       rolemaps-to="Part"
+      >
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.042"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextAlign="Justify"
+        rolemaps-to="P"
+       >
+      <?MarkedContent page="1" ?>(8)
+     </text>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.043"
+        title="equation*"
+        af="mathml-9.xml tag-AFfile9.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Block"
+       >
+       <AssociatedFile name="mathml-9.xml" xmlns="">
+       <math display="block" xmlns="http://www.w3.org/1998/Math/MathML"> <mi>𝜋</mi> <mo lspace="0.278em" rspace="0.278em">=</mo> <mi> <mglyph/> </mi> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile9.tex" xmlns="">
+       \begin {equation*}\pi = \vcenter { \infer {E}{ A &amp; \infer {D}{B &amp; C} } }\end {equation*}
+       </AssociatedFile>
+      <?MarkedContent page="1" ?>𝜋=𝐴𝐵𝐶𝐷𝐸
+     </Formula>
+    </text-unit>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.044"
+       rolemaps-to="Part"
+      >
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.045"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextAlign="Justify"
+        rolemaps-to="P"
+       >
+      <?MarkedContent page="2" ?>Use 
+      <Code xmlns="http://iso.org/pdf/ssn"
+         id="ID.046"
+        >
+       <?MarkedContent page="2" ?>\kern
+      </Code>
+      <?MarkedContent page="2" ?> to adjust the form of a proof.
+     </text>
+    </text-unit>
+    <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.047"
+       rolemaps-to="Part"
+      >
+     <text xmlns="https://www.latex-project.org/ns/dflt"
+        id="ID.048"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:TextAlign="Justify"
+        rolemaps-to="P"
+       >
+      <?MarkedContent page="2" ?>(9)
+     </text>
+     <Formula xmlns="http://iso.org/pdf2/ssn"
+        id="ID.049"
+        title="equation*"
+        af="mathml-10.xml tag-AFfile10.tex"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:Placement="Block"
+       >
+       <AssociatedFile name="mathml-10.xml" xmlns="">
+       <math display="block" xmlns="http://www.w3.org/1998/Math/MathML"> <mi> <mglyph/> </mi> </math>
+       </AssociatedFile>
+       <AssociatedFile name="tag-AFfile10.tex" xmlns="">
+       \begin {equation*}\infer {E}{ A &amp; \infer {D}{B &amp; C} \kern 0.5cm }\end {equation*}
+       </AssociatedFile>
+      <?MarkedContent page="2" ?>𝐴𝐵𝐶𝐷𝐸
+     </Formula>
+    </text-unit>
+   </Sect>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-partial-mathml/proof/proof-01-BAD.tex
+++ b/tagging-status/testfiles-partial-mathml/proof/proof-01-BAD.tex
@@ -1,0 +1,143 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on,
+  }
+% from proofeg.tex
+\documentclass{article}
+\ifdefined\Uchar
+  \usepackage{unicode-math}
+\fi
+\usepackage{proof}
+
+\def\imp{\to}
+\def\land{\mathbin\&}
+
+\begin{document}
+\section*{Examples of proof.sty}
+
+\verb|\infer| draws beautiful proof figures easily:
+
+\noindent (1)
+\[
+\infer{A}{
+	\infer{B}{
+		B11\land B12\land B13
+		&
+		B21\land B22\land B23
+	}
+	&
+	C
+}
+\]
+
+\noindent (2)
+\[
+\infer{A1\land A2\land A3\land A4\land A5\land A6}{
+	\infer{B}{
+		B11\land B12\land B13
+		&
+		B21\land B22\land B23
+	}
+	&
+	C
+}
+\]
+
+\noindent (3)
+\[
+\infer{A1\land A2\land A3\land A4\land A5\land A6}{
+	C
+	&
+	\infer{B}{
+		B11\land B12\land B13
+		&
+		B21\land B22\land B23
+	}
+}
+\]
+
+You can use also some variations:
+
+\noindent (4)
+\[
+\infer[(1)]{A}{
+	\infer*{B}{
+		B11\land B12\land B13
+		&
+		B21\land B22\land B23
+	}
+	&
+	C
+}
+\]
+
+\noindent (5)
+\[
+\infer*[(1)]{A1\land A2\land A3\land A4\land A5\land A6}{
+	\deduce[{\displaystyle \sum}]{B}{
+		B11\land B12\land B13
+		&
+		B21\land B22\land B23
+	}
+	&
+	\deduce{C}{(2)}
+}
+\]
+
+\noindent (6)
+\[
+\infer={A}{A \land B \land C}
+\]
+
+Here are more practical examples:
+
+\noindent (7)
+\[
+\infer[(\land I)]{A \land B}{A & B}
+\qquad
+\infer[(\land E_l)]A{A\land B}
+\qquad
+\infer[(\land E_r)]B{A\land B}
+\]
+
+\[
+\infer[(\imp I)]{A \imp B}{
+	\infer*{B}{[A]}
+}
+\qquad
+\infer[(\imp E)]{B}{
+	A \imp B
+	&
+	A
+}
+\]
+
+Some techniques:
+Use \verb|\vcenter| for an equation of proofs.
+
+\noindent (8)
+\[
+\pi = \vcenter{
+\infer{E}{
+	A
+	&
+	\infer{D}{B & C}
+}
+}
+\]
+
+Use \verb|\kern| to adjust the form of a proof.
+
+\noindent (9)
+\[
+\infer{E}{
+	A
+	&
+	\infer{D}{B & C} \kern 0.5cm
+}
+\]
+
+\end{document}

--- a/tagging-status/testfiles-partial-mathml/schemata/schemata-01-BAD.pdftex.struct.xml
+++ b/tagging-status/testfiles-partial-mathml/schemata/schemata-01-BAD.pdftex.struct.xml
@@ -1,0 +1,126 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.005"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.006"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Some text has line 1line 2.
+    </text>
+   </text-unit>
+   <Formula xmlns="http://iso.org/pdf2/ssn"
+      id="ID.007"
+      title="math"
+      af="mathml-1.xml tag-AFfile1.tex"
+      xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+      Layout:Placement="Inline"
+     >
+     <AssociatedFile name="mathml-1.xml" xmlns="">
+     <math xmlns="http://www.w3.org/1998/Math/MathML"> <mi> <mglyph/> </mi> <mspace width="0.167em"/> <mrow> <mspace width="1.196pt"/> <mi> <mglyph/> </mi> <mo fence="true" lspace="0" rspace="0" symmetric="true">{</mo> </mrow> <mspace width="0.167em"/> <mi> <mglyph/> </mi> </math>
+     </AssociatedFile>
+     <AssociatedFile name="tag-AFfile1.tex" xmlns="">
+     $\vcenter {\schemabox {A}}\@schemata@lbrace {\@schemata@rheight }\vcenter {\schemabox {B\\C}}$
+     </AssociatedFile>
+    <?MarkedContent page="1" ?>A{︃BC
+   </Formula>
+   <Formula xmlns="http://iso.org/pdf2/ssn"
+      id="ID.008"
+      title="math"
+      af="mathml-2.xml tag-AFfile2.tex"
+      xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+      Layout:Placement="Inline"
+     >
+     <AssociatedFile name="mathml-2.xml" xmlns="">
+     <math xmlns="http://www.w3.org/1998/Math/MathML"> <mi> <mglyph/> </mi> <mspace width="0.167em"/> <mrow> <mspace width="1.196pt"/> <mi> <mglyph/> </mi> <mo fence="true" lspace="0" rspace="0" symmetric="true">[</mo> </mrow> <mspace width="0.167em"/> <mi> <mglyph/> </mi> </math>
+     </AssociatedFile>
+     <AssociatedFile name="tag-AFfile2.tex" xmlns="">
+     $\vcenter {\schemabox {A}}\@schemata@lbrace {\@schemata@rheight }\vcenter {\NudgeSB [left]\schemabox {B\\C}}$
+     </AssociatedFile>
+    <?MarkedContent page="1" ?>A[︃BC
+   </Formula>
+   <Formula xmlns="http://iso.org/pdf2/ssn"
+      id="ID.009"
+      title="math"
+      af="mathml-3.xml tag-AFfile3.tex"
+      xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+      Layout:Placement="Inline"
+     >
+     <AssociatedFile name="mathml-3.xml" xmlns="">
+     <math xmlns="http://www.w3.org/1998/Math/MathML"> <mi> <mglyph/> </mi> <mspace width="-1.992pt"/> <mspace width="0.167em"/> <mrow> <mo fence="true" lspace="0" rspace="0" symmetric="true">)</mo> <mi> <mglyph/> </mi> <mspace width="1.196pt"/> </mrow> <mspace width="0.167em"/> <mi> <mglyph/> </mi> </math>
+     </AssociatedFile>
+     <AssociatedFile name="tag-AFfile3.tex" xmlns="">
+     $\vcenter {\NudgeSB \schemabox {A\\B}}\kern -0.2em\@schemata@rbrace {\@schemata@lheight }\vcenter {\schemabox {C}}$
+     </AssociatedFile>
+    <?MarkedContent page="1" ?>AB)︃C
+   </Formula>
+   <Formula xmlns="http://iso.org/pdf2/ssn"
+      id="ID.010"
+      title="math"
+      af="mathml-4.xml tag-AFfile4.tex"
+      xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+      Layout:Placement="Inline"
+     >
+     <AssociatedFile name="mathml-4.xml" xmlns="">
+     <math xmlns="http://www.w3.org/1998/Math/MathML"> <mi> <mglyph/> </mi> <mi> <mglyph/> </mi> <mi> <mglyph/> </mi> </math>
+     </AssociatedFile>
+     <AssociatedFile name="tag-AFfile4.tex" xmlns="">
+     $\vcenter {\vskip 1.44265\@schemata@one \smallskip \schemabox {A}}\@schemata@biglbrace {0ex}{3ex}\vcenter {\Schema [close]{0ex}{3ex} {\NudgeSB \schemabox {B\\C}} {\smallskip \schemabox {D}} }$
+     </AssociatedFile>
+    <?MarkedContent page="1" ?>A⎧⎪⎪⎪⎪⎪⎪⎪⎪⎪⎩BC⎫⎪⎪⎪⎪⎪⎪⎪⎪⎪⎭D
+   </Formula>
+   <Formula xmlns="http://iso.org/pdf2/ssn"
+      id="ID.011"
+      title="math"
+      af="mathml-5.xml tag-AFfile5.tex"
+      xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+      Layout:Placement="Inline"
+     >
+     <AssociatedFile name="mathml-5.xml" xmlns="">
+     <math xmlns="http://www.w3.org/1998/Math/MathML"> <mi> <mglyph/> </mi> <mspace width="0.167em"/> <mrow> <mspace width="1.196pt"/> <mi> <mglyph/> </mi> <mo fence="true" lspace="0" rspace="0" symmetric="true">⟮</mo> </mrow> <mspace width="0.167em"/> <mi> <mglyph/> </mi> </math>
+     </AssociatedFile>
+     <AssociatedFile name="tag-AFfile5.tex" xmlns="">
+     $\vcenter { \schemabox {\textsc {Essentiam},} }\@schemata@lbrace {\@schemata@rheight }\vcenter { \schemabox {Unitate natur\ae {}.\\ Trinitate personarum.\\ Operibus ad intra.} }$
+     </AssociatedFile>
+    <?MarkedContent page="1" ?>A{︃BC
+   </Formula>
+   <Formula xmlns="http://iso.org/pdf2/ssn"
+      id="ID.012"
+      title="math"
+      af="mathml-6.xml tag-AFfile6.tex"
+      xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+      Layout:Placement="Inline"
+     >
+     <AssociatedFile name="mathml-6.xml" xmlns="">
+     <math xmlns="http://www.w3.org/1998/Math/MathML"> <mi> <mglyph/> </mi> <mspace width="0.167em"/> <mrow> <mspace width="1.196pt"/> <mi> <mglyph/> </mi> <mo fence="true" lspace="0" rspace="0" symmetric="true">⟮</mo> </mrow> <mspace width="0.167em"/> <mi> <mglyph/> </mi> </math>
+     </AssociatedFile>
+     <AssociatedFile name="tag-AFfile6.tex" xmlns="">
+     $\vcenter { \schemabox {\textsc {Voluntatem},\\ manifestatam in\\ operibus ad extra;\\ ut in} }\@schemata@lbrace {\@schemata@rheight }\vcenter { \schemabox {Creatione.\\ Sustentatione natur\ae {} laps\ae {}.\\ Reparatione.\\ Conversione.\\ Justificatione.\\ Sanctificatione \&amp;\\ Glorificatione ejusdem.} }$
+     </AssociatedFile>
+    <?MarkedContent page="1" ?>A{︃BC
+   </Formula>
+   <Formula xmlns="http://iso.org/pdf2/ssn"
+      id="ID.013"
+      title="math"
+      af="mathml-7.xml tag-AFfile7.tex"
+      xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+      Layout:Placement="Inline"
+     >
+     <AssociatedFile name="mathml-7.xml" xmlns="">
+     <math xmlns="http://www.w3.org/1998/Math/MathML"> <mi> <mglyph/> </mi> <mspace width="0.167em"/> <mrow> <mspace width="1.196pt"/> <mi> <mglyph/> </mi> <mo fence="true" lspace="0" rspace="0" symmetric="true">⟮</mo> </mrow> <mspace width="0.167em"/> <mi> <mglyph/> </mi> </math>
+     </AssociatedFile>
+     <AssociatedFile name="tag-AFfile7.tex" xmlns="">
+     $\vcenter { \schemabox {Subjectum theo-\\ logi\ae {} est Notitia\\ Dei. Considerat\\ ergo, Dei, vel} }\@schemata@lbrace {\@schemata@rheight }\vcenter { \schema { \schemabox {\textsc {Essentiam},} } { \schemabox {Unitate natur\ae {}.\\ Trinitate personarum.\\ Operibus ad intra.} } \schema { \schemabox {\textsc {Voluntatem},\\ manifestatam in\\ operibus ad extra;\\ ut in} } { \schemabox {Creatione.\\ Sustentatione natur\ae {} laps\ae {}.\\ Reparatione.\\ Conversione.\\ Justificatione.\\ Sanctificatione \&amp;\\ Glorificatione ejusdem.} } }$
+     </AssociatedFile>
+    <?MarkedContent page="1" ?>Subjectum theo-logiæ est NotitiaDei. Consideratergo, Dei, vel⎧⎪⎪⎪⎪⎪⎪⎪⎪⎪⎪⎪⎪⎪⎪⎪⎪⎪⎪⎪⎪⎪⎪⎪⎪⎪⎪⎪⎪⎪⎪⎪⎪⎪⎪⎪⎪⎪⎪⎩Essentiam,⎧⎪⎪⎪⎪⎪⎪⎪⎩Unitate naturæ.Trinitate personarum.Operibus ad intra.Voluntatem,manifestatam inoperibus ad extra;ut in⎧⎪⎪⎪⎪⎪⎪⎪⎪⎪⎪⎪⎪⎪⎪⎪⎪⎪⎪⎪⎪⎪⎪⎩Creatione.Sustentatione naturæ lapsæ.Reparatione.Conversione.Justificatione.Sanctificatione &amp;Glorificatione ejusdem.
+   </Formula>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-partial-mathml/schemata/schemata-01-BAD.struct.xml
+++ b/tagging-status/testfiles-partial-mathml/schemata/schemata-01-BAD.struct.xml
@@ -1,0 +1,138 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.002"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.006"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.007"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Some text has line 1line 2.
+    </text>
+   </text-unit>
+   <Formula xmlns="http://iso.org/pdf2/ssn"
+      id="ID.008"
+      title="math"
+      af="mathml-1.xml tag-AFfile1.tex"
+      xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+      Layout:Placement="Inline"
+     >
+     <AssociatedFile name="mathml-1.xml" xmlns="">
+     <math xmlns="http://www.w3.org/1998/Math/MathML"> <mi> <mglyph/> </mi> <mspace width="0.167em"/> <mrow> <mspace width="1.196pt"/> <mi> <mglyph/> </mi> <mo fence="true" lspace="0" rspace="0" symmetric="true">{</mo> </mrow> <mspace width="0.167em"/> <mi> <mglyph/> </mi> </math>
+     </AssociatedFile>
+     <AssociatedFile name="tag-AFfile1.tex" xmlns="">
+     $\vcenter {\schemabox {A}}\@schemata@lbrace {\@schemata@rheight }\vcenter {\schemabox {B\\C}}$
+     </AssociatedFile>
+    <?MarkedContent page="1" ?>
+    <?MarkedContent page="1" ?>Af
+    <?MarkedContent page="1" ?>BC
+   </Formula>
+   <Formula xmlns="http://iso.org/pdf2/ssn"
+      id="ID.009"
+      title="math"
+      af="mathml-2.xml tag-AFfile2.tex"
+      xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+      Layout:Placement="Inline"
+     >
+     <AssociatedFile name="mathml-2.xml" xmlns="">
+     <math xmlns="http://www.w3.org/1998/Math/MathML"> <mi> <mglyph/> </mi> <mspace width="0.167em"/> <mrow> <mspace width="1.196pt"/> <mi> <mglyph/> </mi> <mo fence="true" lspace="0" rspace="0" symmetric="true">[</mo> </mrow> <mspace width="0.167em"/> <mi> <mglyph/> </mi> </math>
+     </AssociatedFile>
+     <AssociatedFile name="tag-AFfile2.tex" xmlns="">
+     $\vcenter {\schemabox {A}}\@schemata@lbrace {\@schemata@rheight }\vcenter {\NudgeSB [left]\schemabox {B\\C}}$
+     </AssociatedFile>
+    <?MarkedContent page="1" ?>
+    <?MarkedContent page="1" ?>A[
+    <?MarkedContent page="1" ?>BC
+   </Formula>
+   <Formula xmlns="http://iso.org/pdf2/ssn"
+      id="ID.010"
+      title="math"
+      af="mathml-3.xml tag-AFfile3.tex"
+      xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+      Layout:Placement="Inline"
+     >
+     <AssociatedFile name="mathml-3.xml" xmlns="">
+     <math xmlns="http://www.w3.org/1998/Math/MathML"> <mi> <mglyph/> </mi> <mspace width="-1.992pt"/> <mspace width="0.167em"/> <mrow> <mo fence="true" lspace="0" rspace="0" symmetric="true">)</mo> <mi> <mglyph/> </mi> <mspace width="1.196pt"/> </mrow> <mspace width="0.167em"/> <mi> <mglyph/> </mi> </math>
+     </AssociatedFile>
+     <AssociatedFile name="tag-AFfile3.tex" xmlns="">
+     $\vcenter {\NudgeSB \schemabox {A\\B}}\kern -0.2em\@schemata@rbrace {\@schemata@lheight }\vcenter {\schemabox {C}}$
+     </AssociatedFile>
+    <?MarkedContent page="1" ?>
+    <?MarkedContent page="1" ?>AB)
+    <?MarkedContent page="1" ?>C
+   </Formula>
+   <Formula xmlns="http://iso.org/pdf2/ssn"
+      id="ID.011"
+      title="math"
+      af="mathml-4.xml tag-AFfile4.tex"
+      xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+      Layout:Placement="Inline"
+     >
+     <AssociatedFile name="mathml-4.xml" xmlns="">
+     <math xmlns="http://www.w3.org/1998/Math/MathML"> <mi> <mglyph/> </mi> <mi> <mglyph/> </mi> <mi> <mglyph/> </mi> </math>
+     </AssociatedFile>
+     <AssociatedFile name="tag-AFfile4.tex" xmlns="">
+     $\vcenter {\vskip 1.44265\@schemata@one \smallskip \schemabox {A}}\@schemata@biglbrace {0ex}{3ex}\vcenter {\Schema [close]{0ex}{3ex} {\NudgeSB \schemabox {B\\C}} {\smallskip \schemabox {D}} }$
+     </AssociatedFile>
+    <?MarkedContent page="1" ?>
+    <?MarkedContent page="1" ?>A⟮⟮⟮⟮
+    <?MarkedContent page="1" ?>BC⟯⟯⟯⟯
+    <?MarkedContent page="1" ?>D
+   </Formula>
+   <Formula xmlns="http://iso.org/pdf2/ssn"
+      id="ID.012"
+      title="math"
+      af="mathml-5.xml tag-AFfile5.tex"
+      xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+      Layout:Placement="Inline"
+     >
+     <AssociatedFile name="mathml-5.xml" xmlns="">
+     <math xmlns="http://www.w3.org/1998/Math/MathML"> <mi> <mglyph/> </mi> <mspace width="0.167em"/> <mrow> <mspace width="1.196pt"/> <mi> <mglyph/> </mi> <mo fence="true" lspace="0" rspace="0" symmetric="true">⟮</mo> </mrow> <mspace width="0.167em"/> <mi> <mglyph/> </mi> </math>
+     </AssociatedFile>
+     <AssociatedFile name="tag-AFfile5.tex" xmlns="">
+     $\vcenter { \schemabox {\textsc {Essentiam},} }\@schemata@lbrace {\@schemata@rheight }\vcenter { \schemabox {Unitate natur\ae {}.\\ Trinitate personarum.\\ Operibus ad intra.} }$
+     </AssociatedFile>
+   </Formula>
+   <Formula xmlns="http://iso.org/pdf2/ssn"
+      id="ID.013"
+      title="math"
+      af="mathml-6.xml tag-AFfile6.tex"
+      xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+      Layout:Placement="Inline"
+     >
+     <AssociatedFile name="mathml-6.xml" xmlns="">
+     <math xmlns="http://www.w3.org/1998/Math/MathML"> <mi> <mglyph/> </mi> <mspace width="0.167em"/> <mrow> <mspace width="1.196pt"/> <mi> <mglyph/> </mi> <mo fence="true" lspace="0" rspace="0" symmetric="true">⟮</mo> </mrow> <mspace width="0.167em"/> <mi> <mglyph/> </mi> </math>
+     </AssociatedFile>
+     <AssociatedFile name="tag-AFfile6.tex" xmlns="">
+     $\vcenter { \schemabox {\textsc {Voluntatem},\\ manifestatam in\\ operibus ad extra;\\ ut in} }\@schemata@lbrace {\@schemata@rheight }\vcenter { \schemabox {Creatione.\\ Sustentatione natur\ae {} laps\ae {}.\\ Reparatione.\\ Conversione.\\ Justificatione.\\ Sanctificatione \&amp;\\ Glorificatione ejusdem.} }$
+     </AssociatedFile>
+   </Formula>
+   <Formula xmlns="http://iso.org/pdf2/ssn"
+      id="ID.014"
+      title="math"
+      af="mathml-7.xml tag-AFfile7.tex"
+      xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+      Layout:Placement="Inline"
+     >
+     <AssociatedFile name="mathml-7.xml" xmlns="">
+     <math xmlns="http://www.w3.org/1998/Math/MathML"> <mi> <mglyph/> </mi> <mspace width="0.167em"/> <mrow> <mspace width="1.196pt"/> <mi> <mglyph/> </mi> <mo fence="true" lspace="0" rspace="0" symmetric="true">⟮</mo> </mrow> <mspace width="0.167em"/> <mi> <mglyph/> </mi> </math>
+     </AssociatedFile>
+     <AssociatedFile name="tag-AFfile7.tex" xmlns="">
+     $\vcenter { \schemabox {Subjectum theo-\\ logi\ae {} est Notitia\\ Dei. Considerat\\ ergo, Dei, vel} }\@schemata@lbrace {\@schemata@rheight }\vcenter { \schema { \schemabox {\textsc {Essentiam},} } { \schemabox {Unitate natur\ae {}.\\ Trinitate personarum.\\ Operibus ad intra.} } \schema { \schemabox {\textsc {Voluntatem},\\ manifestatam in\\ operibus ad extra;\\ ut in} } { \schemabox {Creatione.\\ Sustentatione natur\ae {} laps\ae {}.\\ Reparatione.\\ Conversione.\\ Justificatione.\\ Sanctificatione \&amp;\\ Glorificatione ejusdem.} } }$
+     </AssociatedFile>
+    <?MarkedContent page="1" ?>
+    <?MarkedContent page="1" ?>Subjectum theo-logiæ est NotitiaDei. Consideratergo, Dei, vel⟮⟮⟮⟮⟮⟮⟮⟮⟮⟮⟮⟮⟮
+    <?MarkedContent page="1" ?>Essentiam,⟮⟮⟮
+    <?MarkedContent page="1" ?>Unitate naturæ.Trinitate personarum.Operibus ad intra.
+    <?MarkedContent page="1" ?>Voluntatem,manifestatam inoperibus ad extra;ut in⟮⟮⟮⟮⟮⟮⟮⟮
+    <?MarkedContent page="1" ?>Creatione.Sustentatione naturæ lapsæ.Reparatione.Conversione.Justificatione.Sanctificatione &amp;Glorificatione ejusdem.
+   </Formula>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-partial-mathml/schemata/schemata-01-BAD.tex
+++ b/tagging-status/testfiles-partial-mathml/schemata/schemata-01-BAD.tex
@@ -1,0 +1,77 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on,
+  }
+\documentclass{article}
+
+\ifdefined\Uchar
+  \usepackage{unicode-math}
+\fi
+\usepackage{schemata}
+
+\title{schemata tagging test}
+
+\begin{document}
+
+Some text has \schemabox{line 1\\ line 2}.
+
+ \schema
+   {\schemabox{A}}
+   {\schemabox{B\\C}}
+
+ \DoBrackets
+ \schema
+   {\schemabox{A}}
+   {\NudgeSB[left]\schemabox{B\\C}}
+
+ \DoParens
+ \schema[close]
+   {\NudgeSB\schemabox{A\\B}}
+   {\schemabox{C}}
+
+ \DoGroups
+ \Schema{0ex}{3ex}
+   {\smallskip\schemabox{A}}
+   {\Schema[close]{0ex}{3ex}
+     {\NudgeSB\schemabox{B\\C}}
+     {\smallskip\schemabox{D}}
+ }
+ 
+  \schema
+  {
+    \schemabox{Subjectum theo-\\
+      logi\ae{} est Notitia\\
+      Dei. Considerat\\
+      ergo, Dei, vel}
+  }
+  {
+    \schema
+    {
+      \schemabox{\textsc{Essentiam},}
+    }
+    {
+      \schemabox{Unitate natur\ae{}.\\
+      Trinitate personarum.\\
+      Operibus ad intra.}
+    }
+    \schema
+    {
+      \schemabox{\textsc{Voluntatem},\\
+      manifestatam in\\
+      operibus ad extra;\\
+      ut in}
+    }
+    {
+      \schemabox{Creatione.\\
+      Sustentatione natur\ae{} laps\ae{}.\\
+      Reparatione.\\
+      Conversione.\\
+      Justificatione.\\
+      Sanctificatione \&\\
+      Glorificatione ejusdem.}
+    }
+  }
+\end{document}

--- a/tagging-status/testfiles-partial/progressbar/progressbar-01-BAD.pdftex.struct.xml
+++ b/tagging-status/testfiles-partial/progressbar/progressbar-01-BAD.pdftex.struct.xml
@@ -1,0 +1,28 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.02"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.05"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.06"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Some text
+     <?MarkedContent page="1" ?>more text
+     <?MarkedContent page="1" ?>more text
+     <?MarkedContent page="1" ?>more text
+     <?MarkedContent page="1" ?>more text
+     <?MarkedContent page="1" ?>more text
+     <?MarkedContent page="1" ?>more text
+     <?MarkedContent page="1" ?>more text
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-partial/progressbar/progressbar-01-BAD.struct.xml
+++ b/tagging-status/testfiles-partial/progressbar/progressbar-01-BAD.struct.xml
@@ -1,0 +1,22 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.02"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.06"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.07"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>Some text 
+     <?MarkedContent page="1" ?> more text
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-partial/progressbar/progressbar-01-BAD.tex
+++ b/tagging-status/testfiles-partial/progressbar/progressbar-01-BAD.tex
@@ -1,0 +1,18 @@
+\DocumentMetadata
+  {
+    lang=en-US,
+    pdfversion=2.0,
+    pdfstandard=ua-2,
+    tagging=on,
+  }
+\documentclass{article}
+
+\usepackage{progressbar}
+
+\title{progressbar tagging test}
+
+\begin{document}
+
+Some text \progressbar{0.6} more text
+
+\end{document}


### PR DESCRIPTION
Adds tests for pdfcolparallel and pdfcolparcolumns.

Lists perltex as compatible and adds a test but excludes it since it needs to be run with perltex and that seems too complicated to set up.

Lists program, pseudocode, qcircuit, qtree, and quantikz as incompatible with tests.

Lists progressbar, proof, and schemata as partially compatible with tests.