### PR TITLE
status updates for TikZ packages

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -2056,6 +2056,14 @@
   comments: "beamer is not a supported class."
   updated: 2026-01-30
 
+- name: bearwear
+  type: package
+  status: compatible
+  priority: 9
+  tests: false
+  comments: "Compatible as long as `alt` text given to the containing `tikzpicture`."
+  updated: 2026-08-24
+
 - name: bera
   type: package
   status: compatible
@@ -2516,6 +2524,13 @@
   comments: "Incompatible with unicode-math. No luamml support."
   package-repository: "https://github.com/wspr/breqn"
   updated: 2026-01-25
+
+- name: broydensolve
+  type: package
+  status: compatible
+  priority: 9
+  tests: false
+  updated: 2026-08-24
 
 - name: bussproofs
   type: package
@@ -8046,6 +8061,14 @@
   tests: false
   updated: 2024-07-26
 
+- name: liftarm
+  type: package
+  status: compatible
+  priority: 9
+  tests: false
+  comments: "Compatible as long as `alt` text given to the containing `tikzpicture`."
+  updated: 2026-08-24
+
 - name: ligtype
   type: package
   status: compatible
@@ -11246,12 +11269,20 @@
 
 - name: pgfornament
   type: package
-  status: unchecked
+  status: partially-compatible
   included-in: [ol0.1]
   priority: 9
-  tests: false
-  tasks: needs tests
-  updated: 2026-01-23
+  tests: true
+  comments: "No way to add alt text to a `\\pgfornament`."
+  updated: 2026-08-24
+
+- name: pgfornament-han
+  type: package
+  status: partially-compatible
+  priority: 9
+  tests: true
+  comments: "See pgfornament."
+  updated: 2026-08-24
 
 - name: pgfpages
   ctan-pkg: pgf
@@ -11572,6 +11603,14 @@
   issues: [612]
   tests: true
   updated: 2024-08-20
+
+- name: polyomino
+  type: package
+  status: compatible
+  priority: 9
+  tests: false
+  comments: "Compatible as long as `alt` text given to the containing `tikzpicture`."
+  updated: 2026-08-24
 
 - name: polytable
   type: package
@@ -14297,12 +14336,12 @@
 
 - name: tikz-3dplot
   type: package
-  status: partially-compatible
+  status: compatible
   included-in: [ol0.1]
   priority: 9
   tests: false
-  comments: See tikz.
-  updated: 2026-06-09
+  comments: "Compatible as long as `alt` text given to the containing `tikzpicture`."
+  updated: 2026-08-24
 
 - name: tikz-cd
   type: package
@@ -14315,30 +14354,31 @@
 
 - name: tikz-dependency
   type: package
-  status: unchecked
+  status: compatible
   included-in: [ol0.02]
   priority: 9
   tests: false
-  tasks: needs tests
-  updated: 2026-01-23
+  comments: "Compatible as long as `alt` text given to the containing `dependency` environment."
+  updated: 2026-08-24
 
 - name: tikz-dimline
   type: package
-  status: unchecked
+  status: compatible
   included-in: [ol0.02]
   priority: 9
   tests: false
-  tasks: needs tests
-  updated: 2026-01-23
+  comments: "Compatible as long as `alt` text given to the containing `tikzpicture`."
+  updated: 2026-08-24
 
 - name: tikz-feynman
   type: package
-  status: unchecked
+  status: compatible
   included-in: [ol0.1]
   priority: 9
   tests: false
-  tasks: needs tests
-  updated: 2026-01-23
+  comments: "Compatible as long as `alt` text given to `\\feynmandiagram
+             or the containing `tikzpicture`."
+  updated: 2026-08-24
 
 - name: tikz-network
   type: package
@@ -14381,11 +14421,12 @@
 - name: tikzfill
   type: package
   subpackages: [tikzfill.geomarray,tikzfill.hexagon,tikzfill.image,tikzfill.rhombus]
-  status: unchecked
+  status: compatible
   priority: 9
   package-repository: "https://github.com/T-F-S/tikzfill"
   tests: false
-  updated: 2026-06-17
+  comments: "Compatible as long as `alt` text given to the containing `tikzpicture`."
+  updated: 2026-08-24
 
 - name: tikzlibrary-external
   ctan-pkg: tikz
@@ -14424,6 +14465,24 @@
   issues: [30]
   tests: true
   updated: 2025-09-12
+
+- name: tikzlibrary-nfold
+  ctan-pkg: tikz-nfold
+  type: library
+  status: compatible
+  package-repository: "https://github.com/jonschz/tikz-nfold"
+  priority: 9
+  tests: false
+  updated: 2026-08-24
+
+- name: tikzlibrary-shadows.blur
+  ctan-pkg: pgf-blur
+  type: library
+  status: compatible
+  package-repository: "https://github.com/norbusan/pgf-blur"
+  priority: 9
+  tests: false
+  updated: 2026-08-24
 
 - name: tikzlibrary-tikzlings
   ctan-pkg: tikzlings
@@ -14476,12 +14535,29 @@
 
 - name: tikzpeople
   type: package
-  status: unchecked
+  status: compatible
   included-in: [ol0.02]
   priority: 9
   tests: false
-  tasks: needs tests
-  updated: 2026-01-23
+  comments: "Compatible as long as `alt` text given to the containing `tikzpicture`."
+  updated: 2026-08-24
+
+- name: tikzpingus
+  type: package
+  status: compatible
+  priority: 9
+  tests: false
+  comments: "Compatible as long as `alt` text given to the containing `tikzpicture`."
+  package-repository: "https://github.com/EagleoutIce/tikzpingus"
+  updated: 2026-08-24
+
+- name: tikzrput
+  type: package
+  ctan-pkg: pgfornament
+  status: compatible
+  priority: 9
+  tests: false
+  updated: 2026-08-24
 
 - name: tikzscale
   type: package
@@ -15493,6 +15569,14 @@
   priority: 7
   tests: true
   updated: 2024-08-23
+
+- name: wheelchart
+  type: package
+  status: compatible
+  priority: 9
+  tests: false
+  comments: "Compatible as long as `alt` text given to the containing `tikzpicture`."
+  updated: 2026-08-24
 
 - name: widetable
   type: package

--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -15812,6 +15812,7 @@
 
 - name: xetexko
   type: package
+  subpackages: [xetexko-font,xetexko-hanging,xetexko-josa,xetexko-space,xetexko-vertical]
   status: no-support
   priority: 9
   tests: false
@@ -16228,6 +16229,7 @@
 
 - name: zhspacing
   type: package
+  subpackages: [zhfont,zhmath,zhulem]
   status: no-support
   priority: 9
   tests: false

--- a/tagging-status/testfiles-partial/pgfornament/pgfornament-01-BAD.pdftex.struct.xml
+++ b/tagging-status/testfiles-partial/pgfornament/pgfornament-01-BAD.pdftex.struct.xml
@@ -1,0 +1,36 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.02"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.05"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.06"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>text
+     <?MarkedContent page="1" ?>
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.07"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.08"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-partial/pgfornament/pgfornament-01-BAD.struct.xml
+++ b/tagging-status/testfiles-partial/pgfornament/pgfornament-01-BAD.struct.xml
@@ -1,0 +1,33 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.02"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.06"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.07"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>text 
+    </text>
+   </text-unit>
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.08"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.09"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-partial/pgfornament/pgfornament-01-BAD.tex
+++ b/tagging-status/testfiles-partial/pgfornament/pgfornament-01-BAD.tex
@@ -1,0 +1,12 @@
+\DocumentMetadata{tagging=on}
+\documentclass{article}
+\usepackage{pgfornament}
+
+\title{pgfornament tagging test}
+
+\begin{document}
+text
+\pgfornament[width=2cm,color=red]{1}
+
+\pgfornament[width=4cm]{4}
+\end{document}


### PR DESCRIPTION
Lists several TikZ-derived packages as compatible with a comment "Compatible as long as `alt` text given to the containing `tikzpicture`."

Lists pgfornament as partial because there's no way to add alt text when used outside a tikzpicture.

Related issue about the meaning of "compatible" for these types of packages: https://github.com/latex3/tagging-project/issues/1160