### PR TITLE
Memoize ext again

### DIFF
--- a/_data/tagging-status.yml
+++ b/_data/tagging-status.yml
@@ -9343,12 +9343,23 @@
 
 - name: memoize
   type: package
-  status: unchecked
+  status: partially-compatible
+  comments: "Tagging requires third-party package memoize-ext."
   priority: 9
   tests: false
   tasks: needs tests
   package-repository: "https://github.com/sasozivanovic/memoize"
-  updated: 2024-07-18
+  updated: 2026-08-31
+
+- name: memoize-ext
+  type: package
+  status: compatible
+  priority: 9
+  package-repository: "https://codeberg.org/cfr/ltx-logic"
+  tests: true
+  comments: "Adds sockets to the utilisation of externs created by Memoize.
+             actualtext/alt/artifact supported for TikZ pictures."
+  updated: 2026-03-20
 
 - name: mercatormap
   type: package

--- a/tagging-status/build.lua
+++ b/tagging-status/build.lua
@@ -187,5 +187,5 @@ function runtest_tasks(name,run)
 end
 
 -- list of extensions to keep between runs (should check if all these are still needed)
-auxfiles = {"*.aux", "*.lof", "*.lot", "*.toc","*.bbl","*.bcf", "*.mmz", "*.memo"}
+auxfiles = {"*.aux", "*.lof", "*.lot", "*.toc","*.bbl","*.bcf"}
 

--- a/tagging-status/build.lua
+++ b/tagging-status/build.lua
@@ -187,5 +187,5 @@ function runtest_tasks(name,run)
 end
 
 -- list of extensions to keep between runs (should check if all these are still needed)
-auxfiles = {"*.aux", "*.lof", "*.lot", "*.toc","*.bbl","*.bcf"}
+auxfiles = {"*.aux", "*.lof", "*.lot", "*.toc","*.bbl","*.bcf", "*.mmz", "*.memo"}
 

--- a/tagging-status/testfiles-compatible/memoize-ext/memoize-ext-01.luatex.struct.xml
+++ b/tagging-status/testfiles-compatible/memoize-ext/memoize-ext-01.luatex.struct.xml
@@ -1,0 +1,34 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.02"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.06"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.07"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <Figure xmlns="http://iso.org/pdf2/ssn"
+        id="ID.08"
+        alt="Square"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:BBox="{ 148.71233, 468.3744, 177.45728, 497.11934 }"
+       >
+      <?MarkedContent page="1" ?>
+     </Figure>
+     <Span xmlns="http://iso.org/pdf2/ssn"
+        id="ID.09"
+        actualtext="oircle"
+       >
+      <?MarkedContent page="1" ?>
+     </Span>
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-compatible/memoize-ext/memoize-ext-01.pdftex.struct.xml
+++ b/tagging-status/testfiles-compatible/memoize-ext/memoize-ext-01.pdftex.struct.xml
@@ -1,0 +1,38 @@
+<PDF>
+ <StructTreeRoot>
+  <Document xmlns="http://iso.org/pdf2/ssn"
+     id="ID.02"
+    >
+   <text-unit xmlns="https://www.latex-project.org/ns/dflt"
+      id="ID.05"
+      rolemaps-to="Part"
+     >
+    <text xmlns="https://www.latex-project.org/ns/dflt"
+       id="ID.06"
+       xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+       Layout:TextAlign="Justify"
+       rolemaps-to="P"
+      >
+     <?MarkedContent page="1" ?>
+     <Figure xmlns="http://iso.org/pdf2/ssn"
+        id="ID.07"
+        alt="Square"
+        xmlns:Layout="http://iso.org/pdf/ssn/Layout"
+        Layout:BBox="{ 148.71233, 468.3744, 177.45728, 497.11934 }"
+       >
+      <?MarkedContent page="1" ?>
+     </Figure>
+     <?MarkedContent page="1" ?>
+     <Span xmlns="http://iso.org/pdf2/ssn"
+        id="ID.08"
+        actualtext="oircle"
+       >
+      <?MarkedContent page="1" ?>
+     </Span>
+     <?MarkedContent page="1" ?>
+     <?MarkedContent page="1" ?>
+    </text>
+   </text-unit>
+  </Document>
+ </StructTreeRoot>
+</PDF>

--- a/tagging-status/testfiles-compatible/memoize-ext/memoize-ext-01.tex
+++ b/tagging-status/testfiles-compatible/memoize-ext/memoize-ext-01.tex
@@ -1,0 +1,23 @@
+\DocumentMetadata{%
+  tagging=on,
+  lang=en-GB,
+  pdfversion=2.0,
+  pdfstandard=UA-2,
+  uncompress,
+}
+\documentclass{article}
+\usepackage{memoize-ext}	
+\usepackage{tikz}
+\title{memoize-ext: 01}
+\begin{document}
+\begin{tikzpicture}[alt=Square]
+  \draw (0,0) rectangle (1,1);
+\end{tikzpicture}%
+\begin{tikzpicture}[actualtext=oircle]
+  \draw circle (10pt);
+\end{tikzpicture}%
+\begin{tikzpicture}[artifact]
+  \draw (0,0) .. controls +(1,-1) and +(1,1) .. (5,5);
+\end{tikzpicture}%
+\end{document}
+% vim: ts=2:sw=2:et:

--- a/tagging-status/testfiles-compatible/memoize-ext/memoize-ext-01.tex
+++ b/tagging-status/testfiles-compatible/memoize-ext/memoize-ext-01.tex
@@ -7,6 +7,7 @@
 }
 \documentclass{article}
 \usepackage{memoize-ext}	
+\mmzset{prefix=./}
 \usepackage{tikz}
 \title{memoize-ext: 01}
 \begin{document}

--- a/tagging-status/testfiles-compatible/memoize-ext/memoize-ext-01.tex
+++ b/tagging-status/testfiles-compatible/memoize-ext/memoize-ext-01.tex
@@ -6,8 +6,9 @@
   uncompress,
 }
 \documentclass{article}
-\usepackage{memoize-ext}	
-\mmzset{prefix=./}
+\usepackage{memoize}
+\mmzset{prefix=./,include context in ccmemo,trace}
+\usepackage{memoize-ext-tag-debug}
 \usepackage{tikz}
 \title{memoize-ext: 01}
 \begin{document}


### PR DESCRIPTION
Response to discussion in the `memoize` issue https://github.com/latex3/tagging-project/issues/1568. 

Please run your `l3build` workflow with the attached test file. The logs will then include a lot more information about what is happening. If `.memo`s are generated, they will include more info, too, but unfortunately github will destroy those, so hopefully the `.log` will be sufficient.

IMHO it does not make sense to add unnecessary additional packages here. Then you do not know which causes a difference when something changes. The test file here is the one I submitted earlier this year and is supposed to be more-or-less similar to the tests `latex-lab` uses for its `tikz` support.  

I cannot guess why your `l3build` aborts memoization. That's not itself an error. It is something `memoize` does in some cases. It is also something `memoize-ext` tells `memoize` to do in some cases. So it does not show anything is wrong. It is only wrong if it shouldn't have happened. 